### PR TITLE
Security hardening for v0.7.5 (#69-#78)

### DIFF
--- a/netbox_ssl/api/serializers/certificates.py
+++ b/netbox_ssl/api/serializers/certificates.py
@@ -102,6 +102,7 @@ class CertificateImportSerializer(serializers.Serializer):
     """Serializer for importing certificates from PEM content."""
 
     pem_content = serializers.CharField(
+        max_length=65536,
         help_text="Certificate in PEM format. May include certificate chain.",
         style={"base_template": "textarea.html"},
     )

--- a/netbox_ssl/api/serializers/csr.py
+++ b/netbox_ssl/api/serializers/csr.py
@@ -9,6 +9,7 @@ from tenancy.models import Tenant
 
 from ...models import CertificateSigningRequest, CSRStatusChoices
 from ...utils import CSRParseError, CSRParser
+from ...utils.parser import CertificateParser
 
 
 class CertificateSigningRequestSerializer(NetBoxModelSerializer):
@@ -64,6 +65,7 @@ class CSRImportSerializer(serializers.Serializer):
     """Serializer for importing CSRs from PEM content."""
 
     pem_content = serializers.CharField(
+        max_length=65536,
         help_text="CSR in PEM format.",
         style={"base_template": "textarea.html"},
     )
@@ -88,6 +90,11 @@ class CSRImportSerializer(serializers.Serializer):
 
     def validate_pem_content(self, value):
         """Validate PEM content."""
+        if CertificateParser.contains_private_key(value):
+            raise serializers.ValidationError(
+                "Private key detected. CSR imports must not include private key material."
+            )
+
         try:
             CSRParser.parse(value)
         except CSRParseError as e:

--- a/netbox_ssl/api/views.py
+++ b/netbox_ssl/api/views.py
@@ -2,6 +2,8 @@
 REST API views for NetBox SSL plugin.
 """
 
+import logging
+
 from django.conf import settings
 from django.db import DatabaseError, IntegrityError, transaction
 from django.db.models import Count
@@ -42,6 +44,8 @@ from .serializers import (
     CSRImportSerializer,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class CertificateViewSet(NetBoxModelViewSet):
     """API viewset for Certificate model."""
@@ -62,6 +66,9 @@ class CertificateViewSet(NetBoxModelViewSet):
         Accepts raw PEM content and automatically parses all X.509 attributes.
         Private keys are rejected for security reasons.
         """
+        if not request.user.has_perm("netbox_ssl.add_certificate"):
+            return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
+
         serializer = CertificateImportSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         certificate = serializer.save()
@@ -91,6 +98,9 @@ class CertificateViewSet(NetBoxModelViewSet):
             }
         ]
         """
+        if not request.user.has_perm("netbox_ssl.add_certificate"):
+            return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
+
         # Validate input is a list
         if not isinstance(request.data, list):
             raise serializers.ValidationError({"detail": "Expected a list of certificate objects."})
@@ -134,11 +144,15 @@ class CertificateViewSet(NetBoxModelViewSet):
                     certificate = serializer.save()
                     created_certificates.append(certificate)
         except IntegrityError as e:
+            logger.error("Bulk import IntegrityError: %s", e)
             raise serializers.ValidationError(
-                {"detail": f"Database integrity error during bulk import: {str(e)}"}
+                {"detail": "A database constraint error occurred. Check for duplicate certificates."}
             ) from e
         except DatabaseError as e:
-            raise serializers.ValidationError({"detail": f"Database error during bulk import: {str(e)}"}) from e
+            logger.error("Bulk import DatabaseError: %s", e)
+            raise serializers.ValidationError(
+                {"detail": "A database error occurred during bulk import. Please try again."}
+            ) from e
 
         # Return created certificates
         output_serializer = CertificateSerializer(created_certificates, many=True, context={"request": request})
@@ -165,12 +179,23 @@ class CertificateViewSet(NetBoxModelViewSet):
             "on_duplicate": "skip"
         }
         """
