### PR TITLE
fix: remove dead $tenant query_params from assignment form

### DIFF
--- a/netbox_ssl/forms/assignments.py
+++ b/netbox_ssl/forms/assignments.py
@@ -41,9 +41,6 @@ class CertificateAssignmentForm(NetBoxModelForm):
         required=False,
         label=_("Device"),
         help_text=_("Select a device to see its services"),
-        query_params={
-            "tenant_id": "$tenant",
-        },
     )
 
     # VM selection - services are automatically filtered
@@ -52,9 +49,6 @@ class CertificateAssignmentForm(NetBoxModelForm):
         required=False,
         label=_("Virtual Machine"),
         help_text=_("Select a VM to see its services"),
-        query_params={
-            "tenant_id": "$tenant",
-        },
     )
 
     # Service selection (filtered by device/VM via HTMX)


### PR DESCRIPTION
## Summary
- Remove unused `$tenant` query_params from device and virtual_machine fields in `CertificateAssignmentForm`
- The form has no `tenant` field, so these filters never applied — dead config

## Context
The HTMX dynamic Service filtering (PRD 5.2) is already fully implemented via `DynamicModelChoiceField` with `query_params` referencing `$device` and `$virtual_machine`. This cleanup removes the non-functional tenant references.

## Test plan
- [ ] Assignment form still works: select Device → Service dropdown filters
- [ ] Assignment form still works: select VM → Service dropdown filters
- [ ] No regressions in assignment creation/editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)