### PR TITLE
fix: include templates in pip package (fixes #30)

### DIFF
--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/netbox_ssl/checks.py
+++ b/netbox_ssl/checks.py
@@ -171,10 +171,11 @@ def check_templates(app_configs, **kwargs):
                 get_template(template_name)
             except TemplateDoesNotExist:
                 errors.append(
-                    Error(
+                    Warning(
                         f"Required template not found: {template_name}",
-                        hint=f"Create the template at templates/{template_name}",
-                        id="netbox_ssl.E007",
+                        hint=f"Ensure the plugin is installed with package data intact. "
+                        f"Expected template at templates/{template_name}",
+                        id="netbox_ssl.W010",
                     )
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "0.4.1"
+version = "0.4.2"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -34,6 +34,12 @@ Repository = "https://github.com/ctrl-alt-automate/netbox-ssl"
 
 [tool.setuptools.packages.find]
 include = ["netbox_ssl*"]
+
+[tool.setuptools.package-data]
+netbox_ssl = [
+    "templates/**/*.html",
+    "static/**/*",
+]
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
## Summary
- **Add `[tool.setuptools.package-data]`** to `pyproject.toml` so that `templates/**/*.html` and `static/**/*` are included when the plugin is installed via `pip install`
- **Downgrade template check from Error to Warning** (`E007` → `W010`) so that `manage.py migrate` is no longer blocked on fresh installs where templates haven't loaded yet
- Bump version to **0.4.2**

## Root Cause
The `pyproject.toml` declared `[tool.setuptools.packages.find]` to include Python packages, but had no `package-data` section. This meant non-Python files (templates, static assets) were silently excluded from the built wheel/sdist. Our Docker Compose dev setup masked this because it volume-mounts the source directory.

Additionally, the Django system check `E007` (template-not-found) was at `Error` severity, which blocks `manage.py migrate` — creating a chicken-and-egg problem on fresh installs.

## Test plan
- [ ] Build the package with `python -m build` and verify templates are in the wheel
- [ ] `pip install` in a clean venv and confirm `templates/` exists in site-packages
- [ ] Run `manage.py migrate netbox_ssl` on a fresh instance — should succeed without errors
- [ ] Run `manage.py check --tag netbox_ssl` — templates should be found (no warnings)

Closes #30