+        if not request.user.has_perm("netbox_ssl.add_certificate"):
+            return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
+
         content = request.data.get("content", "")
         fmt = request.data.get("format", "auto")
         on_duplicate = request.data.get("on_duplicate", "error")
 
         if not content:
             raise serializers.ValidationError({"content": "This field is required."})
+
+        valid_formats = {"auto", "csv", "json"}
+        valid_on_duplicate = {"skip", "error"}
+
+        if fmt not in valid_formats:
+            raise serializers.ValidationError({"format": f"Must be one of: {sorted(valid_formats)}"})
+        if on_duplicate not in valid_on_duplicate:
+            raise serializers.ValidationError({"on_duplicate": f"Must be one of: {sorted(valid_on_duplicate)}"})
 
         result = bulk_parse(content, fmt=fmt)
 
@@ -197,10 +222,14 @@ class CertificateViewSet(NetBoxModelViewSet):
             with transaction.atomic():
                 for row in result.valid_rows:
                     # Duplicate check
-                    exists = Certificate.objects.filter(
-                        serial_number=row["serial_number"],
-                        issuer=row["issuer"],
-                    ).exists()
+                    exists = (
+                        Certificate.objects.restrict(request.user, "view")
+                        .filter(
+                            serial_number=row["serial_number"],
+                            issuer=row["issuer"],
+                        )
+                        .exists()
+                    )
                     if exists:
                         if on_duplicate == "skip":
                             skipped += 1
@@ -248,7 +277,10 @@ class CertificateViewSet(NetBoxModelViewSet):
                     cert.auto_detect_acme(save=True)
                     created_certs.append(cert)
         except IntegrityError as e:
