### PR TITLE
chore: improve plugin audit score from 89% to 94%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,30 @@ jobs:
         run: |
           python -m pytest tests/test_parser.py tests/test_models.py tests/test_events.py tests/test_expiry_scan.py -v -p no:django
 
+  build-package:
+    name: Build Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Validate package
+        run: twine check dist/*
+
   integration-tests:
     name: Integration Tests (NetBox ${{ matrix.netbox_major }})
     runs-on: ubuntu-latest
-    needs: [lint, unit-tests, package-check]
+    needs: [lint, unit-tests, package-check, build-package]
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,12 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]  # Triggers on GitHub Release (not tag push)
+  push:
+    tags:
+      - "v*"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -14,11 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: write
       id-token: write  # Required for Trusted Publisher (OIDC)
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -37,3 +41,16 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         # Uses Trusted Publisher (OIDC) - no API token needed
         # Configure at: https://pypi.org/manage/project/netbox-ssl/settings/publishing/
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          changelog=$(awk "/^## \\[${version}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
+          echo "$changelog" > /tmp/release_notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: /tmp/release_notes.md
+          files: dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.6.0] - 2026-03-09
 
 ### Added
@@ -299,6 +301,7 @@ Initial release of NetBox SSL Plugin.
 - NetBox 4.4.0 - 4.5.x
 - Python 3.10+
 
+[Unreleased]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v0.4.1...v0.5.0

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,28 @@
+# Compatibility Matrix
+
+This document tracks compatibility between NetBox SSL plugin versions and NetBox releases.
+
+## Current
+
+| Plugin Version | NetBox Version | Python Version | Status |
+|:--------------:|:--------------:|:--------------:|:------:|
+| 0.6.x          | 4.5.x          | 3.10 - 3.12   | Primary |
+| 0.6.x          | 4.4.x          | 3.10 - 3.12   | Supported |
+| 0.5.x          | 4.5.x          | 3.10 - 3.12   | Supported |
+| 0.5.x          | 4.4.x          | 3.10 - 3.12   | Supported |
+
+## End of Life
+
+| Plugin Version | NetBox Version | Notes |
+|:--------------:|:--------------:|:------|
+| 0.4.x          | 4.4.x          | Upgrade to 0.6.x recommended |
+| 0.3.x          | 4.4.x          | Upgrade to 0.6.x recommended |
+| any            | 4.3.x or older | Unsupported |
+
+## Version Policy
+
+- **Primary**: Actively developed and tested in CI
+- **Supported**: Tested in CI, receives bug fixes
+- **End of Life**: No longer tested or maintained
+
+Each plugin release is tested against all supported NetBox versions via GitHub Actions CI.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Managing SSL certificates across your infrastructure shouldn't be a scavenger hu
 - 🔒 **Security first** — Private keys are never stored, only location hints for your secret management system
 - 🎯 **Deep integration** — Certificates link directly to NetBox Services, Devices, and VMs
 
+## Requirements
+
+| Dependency | Version |
+|------------|---------|
+| NetBox     | 4.4.0 - 4.5.x |
+| Python     | 3.10+ |
+
+The plugin uses the Python [`cryptography`](https://cryptography.io/) library for X.509 certificate parsing (installed automatically as a dependency).
+
 ## Installation
 
 ```bash

--- a/docs/images/plugin-icon.svg
+++ b/docs/images/plugin-icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <!-- Background circle -->
+  <circle cx="64" cy="64" r="60" fill="#0d6efd" />
+  <!-- Lock body -->
+  <rect x="40" y="58" width="48" height="36" rx="4" fill="white" />
+  <!-- Lock shackle -->
+  <path d="M48 58V46a16 16 0 0 1 32 0v12" fill="none" stroke="white" stroke-width="6" stroke-linecap="round" />
+  <!-- Keyhole -->
+  <circle cx="64" cy="72" r="5" fill="#0d6efd" />
+  <rect x="62" y="74" width="4" height="10" rx="1" fill="#0d6efd" />
+</svg>

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <!-- Background circle -->
+  <circle cx="64" cy="64" r="60" fill="#0d6efd" />
+  <!-- Lock body -->
+  <rect x="40" y="58" width="48" height="36" rx="4" fill="white" />
+  <!-- Lock shackle -->
+  <path d="M48 58V46a16 16 0 0 1 32 0v12" fill="none" stroke="white" stroke-width="6" stroke-linecap="round" />
+  <!-- Keyhole -->
+  <circle cx="64" cy="72" r="5" fill="#0d6efd" />
+  <rect x="62" y="74" width="4" height="10" rx="1" fill="#0d6efd" />
+</svg>


### PR DESCRIPTION
## Summary

- **COMPATIBILITY.md** — versie-compatibiliteitsmatrix toegevoegd
- **CHANGELOG** — `[Unreleased]` sectie conform Keep a Changelog standaard
- **CI** — `build-package` job met `python -m build` + `twine check`
- **Publish workflow** — tag-push trigger (`v*`) met automatische GitHub Release + changelog extractie
- **README** — Requirements/Dependencies sectie met NetBox/Python versies
- **Plugin icon** — SVG icon in root en `docs/images/` voor certificeringsgereedheid

## Audit resultaat

| | Voor | Na |
|---|---|---|
| Score | 124/139 (89%) | 130/139 (94%) |
| Errors | 0 | 0 |
| Warnings | 5 | 5 |
| Info | 10 | 4 |

Resterende warnings zijn false positives (directory-structuur + black/flake8 niet relevant bij ruff).

## Test plan

- [ ] CI pipeline slaagt (lint, unit tests, package-check, build-package)
- [ ] `netbox-plugin-audit` lokaal draait met 94%+ score
- [ ] Publish workflow YAML is valide (tag trigger + GitHub Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)