### PR TITLE
feat: upgrade to netbox-docker 4.0.0 (Granian, Valkey 9, PostgreSQL 18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,18 @@ jobs:
           python -m pytest tests/test_parser.py tests/test_models.py -v -p no:django
 
   integration-tests:
-    name: Integration Tests (NetBox ${{ matrix.netbox_version }})
+    name: Integration Tests (NetBox ${{ matrix.netbox_major }})
     runs-on: ubuntu-latest
     needs: [lint, unit-tests]
-    timeout-minutes: 30  # Allow enough time for NetBox startup and migrations
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        netbox_version: ["v4.5", "v4.4"]
+        include:
+          - netbox_version: "v4.5-4.0.0"
+            netbox_major: "v4.5"
+          - netbox_version: "v4.4"
+            netbox_major: "v4.4"
     steps:
       - uses: actions/checkout@v4
 
@@ -66,10 +70,8 @@ jobs:
           mkdir -p env development/configuration
 
           # Create NetBox environment file (version-specific settings)
-          # v4.5 doesn't accept SUPERUSER_API_TOKEN via env (new v2 token system with different format)
-          if [[ "${{ matrix.netbox_version }}" == "v4.5" ]]; then
-            # v4.5: Skip automatic superuser creation due to incompatibility with new v2 token system
-            # We'll create the superuser manually after startup without API token
+          if [[ "${{ matrix.netbox_major }}" == "v4.5" ]]; then
+            # v4.5: Skip automatic superuser creation (v2 token incompatibility)
             printf '%s\n' \
               'CORS_ORIGIN_ALLOW_ALL=True' \
               'DB_HOST=postgres' \
@@ -93,6 +95,7 @@ jobs:
               'REDIS_SSL=false' \
               'SECRET_KEY=test-secret-key-for-ci-only-do-not-use-in-production' \
               'SKIP_SUPERUSER=true' \
+              'API_TOKEN_PEPPER_1=Eb_30LtX2Rz01aSiZ29i8IwRyrbyy-maTokgIzAzADCt78gtlu5jd6EY1wGlX7RJ4XvpjRdLsyc4jnwj' \
               > env/netbox.env
           else
             printf '%s\n' \
@@ -132,15 +135,12 @@ jobs:
             'POSTGRES_USER=netbox' \
             > env/postgres.env
 
-          # Create Redis environment files
+          # Create Redis/Valkey environment files
           echo "REDIS_PASSWORD=netbox" > env/redis.env
           echo "REDIS_PASSWORD=netbox" > env/redis-cache.env
 
           # Create plugins configuration with version-specific settings
-          # API_TOKEN_PEPPERS is only required in v4.5+ (new v2 token system)
-          if [[ "${{ matrix.netbox_version }}" == "v4.5" ]]; then
-            # NetBox 4.5: API_TOKEN_PEPPERS must be a dictionary with numeric keys
-            # Pepper must be at least 50 characters
+          if [[ "${{ matrix.netbox_major }}" == "v4.5" ]]; then
             printf '%s\n' \
               'PLUGINS = ["netbox_ssl"]' \
               'PLUGINS_CONFIG = {' \
@@ -156,7 +156,6 @@ jobs:
               '}' \
               > development/configuration/plugins.py
           else
-            # NetBox 4.4: No API_TOKEN_PEPPERS needed (v2 tokens not supported)
             printf '%s\n' \
               'PLUGINS = ["netbox_ssl"]' \
               'PLUGINS_CONFIG = {' \
@@ -170,29 +169,24 @@ jobs:
 
       - name: Start NetBox
         run: |
-          # Debug: show configuration files
-          echo "=== netbox.env contents ==="
+          echo "=== Configuration ==="
+          echo "NetBox version: ${{ matrix.netbox_version }}"
           cat env/netbox.env
-          echo "=== plugins.py contents ==="
           cat development/configuration/plugins.py
           echo "==========================="
 
-          # Start only the core services for testing (skip worker/housekeeping to avoid healthcheck delays)
-          # The worker and housekeeping services depend on netbox being healthy, but migrations take time
+          # Use Valkey 9 + PostgreSQL 18 for all versions (Valkey is Redis-compatible)
+          # Only override the NetBox image tag per matrix version
           echo "Starting core services..."
           NETBOX_VERSION=${{ matrix.netbox_version }} docker compose up -d postgres redis redis-cache netbox
 
-          # Wait for NetBox to be healthy using our own loop (more patient than docker-compose healthcheck)
           echo "Waiting for NetBox to be healthy..."
           timeout 900 bash -c 'until docker compose exec -T netbox curl -sf http://localhost:8080/login/ > /dev/null 2>&1; do echo "Waiting for NetBox..."; sleep 15; done'
           echo "NetBox is ready!"
-        env:
-          NETBOX_VERSION: ${{ matrix.netbox_version }}
 
       - name: Create superuser for v4.5
-        if: matrix.netbox_version == 'v4.5'
+        if: matrix.netbox_major == 'v4.5'
         run: |
-          # Create superuser manually for v4.5 (automatic creation is disabled due to v2 token incompatibility)
           docker compose exec -T netbox /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py shell -c "
           from django.contrib.auth import get_user_model
           User = get_user_model()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,19 @@
 # NetBox SSL Plugin - Development Environment
 #
+# Requires: netbox-docker 4.0.0+ (Granian, Valkey, PostgreSQL 18)
+#
 # Usage:
 #   docker-compose up -d        # Start NetBox
 #   docker-compose logs -f      # View logs
 #   docker-compose down         # Stop everything
 #
-# Switch NetBox version by setting NETBOX_VERSION:
-#   NETBOX_VERSION=v4.4 docker-compose up -d
+# First-time setup or after upgrade from 3.x:
+#   docker-compose down -v      # Remove old volumes (destroys data!)
+#   docker-compose up -d        # Fresh start with new stack
 
 services:
-  netbox:
-    image: netboxcommunity/netbox:${NETBOX_VERSION:-v4.5}
+  netbox: &netbox
+    image: netboxcommunity/netbox:${NETBOX_VERSION:-v4.5-4.0.0}
     depends_on:
       postgres:
         condition: service_healthy
@@ -38,7 +41,7 @@ services:
       - "8000:8080"
 
   netbox-worker:
-    image: netboxcommunity/netbox:${NETBOX_VERSION:-v4.5}
+    <<: *netbox
     depends_on:
       netbox:
         condition: service_healthy
@@ -46,81 +49,70 @@ services:
       - /opt/netbox/venv/bin/python
       - /opt/netbox/netbox/manage.py
       - rqworker
-    env_file: env/netbox.env
     healthcheck:
       test: ps -aux | grep -v grep | grep -q rqworker || exit 1
       start_period: 20s
       timeout: 3s
       interval: 15s
-    volumes:
-      - ./netbox_ssl:/opt/netbox/netbox/netbox_ssl:ro
-      - ./development/configuration/plugins.py:/etc/netbox/config/plugins.py:ro
-      - netbox-media-files:/opt/netbox/netbox/media
-      - netbox-reports-files:/opt/netbox/netbox/reports
-      - netbox-scripts-files:/opt/netbox/netbox/scripts
+    ports: []
 
   netbox-housekeeping:
-    image: netboxcommunity/netbox:${NETBOX_VERSION:-v4.5}
+    <<: *netbox
     depends_on:
       netbox:
         condition: service_healthy
     command:
       - /opt/netbox/housekeeping.sh
-    env_file: env/netbox.env
     healthcheck:
       test: ps -aux | grep -v grep | grep -q housekeeping || exit 1
       start_period: 20s
       timeout: 3s
       interval: 15s
-    volumes:
-      - ./netbox_ssl:/opt/netbox/netbox/netbox_ssl:ro
-      - ./development/configuration/plugins.py:/etc/netbox/config/plugins.py:ro
-      - netbox-media-files:/opt/netbox/netbox/media
-      - netbox-reports-files:/opt/netbox/netbox/reports
-      - netbox-scripts-files:/opt/netbox/netbox/scripts
+    ports: []
 
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     env_file: env/postgres.env
     volumes:
-      - netbox-postgres-data:/var/lib/postgresql/data
+      - netbox-postgres-data:/var/lib/postgresql
     healthcheck:
       test: pg_isready -q -t 2 -d $$POSTGRES_DB -U $$POSTGRES_USER
       start_period: 20s
-      timeout: 5s
+      timeout: 30s
       interval: 10s
+      retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:9.0-alpine
     command:
       - sh
       - -c
-      - redis-server --appendonly yes --requirepass $$REDIS_PASSWORD
+      - valkey-server --appendonly yes --requirepass $$REDIS_PASSWORD
     env_file: env/redis.env
     volumes:
       - netbox-redis-data:/data
-    healthcheck:
-      test: '[ $$(redis-cli --pass "$${REDIS_PASSWORD}" ping) = "PONG" ]'
+    healthcheck: &valkey-healthcheck
+      test: '[ "$$(valkey-cli --pass "$${REDIS_PASSWORD}" ping)" = "PONG" ]'
       start_period: 5s
       timeout: 3s
-      interval: 5s
+      interval: 1s
+      retries: 5
 
   redis-cache:
-    image: redis:7-alpine
+    image: valkey/valkey:9.0-alpine
     command:
       - sh
       - -c
-      - redis-server --requirepass $$REDIS_PASSWORD
+      - valkey-server --requirepass $$REDIS_PASSWORD
     env_file: env/redis-cache.env
-    healthcheck:
-      test: '[ $$(redis-cli --pass "$${REDIS_PASSWORD}" ping) = "PONG" ]'
-      start_period: 5s
-      timeout: 3s
-      interval: 5s
+    volumes:
+      - netbox-redis-cache-data:/data
+    healthcheck: *valkey-healthcheck
 
 volumes:
   netbox-media-files:
   netbox-postgres-data:
   netbox-redis-data:
+  netbox-redis-cache-data:
   netbox-reports-files:
   netbox-scripts-files:


### PR DESCRIPTION
## Summary

Upgrade de volledige Docker development stack naar netbox-docker 4.0.0:

- **Nginx Unit → Granian** — Nginx Unit wordt niet meer onderhouden, Granian is de nieuwe webserver met uvloop en 4 workers
- **Redis 7 → Valkey 9.0** — Valkey is de open-source Redis fork, volledig backward-compatible
- **PostgreSQL 16 → 18** — Nieuwe major versie met verbeterde mount structuur
- **NetBox image tag** — Default naar `v4.5-4.0.0` (Granian-based)
- **docker-compose.yml** — YAML anchors voor DRY service definitions, Valkey healthchecks
- **CI pipeline** — Matrix gebruikt dezelfde Valkey/PostgreSQL 18 infra voor v4.4 en v4.5

### Breaking change
Vereist `docker-compose down -v` om oude volumes te verwijderen (PostgreSQL data format incompatibel).

## Lokaal getest

| Component | Status |
|-----------|--------|
| Granian (4 workers, poort 8080) | Running |
| PostgreSQL 18-alpine | Healthy |
| Valkey 9.0-alpine (x2) | Healthy |
| Plugin Django check | Passed |
| Unit tests (36 passed) | Passed |
| HTTP 200 op localhost:8000 | OK |

## Test plan

- [x] `docker-compose down -v && docker-compose up -d` — fresh start
- [x] Granian draait i.p.v. nginx-unit (`ps aux | grep granian`)
- [x] Plugin geladen (`manage.py check --tag netbox_ssl`)
- [x] Webinterface bereikbaar op :8000
- [ ] CI pipeline slaagt voor v4.4 en v4.5 matrix