-            raise serializers.ValidationError({"detail": f"Database error during import: {e}"}) from e
+            logger.error("Bulk data import IntegrityError: %s", e)
+            raise serializers.ValidationError(
+                {"detail": "A database constraint error occurred. Check for duplicate certificates."}
+            ) from e
 
         output = CertificateSerializer(created_certs, many=True, context={"request": request})
         return Response(
@@ -346,7 +378,11 @@ class CertificateViewSet(NetBoxModelViewSet):
         if ids:
             try:
                 ids = [int(i) for i in ids]
-                certificates = Certificate.objects.filter(pk__in=ids).annotate(_assignment_count=Count("assignments"))
+                certificates = (
+                    Certificate.objects.restrict(request.user, "view")
+                    .filter(pk__in=ids)
+                    .annotate(_assignment_count=Count("assignments"))
+                )
             except (ValueError, TypeError) as e:
                 raise serializers.ValidationError(
                     {"ids": "Invalid certificate IDs. Must be a list of integers."}
@@ -370,6 +406,11 @@ class CertificateViewSet(NetBoxModelViewSet):
         if fields:
             if isinstance(fields, str):
                 fields = [f.strip() for f in fields.split(",")]
+            # Validate fields against allowlist
+            allowed = set(CertificateExporter.DEFAULT_FIELDS + CertificateExporter.EXTENDED_FIELDS)
+            invalid = set(fields) - allowed
+            if invalid:
+                raise serializers.ValidationError({"fields": f"Unknown fields: {sorted(invalid)}"})
         else:
             fields = None  # Use defaults
 
@@ -385,7 +426,10 @@ class CertificateViewSet(NetBoxModelViewSet):
         except ImportError as e:
             raise serializers.ValidationError({"detail": str(e)}) from e
         except Exception as e:
-            raise serializers.ValidationError({"detail": f"Export failed: {str(e)}"}) from e
+            logger.error("Certificate export failed: %s", e)
+            raise serializers.ValidationError(
+                {"detail": "Export failed due to an internal error. Please check your parameters and try again."}
+            ) from e
 
         # Get content type and extension
         content_type = CertificateExporter.get_content_type(export_format)
@@ -434,7 +478,8 @@ class CertificateViewSet(NetBoxModelViewSet):
 
         response = HttpResponse(content, content_type=content_type)
         # Use common name in filename (sanitized)
-        safe_name = "".join(c if c.isalnum() or c in ".-_" else "_" for c in certificate.common_name)
+        safe_name = "".join(c if (c.isascii() and c.isalnum()) or c in ".-_" else "_" for c in certificate.common_name)
+        safe_name = safe_name[:64] or "certificate"
         filename = f"{safe_name}.{extension}"
         response["Content-Disposition"] = f'attachment; filename="{filename}"'
 
@@ -539,6 +584,9 @@ class CertificateViewSet(NetBoxModelViewSet):
             "ids": [1, 2, 3, 4, 5]
         }
         """
+        if not request.user.has_perm("netbox_ssl.change_certificate"):
+            return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
+
         certificate_ids = request.data.get("ids", [])
 
         if not certificate_ids:
@@ -552,7 +600,7 @@ class CertificateViewSet(NetBoxModelViewSet):
                 {"detail": f"Batch size exceeds maximum of {max_batch_size} certificates."}
             )
 
-        certificates = list(Certificate.objects.filter(pk__in=certificate_ids))
+        certificates = list(Certificate.objects.restrict(request.user, "view").filter(pk__in=certificate_ids))
         results = []
         certs_to_update = []
 
@@ -626,7 +674,9 @@ class CertificateViewSet(NetBoxModelViewSet):
             )
 
         # Get certificates with tenant prefetched to avoid N+1 queries
-        certificates = Certificate.objects.filter(pk__in=certificate_ids).select_related("tenant")
+        certificates = (
+            Certificate.objects.restrict(request.user, "view").filter(pk__in=certificate_ids).select_related("tenant")
+        )
         found_ids = set(certificates.values_list("pk", flat=True))
         missing_ids = set(certificate_ids) - found_ids
 
@@ -700,6 +750,9 @@ class CertificateViewSet(NetBoxModelViewSet):
             "ids": [1, 2, 3, 4, 5]
         }
         """
+        if not request.user.has_perm("netbox_ssl.change_certificate"):
+            return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
+
         ids = request.data.get("ids", [])
 
         if not ids:
@@ -716,7 +769,7 @@ class CertificateViewSet(NetBoxModelViewSet):
                 {"detail": f"Batch size exceeds maximum of {max_batch_size} certificates."}
             )
 
-        certificates = list(Certificate.objects.filter(pk__in=ids))
+        certificates = list(Certificate.objects.restrict(request.user, "view").filter(pk__in=ids))
         found_ids = {cert.pk for cert in certificates}
         missing_ids = set(ids) - found_ids
 
@@ -806,6 +859,9 @@ class CertificateSigningRequestViewSet(NetBoxModelViewSet):
 
         Accepts raw PEM content and automatically parses all CSR attributes.
         """
+        if not request.user.has_perm("netbox_ssl.add_certificatesigningrequest"):
+            return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
+
         serializer = CSRImportSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         csr = serializer.save()

--- a/netbox_ssl/forms/csr.py
+++ b/netbox_ssl/forms/csr.py
@@ -11,6 +11,7 @@ from utilities.forms.rendering import FieldSet
 
 from ..models import CertificateSigningRequest, CSRStatusChoices
 from ..utils import CSRParseError, CSRParser
+from ..utils.parser import CertificateParser
 
 
 class CertificateSigningRequestForm(NetBoxModelForm):
@@ -132,6 +133,9 @@ class CSRImportForm(forms.Form):
     def clean_pem_content(self):
         """Validate PEM content."""
         pem_content = self.cleaned_data["pem_content"]
+
+        if CertificateParser.contains_private_key(pem_content):
+            raise forms.ValidationError("Private key detected. CSR imports must not include private key material.")
 
         try:
             CSRParser.parse(pem_content)

--- a/netbox_ssl/graphql/schema.py
+++ b/netbox_ssl/graphql/schema.py
@@ -18,52 +18,64 @@ class NetBoxSSLQuery:
     """GraphQL query type for NetBox SSL plugin."""
 
     @strawberry_django.field
-    def certificate(self, id: int) -> CertificateType:
+    def certificate(self, info: strawberry.types.Info, id: int) -> CertificateType | None:
         from ..models import Certificate
 
-        return Certificate.objects.get(pk=id)
+        try:
+            return Certificate.objects.restrict(info.context.request.user, "view").get(pk=id)
+        except Certificate.DoesNotExist:
+            return None
 
     @strawberry_django.field
-    def certificate_list(self) -> list[CertificateType]:
+    def certificate_list(self, info: strawberry.types.Info) -> list[CertificateType]:
         from ..models import Certificate
 
-        return Certificate.objects.all()
+        return Certificate.objects.restrict(info.context.request.user, "view")
 
     @strawberry_django.field
-    def certificate_assignment(self, id: int) -> CertificateAssignmentType:
+    def certificate_assignment(self, info: strawberry.types.Info, id: int) -> CertificateAssignmentType | None:
         from ..models import CertificateAssignment
 
-        return CertificateAssignment.objects.get(pk=id)
+        try:
+            return CertificateAssignment.objects.restrict(info.context.request.user, "view").get(pk=id)
+        except CertificateAssignment.DoesNotExist:
+            return None
 
     @strawberry_django.field
-    def certificate_assignment_list(self) -> list[CertificateAssignmentType]:
+    def certificate_assignment_list(self, info: strawberry.types.Info) -> list[CertificateAssignmentType]:
         from ..models import CertificateAssignment
 
-        return CertificateAssignment.objects.all()
+        return CertificateAssignment.objects.restrict(info.context.request.user, "view")
 
     @strawberry_django.field
-    def certificate_authority(self, id: int) -> CertificateAuthorityType:
+    def certificate_authority(self, info: strawberry.types.Info, id: int) -> CertificateAuthorityType | None:
         from ..models import CertificateAuthority
 
-        return CertificateAuthority.objects.get(pk=id)
+        try:
+            return CertificateAuthority.objects.restrict(info.context.request.user, "view").get(pk=id)
+        except CertificateAuthority.DoesNotExist:
+            return None
 
     @strawberry_django.field
-    def certificate_authority_list(self) -> list[CertificateAuthorityType]:
+    def certificate_authority_list(self, info: strawberry.types.Info) -> list[CertificateAuthorityType]:
         from ..models import CertificateAuthority
 
-        return CertificateAuthority.objects.all()
+        return CertificateAuthority.objects.restrict(info.context.request.user, "view")
 
     @strawberry_django.field
-    def certificate_signing_request(self, id: int) -> CertificateSigningRequestType:
+    def certificate_signing_request(self, info: strawberry.types.Info, id: int) -> CertificateSigningRequestType | None:
         from ..models import CertificateSigningRequest
 
-        return CertificateSigningRequest.objects.get(pk=id)
+        try:
+            return CertificateSigningRequest.objects.restrict(info.context.request.user, "view").get(pk=id)
+        except CertificateSigningRequest.DoesNotExist:
+            return None
 
     @strawberry_django.field
-    def certificate_signing_request_list(self) -> list[CertificateSigningRequestType]:
+    def certificate_signing_request_list(self, info: strawberry.types.Info) -> list[CertificateSigningRequestType]:
         from ..models import CertificateSigningRequest
 
-        return CertificateSigningRequest.objects.all()
+        return CertificateSigningRequest.objects.restrict(info.context.request.user, "view")
 
 
 schema = [NetBoxSSLQuery]

--- a/netbox_ssl/graphql/types.py
+++ b/netbox_ssl/graphql/types.py
@@ -14,7 +14,17 @@ from ..models import Certificate, CertificateAssignment, CertificateAuthority, C
 
 @strawberry_django.type(
     CertificateAuthority,
-    fields="__all__",
+    fields=[
+        "id",
+        "name",
+        "description",
+        "issuer_pattern",
+        "website",
+        "is_acme",
+        "tags",
+        "created",
+        "last_updated",
+    ],
     filters=filtersets.CertificateAuthorityFilterSet,
 )
 class CertificateAuthorityType(NetBoxObjectType):
@@ -36,7 +46,25 @@ class CertificateAuthorityType(NetBoxObjectType):
 
 @strawberry_django.type(
     Certificate,
-    fields="__all__",
+    fields=[
+        "id",
+        "common_name",
+        "serial_number",
+        "fingerprint_sha256",
+        "issuer",
+        "valid_from",
+        "valid_to",
+        "algorithm",
+        "key_size",
+        "status",
+        "sans",
+        "tenant",
+        "issuing_ca",
+        "tags",
+        "comments",
+        "created",
+        "last_updated",
+    ],
     filters=filtersets.CertificateFilterSet,
 )
 class CertificateType(NetBoxObjectType):
@@ -46,15 +74,12 @@ class CertificateType(NetBoxObjectType):
     serial_number: str
     fingerprint_sha256: str
     issuer: str
-    issuer_chain: str
     valid_from: str
     valid_to: str
     sans: list[str]
     key_size: int | None
     algorithm: str
     status: str
-    private_key_location: str
-    pem_content: str
     issuing_ca: Annotated["CertificateAuthorityType", strawberry.lazy(".types")] | None
 
     @strawberry_django.field
@@ -80,7 +105,15 @@ class CertificateType(NetBoxObjectType):
 
 @strawberry_django.type(
     CertificateAssignment,
-    fields="__all__",
+    fields=[
+        "id",
+        "certificate",
+        "assigned_object_type",
+        "assigned_object_id",
+        "is_primary",
+        "created",
+        "last_updated",
+    ],
     filters=filtersets.CertificateAssignmentFilterSet,
 )
 class CertificateAssignmentType(NetBoxObjectType):
@@ -88,12 +121,27 @@ class CertificateAssignmentType(NetBoxObjectType):
 
     certificate: Annotated["CertificateType", strawberry.lazy(".types")]
     is_primary: bool
-    notes: str
 
 
 @strawberry_django.type(
     CertificateSigningRequest,
-    fields="__all__",
+    fields=[
+        "id",
+        "common_name",
+        "organization",
+        "organizational_unit",
+        "country",
+        "state",
+        "locality",
+        "sans",
+        "key_size",
+        "algorithm",
+        "status",
+        "tenant",
+        "tags",
+        "created",
+        "last_updated",
+    ],
     filters=filtersets.CertificateSigningRequestFilterSet,
 )
 class CertificateSigningRequestType(NetBoxObjectType):
@@ -108,13 +156,7 @@ class CertificateSigningRequestType(NetBoxObjectType):
     sans: list[str]
     key_size: int | None
     algorithm: str
-    fingerprint_sha256: str
-    pem_content: str
     status: str
-    requested_date: str
-    requested_by: str
-    target_ca: str
-    notes: str
     # resulting_certificate is auto-resolved by strawberry_django from the ForeignKey
     resulting_certificate: Annotated["CertificateType", strawberry.lazy(".types")] | None
 

--- a/netbox_ssl/utils/chain_validator.py
+++ b/netbox_ssl/utils/chain_validator.py
@@ -57,6 +57,8 @@ class ChainValidator:
     - Self-signed root detection
     """
 
+    MAX_CHAIN_DEPTH = 10
+
     @classmethod
     def validate(cls, leaf_pem: str, chain_pem: str = "") -> ChainValidationResult:
         """
@@ -122,6 +124,18 @@ class ChainValidator:
                 chain_depth=1,
                 certificates=certificates,
                 errors=["No valid certificates found in chain"],
+                validated_at=validated_at,
+            )
+
+        # Chain depth cap
+        if len(chain_certs) + 1 > cls.MAX_CHAIN_DEPTH:
+            return ChainValidationResult(
+                status=ChainValidationStatus.PARSE_ERROR,
+                is_valid=False,
+                message=f"Chain too long ({len(chain_certs) + 1} certificates). Maximum is {cls.MAX_CHAIN_DEPTH}.",
+                chain_depth=len(chain_certs) + 1,
+                certificates=certificates,
+                errors=[f"Chain depth {len(chain_certs) + 1} exceeds maximum of {cls.MAX_CHAIN_DEPTH}"],
                 validated_at=validated_at,
             )
 

--- a/netbox_ssl/utils/export.py
+++ b/netbox_ssl/utils/export.py
@@ -76,6 +76,19 @@ class CertificateExporter:
         "last_updated",
     ]
 
+    # Allowlist of all permitted export fields
+    ALLOWED_FIELDS: frozenset[str] = frozenset(DEFAULT_FIELDS + EXTENDED_FIELDS)
+
+    # Characters that trigger formula interpretation in spreadsheet applications
+    _FORMULA_CHARS: frozenset[str] = frozenset("=+-@\t\r")
+
+    @staticmethod
+    def _sanitize_csv_value(value: str) -> str:
+        """Prevent CSV formula injection by prefixing formula-triggering values."""
+        if isinstance(value, str) and value and value[0] in CertificateExporter._FORMULA_CHARS:
+            return "'" + value
+        return value
+
     @classmethod
     def certificate_to_dict(
         cls, certificate, fields: list[str] | None = None, include_pem: bool = False
@@ -120,6 +133,8 @@ class CertificateExporter:
                 data[field] = certificate.is_expiring_soon
             elif field == "expiry_status":
                 data[field] = certificate.expiry_status
+            elif field not in cls.ALLOWED_FIELDS:
+                continue  # skip unknown fields silently
             elif hasattr(certificate, field):
                 data[field] = getattr(certificate, field)
 
@@ -161,7 +176,8 @@ class CertificateExporter:
 
         for cert in certificates:
             row = cls.certificate_to_dict(cert, fields=csv_fields)
-            writer.writerow(row)
+            sanitized_row = {k: cls._sanitize_csv_value(v) for k, v in row.items()}
+            writer.writerow(sanitized_row)
 
         return output.getvalue()
 

--- a/netbox_ssl/utils/parser.py
+++ b/netbox_ssl/utils/parser.py
@@ -52,12 +52,11 @@ class CertificateParser:
     Security: Rejects any input containing private keys.
     """
 
+    MAX_PEM_INPUT_BYTES = 65536
+
     # Patterns to detect private keys
     PRIVATE_KEY_PATTERNS = [
-        r"-----BEGIN\s+(?:RSA\s+)?PRIVATE\s+KEY-----",
-        r"-----BEGIN\s+EC\s+PRIVATE\s+KEY-----",
-        r"-----BEGIN\s+ENCRYPTED\s+PRIVATE\s+KEY-----",
-        r"-----BEGIN\s+OPENSSH\s+PRIVATE\s+KEY-----",
+        r"-----BEGIN\s+(?:\w+\s+)*PRIVATE\s+KEY-----",
     ]
 
     # Pattern to extract individual certificates
@@ -91,6 +90,12 @@ class CertificateParser:
             PrivateKeyDetectedError: If private key material is found
             CertificateParseError: If parsing fails
         """
+        # Size guard: reject oversized input
+        if len(pem_text) > cls.MAX_PEM_INPUT_BYTES:
+            raise CertificateParseError(
+                f"Input too large ({len(pem_text)} bytes). Maximum is {cls.MAX_PEM_INPUT_BYTES} bytes."
+            )
+
         # Security check: reject private keys
         if cls.contains_private_key(pem_text):
             raise PrivateKeyDetectedError(
@@ -157,7 +162,7 @@ class CertificateParser:
             cn_attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
             if cn_attrs:
                 return cn_attrs[0].value
-        except Exception:
+        except (AttributeError, ValueError, UnicodeDecodeError, TypeError):
             pass
         return "Unknown"
 
@@ -171,7 +176,7 @@ class CertificateParser:
                 oid_name = attr.oid._name if hasattr(attr.oid, "_name") else str(attr.oid)
                 parts.append(f"{oid_name}={attr.value}")
             return ", ".join(parts)
-        except Exception:
+        except (AttributeError, ValueError, UnicodeDecodeError, TypeError):
             return str(cert.issuer)
 
     @classmethod
@@ -193,7 +198,7 @@ class CertificateParser:
                     sans.append(str(name.value))
         except x509.ExtensionNotFound:
             pass
-        except Exception:
+        except (AttributeError, ValueError, UnicodeDecodeError, TypeError):
             pass
         return sans
 

--- a/netbox_ssl/views/certificates.py
+++ b/netbox_ssl/views/certificates.py
@@ -4,10 +4,12 @@ Views for Certificate model.
 Includes Smart Paste import and Janus Renewal workflow views.
 """
 
+import contextlib
 from datetime import datetime
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -102,7 +104,7 @@ class CertificateBulkDeleteView(generic.BulkDeleteView):
     table = CertificateTable
 
 
-class CertificateImportView(View):
+class CertificateImportView(LoginRequiredMixin, View):
     """
     Smart Paste import view for PEM certificates.
 
@@ -124,11 +126,8 @@ class CertificateImportView(View):
         renew_from = request.GET.get("renew_from")
         renew_certificate = None
         if renew_from:
-            try:
-                renew_certificate = Certificate.objects.get(pk=int(renew_from))
-                request.session["renew_from_id"] = renew_certificate.pk
-            except (ValueError, TypeError, Certificate.DoesNotExist):
-                pass
+            with contextlib.suppress(ValueError, TypeError, Certificate.DoesNotExist):
+                renew_certificate = Certificate.objects.restrict(request.user, "view").get(pk=int(renew_from))
 
         return render(
             request,
@@ -161,10 +160,14 @@ class CertificateImportView(View):
             parsed = CertificateParser.parse(pem_content)
 
             # Check for existing certificate (duplicate check)
-            existing = Certificate.objects.filter(
-                serial_number=parsed.serial_number,
-                issuer=parsed.issuer,
-            ).first()
+            existing = (
+                Certificate.objects.restrict(request.user, "view")
+                .filter(
+                    serial_number=parsed.serial_number,
+                    issuer=parsed.issuer,
+                )
+                .first()
+            )
 
             if existing:
                 messages.error(
@@ -265,7 +268,7 @@ class CertificateImportView(View):
             )
 
 
-class CertificateRenewView(View):
+class CertificateRenewView(LoginRequiredMixin, View):
     """
     Janus Renewal workflow view.
 
@@ -294,7 +297,10 @@ class CertificateRenewView(View):
             messages.warning(request, _("No pending certificate renewal found."))
             return redirect(reverse("plugins:netbox_ssl:certificate_import"))
 
-        old_certificate = get_object_or_404(Certificate, pk=renewal_candidate_id)
+        old_certificate = get_object_or_404(
+            Certificate.objects.restrict(request.user, "change"),
+            pk=renewal_candidate_id,
+        )
 
         # Parse ISO date strings into formatted dates for the template
         pending_data = dict(pending_data)
@@ -342,7 +348,10 @@ class CertificateRenewView(View):
 
         if is_renewal and renewal_candidate_id:
             # Janus Renewal: Replace & Archive
-            old_certificate = get_object_or_404(Certificate, pk=renewal_candidate_id)
+            old_certificate = get_object_or_404(
+                Certificate.objects.restrict(request.user, "change"),
+                pk=renewal_candidate_id,
+            )
 
             # If the old certificate is tenant-scoped, carry it forward
             if tenant is None and old_certificate.tenant:
@@ -460,7 +469,7 @@ class CertificateRenewView(View):
             return redirect(certificate.get_absolute_url())
 
 
-class CertificateBulkDataImportView(View):
+class CertificateBulkDataImportView(LoginRequiredMixin, View):
     """
     Bulk import certificates from CSV or JSON data.
 
@@ -503,6 +512,10 @@ class CertificateBulkDataImportView(View):
             content = uploaded.read().decode("utf-8-sig")
         else:
             content = request.POST.get("data_content", "")
+
+        if len(content) > self.MAX_UPLOAD_SIZE:
+            messages.error(request, _("Pasted content too large."))
+            return render(request, self.template_name, {"step": "input"})
 
         if not content.strip():
             messages.error(request, _("No data provided. Paste CSV/JSON or upload a file."))

--- a/netbox_ssl/views/csr.py
+++ b/netbox_ssl/views/csr.py
@@ -3,6 +3,7 @@ Views for CertificateSigningRequest model.
 """
 
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect, render
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
@@ -71,7 +72,7 @@ class CertificateSigningRequestBulkDeleteView(generic.BulkDeleteView):
     table = CertificateSigningRequestTable
 
 
-class CSRImportView(View):
+class CSRImportView(LoginRequiredMixin, View):
     """
     Import view for PEM CSRs.
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import argparse
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -110,9 +111,7 @@ class NetBoxSmokeTest:
 
     def _get_api_token(self):
         """Try to get or create an API token."""
-        # For testing, we'll use basic auth or the pre-configured token
-        # The default superuser token from docker setup
-        self.api_token = "0123456789abcdef0123456789abcdef01234567"
+        self.api_token = os.environ.get("NETBOX_TOKEN")
 
     def check_for_errors(self, response: requests.Response) -> str:
         """Check response for error patterns."""


### PR DESCRIPTION
## Summary

Comprehensive security hardening addressing 10 findings from the v0.7.5 security audit.

### CRITICAL
- **#69** — Add `LoginRequiredMixin` to all custom import/renew views

### HIGH
- **#70** — GraphQL resolvers use `.restrict()` + explicit field lists (no more `fields="__all__"`)
- **#71** — API custom actions enforce `has_perm()` + `.restrict()` on all querysets
- **#72** — `max_length=65536` on all `pem_content` fields + size guard in parser + paste-box check
- **#73** — DB error messages sanitized — log server-side, return generic to clients
- **#74** — Export `fields` parameter validated against allowlist before `getattr()`

### MEDIUM
- **#75** — Broadened private key detection regex + added check to CSR import
- **#76** — `.restrict()` on session-sourced PKs + removed orphaned session key
- **#77** — CSV formula injection sanitization in export

### LOW (#78)
- Narrowed `except Exception` to specific types in parser
- `MAX_CHAIN_DEPTH=10` cap in chain validator
- `fmt`/`on_duplicate` allowlist validation in bulk-data-import
- Export filename restricted to ASCII, capped at 64 chars
- Removed hardcoded API token from smoke_test.py

## Files Changed (12)
- `views/certificates.py`, `views/csr.py` — auth mixins, session hardening
- `api/views.py` — permission checks, error sanitization, input validation
- `api/serializers/certificates.py`, `api/serializers/csr.py` — max_length, private key check
- `graphql/schema.py`, `graphql/types.py` — restrict() + explicit fields
- `utils/parser.py` — size guard, broader key detection, narrowed exceptions
- `utils/export.py` — field allowlist, CSV sanitization
- `utils/chain_validator.py` — depth cap
- `forms/csr.py` — private key check
- `scripts/smoke_test.py` — removed hardcoded token

## Test plan
- [x] Ruff lint clean
- [x] Ruff format clean
- [x] Local unit tests pass (336 passed)
- [ ] CI pipeline passes (lint + unit + integration v4.4/v4.5)

Fixes #69, #70, #71, #72, #73, #74, #75, #76, #77, #78