### PR TITLE
docs: PRD consolidation for post-v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,10 @@ https://ctrl-alt-automate.github.io/netbox-ssl/.
 ### Deprecated
 
 - The `add_certificate` permission fallback for import endpoints (introduced
-  in v0.9.0 for backward compatibility) will be **removed in v1.1**. Assign
-  the `import_certificate` custom permission explicitly before upgrading.
+  in v0.9.0 for backward compatibility) will be **removed in v2.0.0**.
+  Removal is a breaking change, so per SemVer it lands in a major release.
+  Assign the `import_certificate` custom permission explicitly before
+  upgrading to v2.0.
   See [permissions reference](https://ctrl-alt-automate.github.io/netbox-ssl/reference/permissions/).
 
 ### Security

--- a/docs/superpowers/plans/2026-04-17-prd-consolidation-implementation.md
+++ b/docs/superpowers/plans/2026-04-17-prd-consolidation-implementation.md
@@ -1,0 +1,1150 @@
+# PRD Consolidation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace two legacy Dutch PRDs with a canonical English `PRD.md` (product charter) and `ROADMAP.md` (forward-looking), archiving the originals under `project-requirement-document/archive/`.
+
+**Architecture:** All work is Markdown in a single directory. Feature branch `chore/prd-consolidation` off `dev`. Commits are logically grouped per deliverable. PR flow mirrors the v1.0 release pattern (CI + Gemini → admin-merge to dev, then dev → main, no tag).
+
+**Tech Stack:** Markdown, `git mv` for history preservation, MkDocs (strict build check only — PRD/ROADMAP stay outside the site).
+
+---
+
+## Spec Reference
+
+This plan implements: `docs/superpowers/specs/2026-04-17-prd-consolidation-design.md`
+
+## File Structure
+
+### Created
+
+```
+project-requirement-document/PRD.md                              # Product Charter, ~500 lines
+project-requirement-document/ROADMAP.md                          # Forward-looking, ~250 lines
+project-requirement-document/archive/README.md                   # ~40 lines
+```
+
+### Moved (git mv, history preserved)
+
+```
+project-requirement-document/Product Requirements Document.md
+    → project-requirement-document/archive/2026-01-17-prd-v1-mvp.md
+
+project-requirement-document/PRD v2 - Roadmap & Next Phases.md
+    → project-requirement-document/archive/2026-03-09-prd-v2-roadmap.md
+```
+
+### Unchanged
+
+- `docs/` — the MkDocs site stays as-is; the PRD references it
+- `README.md`, `CHANGELOG.md`, `COMPATIBILITY.md` — untouched
+- Plugin code — untouched
+
+---
+
+## Phase 1 — Archive legacy PRDs
+
+### Task 1: Create archive folder and move legacy PRDs
+
+**Files:**
+- Create: `project-requirement-document/archive/README.md`
+- Move: legacy PRDs into `archive/`
+
+- [ ] **Step 1: Create archive directory**
+
+```bash
+mkdir -p project-requirement-document/archive/
+```
+
+- [ ] **Step 2: Move legacy PRDs with git mv (preserves history)**
+
+```bash
+git mv "project-requirement-document/Product Requirements Document.md" \
+       "project-requirement-document/archive/2026-01-17-prd-v1-mvp.md"
+
+git mv "project-requirement-document/PRD v2 - Roadmap & Next Phases.md" \
+       "project-requirement-document/archive/2026-03-09-prd-v2-roadmap.md"
+```
+
+- [ ] **Step 3: Verify moves via git status**
+
+Run: `git status`
+Expected: two `renamed:` entries, no unmerged content.
+
+- [ ] **Step 4: Write `archive/README.md`**
+
+Exact content (40 lines):
+
+```markdown
+# Archived Product Requirements Documents
+
+This folder holds historical PRDs preserved for provenance. **They are out
+of date.** For current specification, see:
+
+- [PRD.md](../PRD.md) — canonical product charter
+- [ROADMAP.md](../ROADMAP.md) — forward-looking plans
+
+## Index
+
+| File | Date | Role | Status at write time |
+|------|------|------|----------------------|
+| [2026-01-17-prd-v1-mvp.md](2026-01-17-prd-v1-mvp.md) | 2026-01-17 | MVP scope spec | Pre-implementation (v0.x) |
+| [2026-03-09-prd-v2-roadmap.md](2026-03-09-prd-v2-roadmap.md) | 2026-03-09 | Roadmap v0.6 → v1.0 | Mid-implementation |
+
+## Why archive, not delete?
+
+- **Rationale preservation** — architectural decisions are first
+  articulated here; the current PRD references them.
+- **Historical provenance** — audit questions about decision origin can
+  be answered from this folder.
+- **Honest evolution** — shows how thinking developed; useful for
+  contributors learning why the product looks the way it does.
+
+## Should I read these?
+
+No, unless you need a historical perspective. Current-product content
+lives in `PRD.md` or the
+[documentation site](https://ctrl-alt-automate.github.io/netbox-ssl/).
+
+Both documents are in Dutch — the original working language of the
+project. The canonical `PRD.md` is in English for community accessibility.
+```
+
+- [ ] **Step 5: Commit Phase 1**
+
+```bash
+git add -A project-requirement-document/
+git commit -m "docs: archive legacy PRDs under project-requirement-document/archive/
+
+Move 'Product Requirements Document.md' and 'PRD v2 - Roadmap & Next
+Phases.md' into a dated archive/ folder, preserving git history via
+git mv. Add archive/README.md pointing readers at the canonical
+PRD.md and ROADMAP.md (to be added in subsequent commits)."
+```
+
+---
+
+## Phase 2 — Write `PRD.md` (Product Charter)
+
+### Task 2: Write the new product charter
+
+**Files:**
+- Create: `project-requirement-document/PRD.md`
+
+Target length: **~500 lines** of Markdown. Charter-style: compact, referential,
+authoritative on the *why*. No duplication of content that already lives in
+`docs/`.
+
+The charter is written **section by section**. Each sub-task below produces
+one section. Commit once after all sections land (Step 11).
+
+- [ ] **Step 1: Write section 1 — Metadata**
+
+At the top of `PRD.md`, add the metadata block:
+
+```markdown
+# NetBox SSL — Product Requirements Document
+
+**Project code:** JANUS
+**Applies to plugin version:** v1.0.x
+**Status:** Canonical — replaces legacy PRDs in `archive/`
+**Maintainer:** NetBox SSL team (see `CONTRIBUTING.md`)
+**Last updated:** 2026-04-17
+**Language:** English (Dutch originals preserved under `archive/`)
+
+> This document is the canonical product specification for NetBox SSL. It
+> describes the product as built at v1.0.0 GA, the design principles that
+> govern ongoing work, and the architectural decisions behind key trade-offs.
+>
+> For step-by-step usage and API reference, see the
+> [documentation site](https://ctrl-alt-automate.github.io/netbox-ssl/).
+> For forward-looking plans, see [ROADMAP.md](ROADMAP.md).
+
+---
+```
+
+- [ ] **Step 2: Write section 2 — Executive Summary**
+
+Target: ~200 words. Structure: one paragraph on what it is, one on target
+audience, one on what distinguishes it.
+
+Use this opening (verbatim):
+
+```markdown
+## 2. Executive Summary
+
+NetBox SSL is a plugin that turns [NetBox](https://github.com/netbox-community/netbox)
+into a single source of truth for TLS/SSL certificate inventory. It imports
+certificates from PEM, parses every X.509 attribute, links certificates to the
+services, devices, and virtual machines that present them, and surfaces
+expiry risk before it becomes outage risk.
+
+The product is aimed at infrastructure and security teams already running
+NetBox who want certificate visibility without adopting a separate PKI
+platform. It is useful for compliance evidence, renewal coordination, and
+blast-radius analysis when a CA is deprecated or compromised.
+
+What distinguishes NetBox SSL from alternatives: it is **passive by design**.
+It observes and documents; it does not issue, deploy, or rotate certificates.
+Private keys are never stored — only public metadata and operator-provided
+location hints (e.g., a Vault path). The plugin's value is visibility and
+audit trail, deliberately leaving issuance and deployment to the specialised
+tooling that already owns those responsibilities.
+```
+
+- [ ] **Step 3: Write section 3 — Product Vision & Design Principles**
+
+Target: ~80 lines. Five sub-sections, each ~15 lines:
+
+- 3.1 Passive Administration — quote from legacy PRD v1 §2.2 in English
+- 3.2 No Private Keys, Ever — quote the "honeypot" rationale from v1 §3.1.2
+- 3.3 Audit Trail Is Sacred — rationale for replace-and-archive from v1 §4.2.1
+- 3.4 NetBox-Native — reuse NetBox's auth, permissions, changelog; no standalone DB/UI
+- 3.5 Community-First — Apache 2.0, public PyPI, versioned docs, contribution guide
+
+Each sub-section: *principle statement* (1 line, bold) + *why* (1 paragraph) +
+*how it manifests* (1 paragraph).
+
+Example for 3.1 (use as template for the others):
+
+```markdown
+### 3.1 Passive Administration
+
+**Principle:** NetBox SSL observes and documents the certificate landscape.
+It does not issue, deploy, rotate, or revoke certificates.
+
+**Why.** The plugin runs inside the NetBox process. Giving that process the
+permissions needed to *act* on certificates (SSH keys for deployment, CA API
+credentials, kubeconfig, secrets manager write access) expands NetBox's
+blast radius far beyond its intended role as an inventory. Active tools have
+different failure modes — stuck renewals, partial deployments, production
+outages — and belong in dedicated platforms (Certbot, cert-manager, ACME
+clients) that have access control shaped for that work.
+
+**How it manifests.** The plugin has no outbound credentials for CAs or
+devices. The only outbound calls are HTTPS reads of certificate metadata
+(ACME renewal information, external inventory sources) under shared SSRF
+controls. Deployment remains the job of whatever already owned it.
+```
+
+- [ ] **Step 4: Write section 4 — Scope**
+
+Target: ~60 lines. Three subsections:
+
+- 4.1 In Scope — table: feature → status (✓ shipped in v1.0)
+- 4.2 Out of Scope — table: feature → rationale
+- 4.3 Explicit Non-Goals — bulleted list with one-sentence rationale each
+
+Example table for 4.1 (expand with full v1.0 feature set):
+
+```markdown
+### 4.1 In Scope
+
+| Capability | Status |
+|------------|:------:|
+| Smart Paste Import (PEM with private-key rejection) | ✓ v0.1 |
+| Multi-target Assignments (Service, Device, VM via GenericForeignKey) | ✓ v0.2 |
+| Janus Renewal Workflow (replace & archive, atomic) | ✓ v0.2 |
+| Dashboard expiry widget + analytics dashboard | ✓ v0.5, v0.7 |
+| Certificate Authority auto-detection | ✓ v0.4 |
+| Chain validation (capped depth) | ✓ v0.5 |
+| Compliance policies (tag-scoped from v0.9) | ✓ v0.5, v0.9 |
+| CSR tracking | ✓ v0.4 |
+| ACME certificate monitoring (15+ providers) | ✓ v0.5 |
+| Bulk CSV/JSON/PEM import + bulk operations | ✓ v0.5, v0.8 |
+| Multi-format export (CSV, JSON, YAML, PEM) | ✓ v0.5 |
+| REST API (15+ actions) + GraphQL | ✓ v0.5 |
+| Event/webhook integration via NetBox Event Rules | ✓ v0.6 |
+| Scheduled expiry scan (idempotent) | ✓ v0.6 |
+| Compliance trend charts + export | ✓ v0.7 |
+| Certificate topology map | ✓ v0.7 |
+| Lifecycle tracking (state transitions + timeline) | ✓ v0.8 |
+| Auto-archive of expired certificates | ✓ v0.8 |
+| External Source sync (Lemur, Generic REST) | ✓ v0.8 |
+| Granular custom permissions | ✓ v0.9 |
+| Performance indexes + lazy PEM loading | ✓ v0.9 |
+| DER + PKCS#7 import, diff API, scheduled export | ✓ v0.9 |
+| Custom fields + tag-based filtering | ✓ v0.9 |
+| ARI monitoring (RFC 9773) | ✓ v0.9 |
+| Versioned MkDocs Material documentation site | ✓ v1.0 |
+| Load testing suite (Locust) | ✓ v1.0 |
+```
+
+For 4.2 (Out of Scope), reuse the table from legacy PRD v1 §2.1, translated
+to English, with an added *Why* column:
+
+| Capability | Why out of scope |
+|------------|------------------|
+| Active deployment of keys to servers | Would require SSH/device credentials — violates passive administration |
+| Storage of private keys | Creates a honeypot; private key storage belongs in dedicated secrets managers |
+| Full PKI management (issuance, CA operations) | Specialised tools exist; NetBox's strength is documentation |
+| Active network scanning | Requires outbound credentials and a different trust model |
+| CA API integrations (Let's Encrypt client, DigiCert issuance) | Belongs in ACME clients and certificate managers — we sync from them read-only instead |
+
+For 4.3 (Explicit Non-Goals):
+
+- Never become an ACME client (Certbot / acme.sh own this)
+- Never broker CA issuance
+- Never push TLS config to load balancers or appliances
+- Never decrypt TLS traffic
+- Never run outbound scans for discovery
+- Never store credentials for external systems as plaintext in the database
+  (use `env:VAR_NAME` references only)
+
+- [ ] **Step 5: Write section 5 — Architectural Decision Records (ADRs)**
+
+Target: ~200 lines. Seven ADRs. Format for each (~30 lines):
+
+```markdown
+### 5.X ADR-0X: <Title>
+
+**Status:** Accepted <YYYY-MM-DD>
+**Context.** <1 paragraph — what problem did we face?>
+**Decision.** <1 paragraph — what did we decide?>
+**Consequences.** <1 paragraph — what changes because of this?>
+**Alternatives considered.** <bullet list of 1-3 alternatives with reason they lost>
+```
+
+ADRs to include (content source in parens):
+
+- 5.1 ADR-01: Passive over Active (legacy PRD v1 §2.2)
+- 5.2 ADR-02: No Private Key Storage (legacy PRD v1 §3.1.2)
+- 5.3 ADR-03: Replace & Archive (legacy PRD v1 §4.2.1, docs/explanation/janus-workflow.md)
+- 5.4 ADR-04: Chain as Metadata, Not Entities (legacy PRD v1 §3.1.1)
+- 5.5 ADR-05: GenericForeignKey for Assignments (legacy PRD v1 §3.2.1)
+- 5.6 ADR-06: External Sources as Read-Only Sync (legacy PRD v2 §5.2.5)
+- 5.7 ADR-07: Versioned Docs via MkDocs Material + mike (v1.0 implementation; docs/superpowers/specs/2026-04-16-v1.0-ga-release-design.md)
+
+Example ADR (use as template):
+
+```markdown
+### 5.2 ADR-02: No Private Key Storage
+
+**Status:** Accepted 2026-01-17. Reaffirmed at v1.0 GA (2026-04-16).
+
+**Context.** Early design raised the option of storing encrypted private keys
+alongside certificate metadata, so that NetBox SSL could offer "complete
+asset management". Every data field stored in NetBox is accessible to
+superusers and, via `.restrict()`, to scoped users. Private keys would make
+the NetBox database a concentration of secrets.
+
+**Decision.** The database stores no private keys, encrypted or otherwise.
+The parser actively rejects PEM input containing any private-key header.
+A free-text `private_key_location` field holds an operator-provided hint
+(e.g., `vault://secret/tls/api.example.com`) pointing at the secrets
+manager that *does* own the key.
+
+**Consequences.** The NetBox database cannot be used to decrypt traffic,
+impersonate endpoints, or forge certificates. The plugin avoids an entire
+class of compliance obligations around key management. The trade-off is
+that operators must run a separate secrets manager — which they typically
+already do.
+
+**Alternatives considered.**
+- *Encrypted key storage with per-tenant keys.* Rejected: moves the secret
+  one level, doesn't remove it.
+- *Write-only API for private keys.* Rejected: still a honeypot from the
+  perspective of anyone who compromises the NetBox host.
+- *Optional per-install toggle.* Rejected: makes the security story
+  conditional and undermines the "never a honeypot" guarantee.
+```
+
+- [ ] **Step 6: Write section 6 — Data Model Overview**
+
+Target: ~60 lines. Three subsections:
+
+- 6.1 Core entities (bulleted list with one-line descriptions)
+- 6.2 Relationship diagram (Mermaid erDiagram — reuse from `docs/explanation/architecture.md`)
+- 6.3 Field-level details (link to `docs/reference/data-models.md`)
+
+Content for 6.1 (list):
+
+```markdown
+### 6.1 Core Entities
+
+- **Certificate** — a unique X.509 certificate record; the library item
+- **CertificateAssignment** — links a Certificate to a target via
+  GenericForeignKey (Service, Device, VirtualMachine)
+- **CertificateAuthority** — issuing CA record, with auto-detection from
+  the issuer string
+- **CertificateSigningRequest** — tracked CSR, optionally linked to the
+  Certificate it produced
+- **CertificateLifecycleEvent** — append-only log of status transitions,
+  renewals, assignment changes
+- **CertificateEventLog** — idempotency tracker for the expiry scan
+  (prevents duplicate events within a cooldown window)
+- **CompliancePolicy** / **ComplianceResult** — per-policy checks and
+  their historical outcomes
+- **ExternalSource** / **ExternalSourceSyncLog** — read-only sync to
+  third-party certificate managers
+```
+
+For 6.2, paste the erDiagram block from `docs/explanation/architecture.md`
+verbatim so the PRD is self-contained on domain structure.
+
+For 6.3, a single line: `See [data models reference](https://ctrl-alt-automate.github.io/netbox-ssl/reference/data-models/) for field-level definitions.`
+
+- [ ] **Step 7: Write section 7 — Core Workflows**
+
+Target: ~60 lines. Five subsections, each ~10 lines:
+
+- 7.1 Smart Paste Import — one paragraph summary + link to tutorial 01
+- 7.2 Janus Renewal — one paragraph summary + link to tutorial 02
+- 7.3 Expiry Monitoring — one paragraph summary + link to tutorial 03
+- 7.4 External Source Sync — one paragraph summary + link to how-to
+- 7.5 Bulk Operations — one paragraph summary + link to how-to
+
+Example for 7.1:
+
+```markdown
+### 7.1 Smart Paste Import
+
+Operator pastes raw PEM into a single text area. The backend rejects any
+input containing a private key header, then uses the Python `cryptography`
+library to extract CN, SANs, validity window, issuer, fingerprint,
+algorithm, and key size. Duplicate detection is by `serial_number + issuer`.
+Parsed metadata is presented in a preview before the record is created.
+
+→ [Tutorial: Your First Certificate Import](https://ctrl-alt-automate.github.io/netbox-ssl/tutorials/01-first-import/)
+```
+
+- [ ] **Step 8: Write section 8 — Non-Functional Requirements**
+
+Target: ~80 lines. Five subsections:
+
+- 8.1 Security — list the layered controls (private-key rejection, PEM
+  size cap, SSRF guards, permission model, CSV injection prevention,
+  credential pattern `env:VAR_NAME`)
+- 8.2 Performance — target SLOs (list p50/p95/p99 from load-testing doc),
+  database indexes (9 indexes on Certificate in v0.9), lazy PEM loading
+- 8.3 Compatibility — NetBox 4.4 & 4.5, Python 3.10–3.12, macOS/Linux
+  dev environments
+- 8.4 Observability — NetBox Event Rules, scheduled scan idempotency,
+  structured lifecycle log
+- 8.5 Deployability — pure `pip install`, no external services required,
+  works within standard NetBox plugin loading
+
+- [ ] **Step 9: Write section 9 — Success Metrics**
+
+Target: ~40 lines. Table format:
+
+```markdown
+### 9.1 Adoption
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| PyPI package published | ✓ | — |
+| PyPI downloads/month | Track post-v1.0 | >500 within 12 months |
+| GitHub stars | Track | >50 within 12 months |
+| GitHub forks | Track | >10 within 12 months |
+
+### 9.2 Quality
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| Unit test coverage on utils | 72% | >= 70% gate |
+| Integration tests in CI | ✓ (v4.4 + v4.5) | — |
+| Bandit findings (high/medium) | 0 | 0 |
+| Known CVEs in deps | 0 | 0 |
+| Security review checklist | ✓ | Living |
+
+### 9.3 Release cadence
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| Semver adherence | ✓ | — |
+| CHANGELOG entries per release | ✓ | — |
+| Time-to-patch a security issue | TBD | <= 14 days for high severity |
+
+### 9.4 Community
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| External contributors | Tracked | >3 within 12 months |
+| Issue turnaround (median) | Tracked | <= 5 business days |
+| Labelled issues (good-first-issue) | ✓ | Keep >= 3 open |
+```
+
+- [ ] **Step 10: Write section 10 — Document Governance**
+
+Target: ~40 lines. Three subsections:
+
+```markdown
+## 10. Document Governance
+
+### 10.1 Update Triggers
+
+| Trigger | Action |
+|---------|--------|
+| New minor release (v1.1, v1.2, …) | Review PRD: any ADR added? scope change? |
+| New major release (v2.0, …) | Full review + version bump in metadata |
+| New architectural decision | Add ADR to §5 + CHANGELOG entry |
+| Docs site restructure | Update links in §6 and §7 |
+
+### 10.2 Version Field Convention
+
+The "Applies to plugin version" field in the metadata block tracks the
+plugin version. No separate PRD semver — single source of truth is the
+plugin version. "Last updated" is manually maintained.
+
+### 10.3 Relationship to Other Documents
+
+```
+PRD.md (stable)           → why + principles + ADRs
+ROADMAP.md (living)       → what comes next
+CHANGELOG.md (append)     → what has shipped
+docs/ (MkDocs site)       → how to use it
+docs/superpowers/specs/   → brainstorm artefacts
+```
+
+Each layer has one purpose; overlap is the exception.
+
+### 10.4 Document Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-04-17 | Initial consolidation from legacy PRDs v1.1 and v2.0 (now in `archive/`) |
+```
+
+- [ ] **Step 11: Final build and structural check**
+
+Run: `wc -l project-requirement-document/PRD.md`
+Expected: 400–600 lines (not a hard limit, just sanity).
+
+Run: `grep -n "TBD\|TODO\|XXX" project-requirement-document/PRD.md`
+Expected: empty output (no placeholders). Fix any hits before committing.
+
+- [ ] **Step 12: Commit Phase 2**
+
+```bash
+git add project-requirement-document/PRD.md
+git commit -m "docs: add canonical PRD.md (product charter)
+
+Introduce a consolidated, English, charter-style Product Requirements
+Document under project-requirement-document/PRD.md. The document
+describes NetBox SSL v1.0 as-built, using Architecture Decision Records
+(§5) as the authoritative log of design choices. Implementation details
+are referenced to the docs site (ctrl-alt-automate.github.io/netbox-ssl)
+rather than duplicated.
+
+Legacy PRDs (v1.1 and v2.0, Dutch) are preserved under archive/ from
+the previous commit."
+```
+
+---
+
+## Phase 3 — Write `ROADMAP.md` (forward-looking)
+
+### Task 3: Write the roadmap document
+
+**Files:**
+- Create: `project-requirement-document/ROADMAP.md`
+
+Target length: **~250 lines**. Living document, Now/Next/Later/Deferred/Rejected
+taxonomy. Populated at v1.0 ship.
+
+- [ ] **Step 1: Write metadata + reading guide (§1 + §2)**
+
+```markdown
+# NetBox SSL — Roadmap
+
+**Status:** Living document
+**Last reviewed:** 2026-04-17
+**Plugin version at publication:** v1.0.0
+**Owner:** NetBox SSL team (see `CONTRIBUTING.md`)
+
+> This roadmap sketches what *may* come after v1.0.0. It is deliberately
+> vague on timing: a solo or small-team project misses hard dates more
+> often than it hits them, and Now/Next/Later is an honest taxonomy.
+>
+> For current product specification, see [PRD.md](PRD.md). For shipped
+> work, see [CHANGELOG.md](../CHANGELOG.md).
+
+---
+
+## 2. How to Read This Roadmap
+
+No hard dates. Items live in one of five buckets:
+
+| Bucket | Meaning | Matches GitHub Milestone? |
+|--------|---------|---------------------------|
+| **Now** | In active development | Open milestone |
+| **Next** | Committed, scoped, not yet started | Backlog with label |
+| **Later** | Under consideration | Open issue, no milestone |
+| **Deferred** | Considered, not pursued for now | Closed as "wontfix for v1.x" |
+| **Rejected** | Actively not building, with rationale | Closed with the reasoning preserved |
+
+Items move between buckets as priorities shift. A feature in Later may
+become Next (or Rejected), never "missed deadline" — only "different
+priority now".
+```
+
+- [ ] **Step 2: Write Now (§3) — empty at ship**
+
+```markdown
+## 3. Now — In Active Development
+
+*Empty at v1.0.0 ship. Items appear here when an issue is assigned a
+milestone and work has started.*
+```
+
+- [ ] **Step 3: Write Next (§4) — initial candidates**
+
+Populate with three concrete v1.1 candidates:
+
+```markdown
+## 4. Next — Committed, Scoped, Not Yet Started
+
+### 4.1 Vault Read-Only Integration
+
+**Goal:** Resolve `private_key_location` breadcrumbs against a HashiCorp
+Vault instance to confirm the key is where it claims to be, without
+retrieving the key material itself.
+
+**Scope boundary.** We only `HEAD`-check (or list-check) the path. The
+plugin never reads key contents, even if Vault permissions would allow
+it — enforced in code, mirroring the PEM parser's private-key rejection.
+
+**Reference issue.** To be filed.
+
+### 4.2 DigiCert CertCentral Adapter
+
+**Goal:** Add a first-party External Source adapter for DigiCert
+CertCentral. Reads certificate metadata only, never private keys.
+
+**Scope boundary.** Same as the existing Lemur adapter: read-only,
+HTTPS-only, `env:VAR_NAME` credentials, no redirect following.
+
+**Reference issue.** To be filed.
+
+### 4.3 Performance Scaling Pass (> 10k Certificates)
+
+**Goal:** Validate and tune plugin behaviour at 10,000 and 50,000
+certificates. Profile slow queries, tune index usage, add benchmark
+assertions to CI.
+
+**Scope boundary.** No architectural changes — this is tuning, not
+redesign. If a redesign turns out to be needed, it gets promoted to
+a design spec and a separate plan.
+
+**Reference issue.** To be filed.
+```
+
+- [ ] **Step 4: Write Later (§5) — 6 items from legacy v2 §8 + additions**
+
+Pull content from the legacy PRD v2 §8 table and translate to English:
+
+```markdown
+## 5. Later — Under Consideration
+
+### 5.1 Git-backed Audit Trail
+
+Export certificate state to a Git repository for version control outside
+NetBox. Fits the passive philosophy (read-only export, no active control).
+
+### 5.2 CT Log Monitoring
+
+Use Certificate Transparency logs to detect certificates issued for the
+organisation's domains outside the tracked inventory. Passive monitoring
+of public data — aligns with the principle.
+
+### 5.3 SLA Tracking
+
+Define SLAs per tenant or CA ("renewal must land within X days of
+warning"). Purely administrative — tracks the human workflow, does not
+automate it.
+
+### 5.4 AWS ACM Read-Only Adapter
+
+External Source adapter for AWS Certificate Manager. Read-only via
+`list-certificates` / `describe-certificate`. Private keys never fetched,
+even when IAM permissions would allow.
+
+### 5.5 Azure Key Vault Read-Only Adapter
+
+External Source adapter for Azure Key Vault certificates. Public metadata
+only.
+
+### 5.6 Scan Result Ingestion
+
+Import output from `nmap`, `sslyze`, or similar passive scanners. Dedupes
+against the existing inventory and flags discrepancies.
+
+### 5.7 Multi-Language Docs
+
+Dutch translation of the docs site (currently English only). Possibly
+other languages if contributors step up. The PRD itself likely stays
+English as the canonical reference.
+```
+
+- [ ] **Step 5: Write Deferred (§6)**
+
+```markdown
+## 6. Deferred — Considered, Not Pursued For Now
+
+### 6.1 Multi-Instance Sync
+
+Synchronising certificate data between NetBox deployments introduces
+conflict resolution, ownership, and trust questions that exceed the
+current scope. Revisit only if there is a clear operational case and a
+design spec that addresses those questions.
+
+### 6.2 AI-Powered Expiry Prediction
+
+Machine-learning-driven predictions (e.g., "cert X is likely to be
+renewed late based on historical patterns") are an interesting research
+topic but not a short-term priority. The deterministic threshold model
+is sufficient for the current audience.
+
+### 6.3 Commercial PKI UI Embedding
+
+Embedding CA-provider dashboards (e.g., DigiCert web UI, Venafi console)
+inside NetBox. Provides marginal value over the external-source
+metadata sync already in place, at the cost of significant UI complexity.
+```
+
+- [ ] **Step 6: Write Rejected (§7)**
+
+```markdown
+## 7. Rejected — Actively Not Building
+
+These are not "yet to be reconsidered" — they conflict with a design
+principle. Reconsideration requires a convincing argument that the
+principle itself should change.
+
+### 7.1 Active ACME Client
+
+Violates ADR-01 (Passive over Active). The certificate issuance and
+deployment domain is owned by specialised tooling (Certbot, acme.sh,
+Caddy, Traefik, cert-manager). NetBox SSL observes and documents; it
+does not run ACME.
+
+### 7.2 Private Key Storage
+
+Violates ADR-02 (No Private Key Storage). Even encrypted, keys in the
+plugin database create a concentration of secrets inside a non-secrets-
+manager system. Use a secrets manager (HashiCorp Vault, AWS Secrets
+Manager, Azure Key Vault) and record the *location* in the plugin.
+
+### 7.3 Automatic Certificate Deployment to Devices
+
+Violates ADR-01 and expands the plugin's trust boundary to SSH keys,
+kubeconfigs, and device credentials. Dedicated deployment tooling
+(Ansible, Salt, Terraform, custom CI) owns this, and their access
+model is built for it.
+
+### 7.4 Active Network Scanning
+
+Running outbound scans to discover certificates conflicts with passive
+administration and introduces false-positive risk. Passive ingestion
+from an existing scanner's output (see §5.6) is the correct pattern.
+
+### 7.5 TLS Traffic Inspection or MitM
+
+Categorically out of scope. The plugin never handles traffic, only
+metadata.
+```
+
+- [ ] **Step 7: Write Planned Breaking Changes (§8)**
+
+```markdown
+## 8. Planned Breaking Changes (v2.0+)
+
+SemVer requires that breaking changes land in a major release. This
+section lists deprecations that will become removals.
+
+### 8.1 Removal of `add_certificate` Permission Fallback
+
+**Deprecated in:** v1.0.0 (2026-04-16)
+**Removal target:** v2.0.0
+
+Import endpoints currently accept either `import_certificate` (the new
+custom permission introduced in v0.9) or the legacy `add_certificate`
+permission. The legacy fallback will be removed in v2.0.
+
+**Operator action.** Assign `import_certificate` to the appropriate
+roles before upgrading to v2.0. See
+[permissions reference](https://ctrl-alt-automate.github.io/netbox-ssl/reference/permissions/).
+```
+
+- [ ] **Step 8: Write Community Input (§9) + Post-v2.0 Horizon (§10)**
+
+```markdown
+## 9. Community Input
+
+### 9.1 Proposing a Feature
+
+Open a GitHub issue using the feature-request template:
+https://github.com/ctrl-alt-automate/netbox-ssl/issues/new?template=feature_request.yml
+
+Good feature requests include:
+
+- A concrete use case ("team X needs to do Y")
+- Why the existing capabilities are insufficient
+- How the proposed feature fits the passive-administration principle
+- Optional: a proof-of-concept or adapter stub
+
+### 9.2 Track Record
+
+Past community requests and how they were handled:
+
+- `#67` (snapshot TypeError) — accepted as bug, fixed in v0.7.1
+- `#47` (renewal reminders) — accepted as feature, shipped in v0.8
+- `#84` (ARI monitoring) — accepted as feature, shipped in v0.9
+- `#30` (template packaging) — accepted as bug, fixed in v0.4.2
+
+---
+
+## 10. Post-v2.0 Horizon
+
+Directional bets, not commitments:
+
+- **Graph-shaped inventory view** — beyond the tree-shaped topology,
+  show certificate relationships as a graph (shared SANs, shared CAs,
+  sibling services)
+- **Compliance-as-code** — policy definitions in a standard format
+  (Rego? OPA?) rather than per-policy-type rows in a table
+- **Delta-based external-source sync** — most adapters currently fetch
+  full lists; incremental sync reduces API quota and improves latency
+- **Per-tenant alerting policies** — different expiry thresholds and
+  notification channels for different parts of the organisation
+
+None of the above is committed. The Horizon section exists for visibility
+so that contributors thinking long-term know where the product might go.
+```
+
+- [ ] **Step 9: Verify no placeholders**
+
+Run: `grep -n "TBD\|TODO\|XXX" project-requirement-document/ROADMAP.md`
+Expected: two hits — both in Next section as "Reference issue. To be filed."
+These are acceptable because they accurately describe pending work.
+
+Run: `wc -l project-requirement-document/ROADMAP.md`
+Expected: 200–300 lines.
+
+- [ ] **Step 10: Commit Phase 3**
+
+```bash
+git add project-requirement-document/ROADMAP.md
+git commit -m "docs: add ROADMAP.md forward-looking plan
+
+Introduce a Now/Next/Later/Deferred/Rejected roadmap structure for
+post-v1.0 work. Populated with three committed candidates (Vault
+integration, DigiCert adapter, performance scaling pass), seven Later
+items drawn from the legacy PRD v2 §8, and explicit Deferred/Rejected
+sections that preserve the rationale for items the plugin will not
+pursue."
+```
+
+---
+
+## Phase 4 — Verification and quality gates
+
+### Task 4: Run local quality checks
+
+**Files:**
+- (Read-only — verification only)
+
+- [ ] **Step 1: Ruff + bandit (should be unchanged since we touched no Python)**
+
+```bash
+ruff check netbox_ssl/ tests/
+ruff format --check netbox_ssl/ tests/
+```
+
+Expected: clean (no Python files were modified).
+
+- [ ] **Step 2: MkDocs strict build still passes**
+
+```bash
+.venv-docs/bin/mkdocs build --strict 2>&1 | tail -3
+```
+
+Expected: "Documentation built in N seconds" with no warnings.
+
+Rationale: the PRD/ROADMAP live outside `docs/` so they are not picked
+up by MkDocs. The strict build must still pass — this confirms we
+did not accidentally introduce a broken reference.
+
+- [ ] **Step 3: Verify no in-repo references to the old PRD paths**
+
+Run: `grep -rln "Product Requirements Document.md\|PRD v2 - Roadmap" . --exclude-dir=.git --exclude-dir=.venv-docs --exclude-dir=archive --exclude-dir=node_modules`
+Expected: matches only in spec + plan files (`docs/superpowers/`).
+
+Rationale: if any doc (README, contributing, etc.) still points at the
+old paths, it breaks after the archive move. This grep surfaces them.
+
+- [ ] **Step 4: Git log sanity check**
+
+```bash
+git log --oneline dev..HEAD
+```
+
+Expected (in order): Phase 1 commit, Phase 2 commit, Phase 3 commit.
+Three logical commits total.
+
+---
+
+## Phase 5 — PR #1 (chore/prd-consolidation → dev)
+
+### Task 5: Push branch and open PR
+
+**Files:**
+- (Remote actions only)
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin chore/prd-consolidation
+```
+
+Expected: push succeeds, branch exists on GitHub.
+
+- [ ] **Step 2: Open PR with detailed body**
+
+```bash
+gh pr create \
+  --base dev \
+  --head chore/prd-consolidation \
+  --title "docs: consolidate legacy PRDs into canonical PRD.md + ROADMAP.md" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Replaces the two Dutch legacy PRDs in \`project-requirement-document/\`
+with a canonical English product charter (\`PRD.md\`) and a living
+forward-looking roadmap (\`ROADMAP.md\`). Originals are preserved under
+\`archive/\` via \`git mv\` (history retained).
+
+### What changed
+
+- **New:** \`project-requirement-document/PRD.md\` — ~500-line charter-
+  style PRD; ADR-based decision log; references docs site for detail
+- **New:** \`project-requirement-document/ROADMAP.md\` — Now/Next/Later/
+  Deferred/Rejected taxonomy; 3 committed Next items, 7 Later items,
+  explicit Rejected list preserving rationale
+- **New:** \`project-requirement-document/archive/README.md\` explaining
+  why the legacy PRDs remain visible but non-authoritative
+- **Moved:** \`Product Requirements Document.md\` →
+  \`archive/2026-01-17-prd-v1-mvp.md\`
+- **Moved:** \`PRD v2 - Roadmap & Next Phases.md\` →
+  \`archive/2026-03-09-prd-v2-roadmap.md\`
+
+### Why
+
+Both legacy PRDs described planned work that has now shipped as v1.0.0.
+A new reader could not distinguish planned from shipped content. The
+canonical PRD describes the product as-built; the roadmap describes what
+comes next. Archival preserves the original reasoning (useful for
+audit provenance and contributor onboarding).
+
+### Test plan
+
+- [x] \`mkdocs build --strict\` clean (PRD and ROADMAP live outside the
+      docs site, so no site impact)
+- [x] \`ruff check\` clean (no Python changes)
+- [x] \`grep\` for old filenames clean (no lingering references)
+- [ ] CI green (lint, unit-tests, integration v4.4 + v4.5)
+- [ ] Gemini code review addressed
+
+### Spec artefacts
+
+- Design: \`docs/superpowers/specs/2026-04-17-prd-consolidation-design.md\`
+- Plan: \`docs/superpowers/plans/2026-04-17-prd-consolidation-implementation.md\`
+
+### Post-merge actions
+
+1. Merge this PR to \`dev\` with \`--admin --squash\` after CI + Gemini
+2. Open PR \`dev → main\`, admin-merge after CI
+3. **No tag, no PyPI publish** — documentation-only change; the next
+   plugin release will pick these up from main naturally
+EOF
+)"
+```
+
+Expected: outputs the PR URL. Save it for subsequent steps.
+
+### Task 6: Monitor CI on PR #1
+
+- [ ] **Step 1: Watch CI to completion**
+
+```bash
+gh pr checks <N> --watch --interval 30
+```
+
+Expected: all 10 checks pass (lint, unit-tests 3.10/3.11/3.12, package-
+check, build, integration v4.4 + v4.5, Playwright E2E, strict mkdocs).
+
+### Task 7: Address Gemini code review
+
+- [ ] **Step 1: Read the Gemini review**
+
+```bash
+gh pr view <N> --json reviews | jq -r '.reviews[] | select(.author.login == "gemini-code-assist") | .body'
+gh api repos/ctrl-alt-automate/netbox-ssl/pulls/<N>/comments | jq -r '.[] | {path, line, body: .body[:300]}'
+```
+
+- [ ] **Step 2: Classify findings**
+
+- *Serious* (fix before merge): factual error, contradiction with shipped
+  behaviour, broken link, mis-attributed ADR
+- *Minor* (fix if cheap; otherwise note in PR comment): phrasing,
+  structural suggestion, stylistic preference
+
+- [ ] **Step 3: Apply fixes if any**
+
+For each serious finding:
+
+```bash
+# make the fix
+git add project-requirement-document/...
+git commit -m "fix: <gemini-finding-summary> (gemini review)"
+git push
+```
+
+- [ ] **Step 4: Reply to review**
+
+```bash
+gh pr comment <N> --body "Thanks for the review. Addressed serious findings in <commit-shas>."
+```
+
+### Task 8: Admin-merge PR #1
+
+- [ ] **Step 1: Final verification**
+
+```bash
+gh pr checks <N>           # expect all green
+gh pr view <N> --json reviews  # expect Gemini COMMENTED
+```
+
+- [ ] **Step 2: Admin-merge with squash**
+
+```bash
+gh pr merge <N> --admin --squash --delete-branch
+```
+
+Expected: PR merged, branch deleted, CI on `dev` triggered.
+
+- [ ] **Step 3: Sync local dev**
+
+```bash
+git checkout dev
+git pull
+```
+
+---
+
+## Phase 6 — PR #2 (dev → main)
+
+### Task 9: Open PR #2
+
+- [ ] **Step 1: Create PR**
+
+```bash
+gh pr create \
+  --base main \
+  --head dev \
+  --title "docs: PRD consolidation for post-v1.0" \
+  --body "$(cat <<'EOF'
+Promotes the PRD consolidation (PR #<prev-N>) from \`dev\` to \`main\`.
+
+Documentation-only change. No code, no migrations, no release bump. The
+next plugin release will pick these up automatically.
+
+### What's in this promotion
+
+- Canonical \`PRD.md\` replacing the two legacy Dutch PRDs
+- Forward-looking \`ROADMAP.md\`
+- Archived originals under \`project-requirement-document/archive/\`
+EOF
+)"
+```
+
+### Task 10: Monitor + admin-merge PR #2
+
+- [ ] **Step 1: Watch CI**
+
+```bash
+gh pr checks <N> --watch --interval 30
+```
+
+- [ ] **Step 2: Admin-merge**
+
+```bash
+gh pr merge <N> --admin --merge
+```
+
+Use `--merge` (not `--squash`) for dev→main so individual logical
+commits stay visible on `main`'s history.
+
+- [ ] **Step 3: Sync local main**
+
+```bash
+git checkout main
+git pull
+```
+
+---
+
+## Phase 7 — Post-merge
+
+### Task 11: Update MEMORY.md
+
+**Files:**
+- Modify: `~/.claude/projects/<encoded-project-path>/memory/MEMORY.md`
+  (the Claude Code auto-memory file for this project; its exact path is
+  environment-dependent)
+
+- [ ] **Step 1: Append PRD consolidation entry under Release History (or
+    add a new "Documentation Milestones" section if the user prefers)**
+
+Add entry:
+
+```markdown
+- 2026-04-17 — PRD consolidation: legacy v1.1 + v2.0 PRDs archived,
+  canonical English PRD.md + forward-looking ROADMAP.md added under
+  project-requirement-document/. No code changes; no release bump.
+```
+
+### Task 12: Final report
+
+- [ ] **Step 1: Assemble status summary**
+
+Include:
+
+- Commit SHA on main
+- PR URLs (PR #1, PR #2)
+- Files added / renamed / removed
+- Confirmation that no tag or PyPI publish was performed
+
+- [ ] **Step 2: Report to user**
+
+Short summary: "PRD consolidation landed. New canonical PRD.md and
+ROADMAP.md live in project-requirement-document/; legacy PRDs in
+archive/. No code changes, no release."
+
+---
+
+## Self-review checklist
+
+- [x] **Spec coverage** — every section of the design spec maps to at
+      least one task:
+    - §1 (Problem) / §2 (Goals) / §3 (Deliverables) → covered by task
+      structure overall
+    - §4 (PRD.md ToC) → Task 2, steps 1–11
+    - §5 (ROADMAP.md ToC) → Task 3, steps 1–10
+    - §6 (Archival approach) → Task 1
+    - §7 (Maintenance and governance) → included as §10 of PRD + §2 of
+      roadmap reading guide
+    - §8 (Execution flow) → Phases 5–7
+    - §9 (Out-of-band notes) → reflected in task commits and PR body
+- [x] **Placeholder scan** — no "TBD/TODO/XXX" in plan prose. The
+      "Reference issue. To be filed." in ROADMAP §4 is intentional and
+      described as acceptable in the verification task.
+- [x] **Type consistency** — filenames, section numbers, and paths match
+      across tasks.
+- [x] **TDD** — docs-only work; verification is `mkdocs build --strict`
+      and a grep sweep. No test-first flow is needed.
+- [x] **Commit cadence** — one commit per phase (three total) plus any
+      Gemini-fix commits; small and reviewable.
+- [x] **Irreversibility** — no tag, no PyPI publish. Rollback is `git
+      revert` on a documentation commit, cost near zero.

--- a/docs/superpowers/specs/2026-04-17-prd-consolidation-design.md
+++ b/docs/superpowers/specs/2026-04-17-prd-consolidation-design.md
@@ -1,0 +1,394 @@
+# PRD Consolidation — Design Spec
+
+**Date:** 2026-04-17
+**Author:** Elvis (via Claude Opus 4.7 brainstorm session)
+**Status:** Approved — ready for implementation
+**Context:** Post v1.0.0 GA release — consolidating legacy PRDs into an
+up-to-date canonical product charter + forward-looking roadmap.
+
+## 1. Problem
+
+`project-requirement-document/` holds two PRDs:
+
+- `Product Requirements Document.md` (2026-01-17, 206 lines) — MVP spec,
+  written pre-implementation
+- `PRD v2 - Roadmap & Next Phases.md` (2026-03-09, 485 lines) — roadmap
+  covering v0.6 → v1.0, written mid-implementation
+
+Both were written before v1.0.0 shipped (2026-04-16). Every feature in both
+documents is now implemented. The PRDs are technically out of date the
+moment the reader opens them: they describe future work that is already
+past work.
+
+Symptoms:
+
+- A newcomer reading the PRDs cannot tell what is planned vs. shipped
+- Architectural decisions (no private keys, replace-and-archive, passive
+  administration) are scattered across both documents
+- Post-v1.0 ideas live in a single section (PRD v2 §8) rather than a
+  first-class roadmap
+- Both documents are in Dutch while the rest of the repo (README, CHANGELOG,
+  docs site, commits) is in English
+
+## 2. Goals and non-goals
+
+### In scope
+
+- Consolidate the two PRDs into **one canonical product charter** (`PRD.md`)
+  that describes NetBox SSL v1.0 as-built — principles, scope, architectural
+  decisions, data model overview, core workflows, non-functional requirements
+- Extract forward-looking content into a **separate roadmap**
+  (`ROADMAP.md`) using a Now / Next / Later / Deferred / Rejected taxonomy
+- **Archive** the two legacy PRDs under
+  `project-requirement-document/archive/` with a README explaining why they
+  remain visible but are no longer authoritative
+- Write in **English** to match repo conventions
+
+### Out of scope
+
+- Rewriting the documentation site (`docs/`) — the charter links to it,
+  does not duplicate it
+- Content changes to `README.md`, `CHANGELOG.md`, `COMPATIBILITY.md`
+- Plugin code changes
+- Publishing the PRD/roadmap on PyPI or the docs site (stays as repo files)
+- Non-English translations (may follow later as `PRD.nl.md` if needed)
+
+## 3. Deliverables
+
+```
+project-requirement-document/
+├── PRD.md                              # NEW — Product Charter (~350-500 lines)
+├── ROADMAP.md                          # NEW — Post-v1.0 roadmap (~200-300 lines)
+├── archive/                            # NEW — historical source documents
+│   ├── README.md                       # why this folder exists
+│   ├── 2026-01-17-prd-v1-mvp.md       # renamed: "Product Requirements Document.md"
+│   └── 2026-03-09-prd-v2-roadmap.md   # renamed: "PRD v2 - Roadmap & Next Phases.md"
+```
+
+## 4. `PRD.md` — Product Charter structure
+
+Charter-style: compact, referential, authoritative on "why" rather than
+"how". Implementation details live in the docs site
+(`docs/reference/`, `docs/explanation/`). The PRD references, never
+duplicates.
+
+### Table of contents
+
+1. **Metadata**
+   - Version / status / maintainer / last-updated
+   - Relationship to legacy PRDs (link to `archive/`)
+
+2. **Executive Summary** (~200 words)
+   - What NetBox SSL is in one paragraph
+   - Target audience
+   - What distinguishes it from alternatives
+
+3. **Product Vision & Design Principles**
+   - 3.1 Passive Administration
+   - 3.2 No Private Keys, Ever
+   - 3.3 Audit Trail Is Sacred
+   - 3.4 NetBox-Native (no standalone UI or database)
+   - 3.5 Community-First
+
+4. **Scope**
+   - 4.1 In Scope (feature table)
+   - 4.2 Out of Scope (feature table with rationale)
+   - 4.3 Explicit Non-Goals (ACME client, CT monitoring, device push, …)
+
+5. **Architectural Decisions (ADR log)**
+   - 5.1 ADR-01: Passive over Active
+   - 5.2 ADR-02: No Private Key Storage
+   - 5.3 ADR-03: Replace & Archive (Janus Workflow)
+   - 5.4 ADR-04: Chain as Metadata, Not Entities
+   - 5.5 ADR-05: GenericForeignKey for Assignments
+   - 5.6 ADR-06: External Sources as Read-Only Sync
+   - 5.7 ADR-07: Versioned Docs via MkDocs Material + mike
+   - Each ADR: ~40–80 lines. Format: *Context* / *Decision* /
+     *Consequences* / *Alternatives considered* / *Status*
+
+6. **Data Model Overview**
+   - 6.1 Core entities (Certificate, CertificateAssignment,
+     CertificateAuthority, ExternalSource, CertificateLifecycleEvent, …)
+   - 6.2 Relationship diagram (compact Mermaid) or explicit link to
+     `docs/explanation/architecture.md`
+   - 6.3 Field-level details → link to `docs/reference/data-models.md`
+
+7. **Core Workflows**
+   - 7.1 Smart Paste Import (summary, link to tutorial 01)
+   - 7.2 Janus Renewal (summary, link to tutorial 02)
+   - 7.3 Expiry Monitoring (summary, link to tutorial 03)
+   - 7.4 External Source Sync (summary, link to how-to)
+   - 7.5 Bulk Operations (summary, link to how-to)
+
+8. **Non-Functional Requirements**
+   - 8.1 Security (private-key rejection, SSRF guards, permission model,
+     CSV injection prevention)
+   - 8.2 Performance (target SLOs, indexes, lazy loading)
+   - 8.3 Compatibility (NetBox N / N-1, Python 3.10–3.12)
+   - 8.4 Observability (events, webhooks, logging)
+   - 8.5 Deployability (pip install; no external services required)
+
+9. **Success Metrics**
+   - 9.1 Adoption (PyPI downloads, GitHub stars)
+   - 9.2 Quality (test coverage, security findings, CVE count)
+   - 9.3 Release cadence (semver adherence, time-to-patch)
+   - 9.4 Community (contributors, issue turnaround)
+
+10. **Document Governance**
+    - How and when this PRD is updated
+    - Change log of the PRD itself
+    - Relationship to `ROADMAP.md`
+
+### Content NOT in the PRD (lives in docs)
+
+- Step-by-step installation / configuration → `docs/operations/`
+- API endpoint reference → `docs/reference/api.md`
+- Field-level schema → `docs/reference/data-models.md`
+- Contributor patterns → `docs/development/contributing.md`
+
+### Why the ADR section is central
+
+The legacy PRDs scattered architectural decisions across prose in v1 and
+inline decisions in v2 roadmap sections. Grouping them as discrete ADRs
+makes the PRD a referenceable document ("see ADR-03") rather than a
+narrative. ADR-style sections are also easier to audit and to extend as
+new decisions land.
+
+## 5. `ROADMAP.md` — Forward-looking structure
+
+Living document, updated more often than `PRD.md`. Format oriented towards
+maintainer-level upkeep — no hard dates, explicit status taxonomy.
+
+### Table of contents
+
+1. **Metadata**
+   - Status: Living document
+   - Last-reviewed date
+   - Approval / update process
+
+2. **How to Read This Roadmap**
+   - Disclaimer: no hard dates
+   - Status taxonomy (Now / Next / Later / Deferred / Rejected)
+   - Relationship to GitHub Milestones
+
+3. **Now — In Active Development**
+   - Items with an open issue and assigned milestone
+   - Empty at v1.0.0 ship (or contains small v1.0.x polish items)
+
+4. **Next — Committed, Scoped, Not Yet Started**
+   - v1.1 candidates, each with goal / scope boundaries / reference issue
+
+5. **Later — Under Consideration**
+   - Ideas from legacy PRD v2 §8
+   - Community-suggested features tagged "maybe"
+   - Not locked in — can be promoted to Next or rejected
+
+6. **Deferred — Considered, Not Pursued For Now**
+   - Explicitly rejected for v1.x, may revisit for v2.0
+   - E.g., multi-instance sync (complexity)
+
+7. **Rejected — Actively Not Building**
+   - Permanently out-of-scope with rationale
+   - E.g., active ACME client (violates passive administration)
+   - E.g., private key storage (violates no-honeypot principle)
+
+8. **Planned Breaking Changes (v2.0+)**
+   - `add_certificate` permission fallback removal (deprecated v1.0)
+   - Future deprecations
+   - Timeline expressed in releases, not dates
+
+9. **Community Input**
+   - How to propose a feature (GitHub issue link)
+   - Feature request justification template
+   - Historical track record (proposals → accepted / deferred)
+
+10. **Post-v2.0 Horizon**
+    - Big directional bets, still vague
+    - Not for commitment, only for visibility
+
+### Populated state at v1.0.0 ship
+
+| Section | Initial contents |
+|---------|------------------|
+| Now | Empty (v1.0.0 just shipped) |
+| Next | DigiCert adapter, Vault integration, performance scaling |
+| Later | 6 items from legacy PRD v2 §8 + community wishes |
+| Deferred | Historical "never built" items (multi-instance sync) |
+| Rejected | Fundamental no-goes (active ACME deployment, key storage) |
+| Breaking Changes | `add_certificate` fallback removal in v2.0 |
+
+### Why Now / Next / Later instead of release-based
+
+- **Honest** — as a solo/small team you miss release dates. "v1.1 in Q3"
+  becomes a stale promise; "Next" stays true
+- **Easy to update** — items move between columns as priorities shift
+- **No reputational damage** — deferring a Later item does not feel like
+  slippage; un-shipping a "v1.1 feature" does
+- **Matches GitHub Milestones** — Now = assigned milestone, Next = backlog
+  with label, Later = open but no milestone
+
+The explicit **Rejected** section is especially important: it prevents the
+recurring "have you considered X?" conversation by making the reasoning
+visible up front, while still inviting rebuttal ("convince us this is
+different now").
+
+## 6. Archival approach
+
+### Steps
+
+```bash
+mkdir -p project-requirement-document/archive/
+
+git mv "project-requirement-document/Product Requirements Document.md" \
+       "project-requirement-document/archive/2026-01-17-prd-v1-mvp.md"
+
+git mv "project-requirement-document/PRD v2 - Roadmap & Next Phases.md" \
+       "project-requirement-document/archive/2026-03-09-prd-v2-roadmap.md"
+
+# Then write archive/README.md
+```
+
+### `archive/README.md` content (~40 lines)
+
+```markdown
+# Archived Product Requirements Documents
+
+This folder holds historical PRDs preserved for provenance. **They are out
+of date.** For current specification, see:
+
+- [PRD.md](../PRD.md) — canonical product charter
+- [ROADMAP.md](../ROADMAP.md) — forward-looking plans
+
+## Index
+
+| File | Date | Role | Status at write time |
+|------|------|------|----------------------|
+| [2026-01-17-prd-v1-mvp.md](2026-01-17-prd-v1-mvp.md) | 2026-01-17 | MVP scope spec | Pre-implementation (v0.x) |
+| [2026-03-09-prd-v2-roadmap.md](2026-03-09-prd-v2-roadmap.md) | 2026-03-09 | Roadmap v0.6 → v1.0 | Mid-implementation |
+
+## Why archive, not delete?
+
+- **Rationale preservation** — architectural decisions are first
+  articulated here; the current PRD references them
+- **Historical provenance** — audit questions about decision origin can be
+  answered from this folder
+- **Honest evolution** — shows how thinking developed; useful for
+  contributors learning "why the product looks the way it does"
+
+## Should I read these?
+
+No, unless you need a historical perspective. Current-product content
+lives in `PRD.md` or the
+[documentation site](https://ctrl-alt-automate.github.io/netbox-ssl/).
+```
+
+### Naming rationale
+
+- **Folder `archive/`** supplies the "these are old" context, removing the
+  need for `_ARCHIVED` suffixes on filenames
+- **`YYYY-MM-DD-<slug>.md`** makes chronological order explicit in
+  directory listings
+- **Keeping them in repo** (not moved to a branch/external location) means
+  `ls` shows them to anyone exploring the folder
+
+## 7. Maintenance and governance
+
+### `PRD.md`
+
+| Trigger | Action | Owner |
+|---------|--------|-------|
+| New minor release (v1.1, v1.2, …) | Review PRD: new ADRs? scope change? | Maintainer |
+| New major release (v2.0, …) | Full review + version bump in metadata | Maintainer |
+| Breaking architectural decision | Add new ADR + CHANGELOG entry | Author of the change |
+| Docs site restructure | Update links in §6 and §7 | Maintainer |
+
+- **Version field** in `PRD.md` metadata tracks plugin version
+  (`PRD applies to: v1.0.x`)
+- **No separate PRD semver** — single source of truth is plugin version
+- **"Last updated" date** in metadata, manually updated with each change
+- **Document changelog** (ToC §10) lists PRD revisions:
+  `2026-04-17: Initial consolidation from v1 + v2 PRDs`
+
+### `ROADMAP.md`
+
+| Trigger | Action | Owner |
+|---------|--------|-------|
+| Start of a release cycle | Move items Later → Next | Maintainer |
+| Item merged as feature | Remove from Now, log in CHANGELOG | Maintainer |
+| Community feature request | Triage → Now / Next / Later / Deferred / Rejected | Maintainer |
+| Annual review (every April) | Prune stale Later / Deferred items | Maintainer |
+
+- **No dates promised** — only "Now = in current release cycle"
+- **Each section sorted by priority**, highest urgency first
+- **Issue links mandatory** for items in Now (no tracking otherwise)
+
+### Future design-level brainstorms
+
+- Individual design specs continue to live in `docs/superpowers/specs/`
+  (the default brainstorming output location)
+- Large new features: spec in `docs/superpowers/specs/` →
+  summary entry in `ROADMAP.md` → after ship: ADR in `PRD.md` and
+  feature doc in `docs/`
+- A hypothetical "PRD v3" is only warranted by a fundamental re-scope
+  (major rewrite, rename, pivot). In that case: archive current `PRD.md`
+  under `archive/` and write a new `PRD.md`
+
+### Document relationship
+
+```
+PRD.md (stable)           → why + principles + ADRs
+ROADMAP.md (living)       → what comes next
+CHANGELOG.md (append)     → what has shipped
+docs/ (MkDocs site)       → how to use it
+docs/superpowers/specs/   → brainstorm artefacts
+```
+
+Each layer has one purpose; overlap is the exception, not the rule.
+
+## 8. Execution flow
+
+### Phase A — Local work (autonomous)
+
+1. Create feature branch `chore/prd-consolidation` from `dev`
+2. Archive legacy PRDs via `git mv` + write `archive/README.md`
+3. Write `PRD.md` following the ToC in §4
+4. Write `ROADMAP.md` following the ToC in §5
+5. Commit logically (e.g., one commit per deliverable)
+
+### Phase B — PR to dev
+
+1. Push branch, open PR against `dev`
+2. Wait for CI green + Gemini review
+3. Address findings, admin-merge with `--squash`
+
+### Phase C — PR to main
+
+1. Open PR `dev → main`
+2. Wait for CI + Gemini
+3. Admin-merge with `--merge`
+
+No tag or PyPI publish — PRD/roadmap changes do not warrant a release
+bump. The next release that touches plugin code will include these docs
+by virtue of `main` being the release source.
+
+### Phase D — Post-merge
+
+1. Delete the feature branch
+2. Record change in `MEMORY.md`: "v1.0 PRDs consolidated 2026-04-17"
+
+### Autonomy stop conditions
+
+- Gemini flags a policy conflict (e.g., principle stated in PRD
+  contradicts `docs/explanation/security-model.md`) — halt, surface
+- Content-filter strike (as seen during v1.0 build) — halt, split the
+  work into smaller chunks, continue
+
+## 9. Out-of-band notes
+
+- Target date: **2026-04-17** (today, same-session completion expected)
+- Language: **English** (repo convention)
+- The existing folder name `project-requirement-document/` is preserved
+  (singular, slightly awkward, but well-established; renaming adds churn
+  without value)
+- Total net additions: ~600–800 lines of markdown across four new files,
+  no line removals (archive preserves originals verbatim)

--- a/project-requirement-document/PRD.md
+++ b/project-requirement-document/PRD.md
@@ -1,0 +1,616 @@
+# NetBox SSL — Product Requirements Document
+
+**Project code:** JANUS
+**Applies to plugin version:** v1.0.x
+**Status:** Canonical — replaces legacy PRDs in `archive/`
+**Maintainer:** NetBox SSL team (see `CONTRIBUTING.md`)
+**Last updated:** 2026-04-17
+**Language:** English (Dutch originals preserved under `archive/`)
+
+> This document is the canonical product specification for NetBox SSL. It
+> describes the product as built at v1.0.0 GA, the design principles that
+> govern ongoing work, and the architectural decisions behind key trade-offs.
+>
+> For step-by-step usage and API reference, see the
+> [documentation site](https://ctrl-alt-automate.github.io/netbox-ssl/).
+> For forward-looking plans, see [ROADMAP.md](ROADMAP.md).
+
+---
+
+## 1. Metadata
+
+**Source of truth:** This document.
+
+**Predecessors (archived):**
+- [`archive/2026-01-17-prd-v1-mvp.md`](archive/2026-01-17-prd-v1-mvp.md) — v1.1 MVP spec
+- [`archive/2026-03-09-prd-v2-roadmap.md`](archive/2026-03-09-prd-v2-roadmap.md) — v2.0 roadmap
+
+**Revision cadence:** Reviewed per minor release; fully revisited per major release.
+
+---
+
+## 2. Executive Summary
+
+NetBox SSL is a plugin that turns [NetBox](https://github.com/netbox-community/netbox)
+into a single source of truth for TLS/SSL certificate inventory. It imports
+certificates from PEM, parses every X.509 attribute, links certificates to the
+services, devices, and virtual machines that present them, and surfaces
+expiry risk before it becomes outage risk.
+
+The product is aimed at infrastructure and security teams already running
+NetBox who want certificate visibility without adopting a separate PKI
+platform. It is useful for compliance evidence, renewal coordination, and
+blast-radius analysis when a CA is deprecated or compromised.
+
+What distinguishes NetBox SSL from alternatives: it is **passive by design**.
+It observes and documents; it does not issue, deploy, or rotate certificates.
+Private keys are never stored — only public metadata and operator-provided
+location hints (e.g., a Vault path). The plugin's value is visibility and
+audit trail, deliberately leaving issuance and deployment to the specialised
+tooling that already owns those responsibilities.
+
+---
+
+## 3. Product Vision & Design Principles
+
+### 3.1 Passive Administration
+
+**Principle:** NetBox SSL observes and documents the certificate landscape.
+It does not issue, deploy, rotate, or revoke certificates.
+
+**Why.** The plugin runs inside the NetBox process. Giving that process the
+permissions needed to *act* on certificates (SSH keys for deployment, CA API
+credentials, kubeconfig, secrets manager write access) would expand NetBox's
+blast radius far beyond its intended role as an inventory. Active tools have
+different failure modes — stuck renewals, partial deployments, production
+outages — and belong in dedicated platforms (Certbot, cert-manager, ACME
+clients) that have access control shaped for that work.
+
+**How it manifests.** The plugin has no outbound credentials for CAs or
+devices. The only outbound calls are HTTPS reads of certificate metadata
+(ACME Renewal Information, external inventory sources) under shared SSRF
+controls. Deployment remains the job of whatever already owned it.
+
+### 3.2 No Private Keys, Ever
+
+**Principle:** The database stores no private keys, encrypted or otherwise.
+Parser input containing any private-key header is rejected.
+
+**Why.** Storing private keys alongside certificate metadata concentrates
+secrets in a system that is not designed as a secrets manager. Every data
+field is accessible to superusers and, via `.restrict()`, to scoped users.
+Making NetBox a honeypot is a compliance, audit, and blast-radius problem
+with no upside for the plugin's core purpose.
+
+**How it manifests.** A `private_key_location` field stores an operator-
+provided hint (e.g., `vault://secret/tls/api.example.com`) pointing at the
+secrets manager that *does* own the key. The parser's rejection pattern is
+broad and deliberate: `-----BEGIN (RSA|EC|ED25519|...)? PRIVATE KEY-----`
+in any form refuses the whole input.
+
+### 3.3 Audit Trail Is Sacred
+
+**Principle:** Certificate history is append-only where possible. Renewals
+create new records; they never overwrite existing ones.
+
+**Why.** Operators, auditors, and incident responders need to answer
+questions like "what certificate was on the payment endpoint on 2024-06-15?"
+An in-place UPDATE of certificate attributes would erase that answer. The
+audit requirement is strong enough to justify the slightly higher storage
+cost of the replace-and-archive pattern.
+
+**How it manifests.** The Janus renewal workflow creates a new certificate
+record, copies every assignment, then marks the old certificate as
+`Replaced`. Both remain queryable forever. The `CertificateLifecycleEvent`
+table is append-only; status transitions are logged, not mutated.
+
+### 3.4 NetBox-Native
+
+**Principle:** The plugin reuses NetBox's authentication, permissions,
+changelog, tenancy, and UI conventions. It does not ship its own.
+
+**Why.** Operators already understand NetBox. Introducing a parallel
+permission system, a separate login, or a non-NetBox UI layer would turn
+an inventory plugin into a platform migration. Native integration keeps
+the cognitive load low and the surface area predictable.
+
+**How it manifests.** Every view inherits from NetBox base classes. Every
+queryset uses `.restrict(request.user, ...)`. Every model is scoped by
+tenant where relevant. Templates follow NetBox's Bootstrap layout. No
+standalone database; the plugin writes to NetBox's schema.
+
+### 3.5 Community-First
+
+**Principle:** The plugin is Apache 2.0 licensed, published on PyPI,
+documented publicly, and welcomes external contributions.
+
+**Why.** Certificate inventory is a pervasive but under-served problem
+across the NetBox community. A closed or poorly-documented implementation
+reinforces the status quo of spreadsheet-based tracking. The goal is a
+plugin broad enough to accept diverse operators' requirements without
+fragmenting into private forks.
+
+**How it manifests.** Contribution guide, code of conduct, security policy,
+issue templates, and PR template all live in the repository. Documentation
+is versioned and searchable at
+`https://ctrl-alt-automate.github.io/netbox-ssl/`. Every release appears
+on PyPI with a CHANGELOG entry.
+
+---
+
+## 4. Scope
+
+### 4.1 In Scope
+
+| Capability | Status |
+|------------|:------:|
+| Smart Paste Import (PEM with private-key rejection) | ✓ v0.1 |
+| Multi-target Assignments (Service, Device, VM via GenericForeignKey) | ✓ v0.2 |
+| Janus Renewal Workflow (replace & archive, atomic) | ✓ v0.2 |
+| Dashboard expiry widget + analytics dashboard | ✓ v0.5, v0.7 |
+| Certificate Authority auto-detection | ✓ v0.4 |
+| Chain validation (capped depth) | ✓ v0.5 |
+| Compliance policies (tag-scoped from v0.9) | ✓ v0.5, v0.9 |
+| CSR tracking | ✓ v0.4 |
+| ACME certificate monitoring (15+ providers) | ✓ v0.5 |
+| Bulk CSV/JSON/PEM import + bulk operations | ✓ v0.5, v0.8 |
+| Multi-format export (CSV, JSON, YAML, PEM) | ✓ v0.5 |
+| REST API (15+ actions) + GraphQL | ✓ v0.5 |
+| Event/webhook integration via NetBox Event Rules | ✓ v0.6 |
+| Scheduled expiry scan (idempotent) | ✓ v0.6 |
+| Compliance trend charts + export | ✓ v0.7 |
+| Certificate topology map | ✓ v0.7 |
+| Lifecycle tracking (state transitions + timeline) | ✓ v0.8 |
+| Auto-archive of expired certificates | ✓ v0.8 |
+| External Source sync (Lemur, Generic REST) | ✓ v0.8 |
+| Granular custom permissions | ✓ v0.9 |
+| Performance indexes + lazy PEM loading | ✓ v0.9 |
+| DER + PKCS#7 import, diff API, scheduled export | ✓ v0.9 |
+| Custom fields + tag-based filtering | ✓ v0.9 |
+| ARI monitoring (RFC 9773) | ✓ v0.9 |
+| Versioned MkDocs Material documentation site | ✓ v1.0 |
+| Load testing suite (Locust) | ✓ v1.0 |
+
+### 4.2 Out of Scope
+
+| Capability | Why out of scope |
+|------------|------------------|
+| Active deployment of keys to servers | Would require SSH/device credentials — violates passive administration |
+| Storage of private keys | Creates a honeypot; private key storage belongs in dedicated secrets managers |
+| Full PKI management (issuance, CA operations) | Specialised tools exist; NetBox's strength is documentation |
+| Active network scanning | Requires outbound credentials and a different trust model |
+| CA API integrations (Let's Encrypt client, DigiCert issuance) | Belongs in ACME clients and certificate managers — we sync from them read-only instead |
+
+### 4.3 Explicit Non-Goals
+
+- **Never an ACME client.** Certbot and acme.sh already own that role; the plugin syncs the resulting certificates read-only via the External Source framework.
+- **Never broker CA issuance.** Operators talk directly to their CA; the plugin records the outcome.
+- **Never push TLS config to load balancers or appliances.** Deployment belongs in Ansible, Terraform, Salt, Kubernetes, and the like.
+- **Never decrypt TLS traffic.** The plugin never handles live traffic, only metadata.
+- **Never run outbound scans for discovery.** Passive ingestion from an existing scanner's output is the correct pattern.
+- **Never store credentials for external systems as plaintext.** All external-source credentials use the `env:VAR_NAME` reference pattern, enforced in code.
+
+---
+
+## 5. Architectural Decision Records
+
+Architectural Decision Records (ADRs) capture the *why* behind design
+choices. Each ADR states the context, the decision, the consequences that
+follow, and the alternatives that were considered and rejected.
+
+### 5.1 ADR-01: Passive over Active
+
+**Status:** Accepted 2026-01-17. Reaffirmed at v1.0 GA (2026-04-16).
+
+**Context.** Certificate management has two camps: inventory tools
+(observe, document, alert) and deployment tools (issue, push, rotate).
+Combining both in a single plugin would require elevated credentials,
+complex failure-mode handling, and a much larger blast radius if
+compromised.
+
+**Decision.** NetBox SSL is strictly passive. It observes and documents.
+It does not issue, push, rotate, or revoke certificates. Active behaviour
+is explicitly rejected.
+
+**Consequences.** The plugin has a minimal credential footprint (read-only
+outbound HTTPS for ARI and external sources). Integrations with ACME
+clients, cert-manager, CA APIs, and deployment tools are one-way (pull
+metadata in, never push out). Operators retain their existing deployment
+workflows unchanged.
+
+**Alternatives considered.**
+- *Active ACME client.* Rejected — specialised tooling already exists
+  and operators are already comfortable with it.
+- *Certificate push to devices.* Rejected — expands the trust boundary
+  to SSH, kubeconfig, device APIs, all of which are owned by different
+  tools with different access models.
+- *Dual-mode (passive by default, active opt-in).* Rejected — the
+  opt-in path would still require us to build the active path, and the
+  security story becomes conditional.
+
+### 5.2 ADR-02: No Private Key Storage
+
+**Status:** Accepted 2026-01-17. Reaffirmed at v1.0 GA (2026-04-16).
+
+**Context.** Early design raised the option of storing encrypted private
+keys alongside certificate metadata, so that the plugin could offer
+"complete asset management". Every field stored in NetBox is accessible
+to superusers and, via `.restrict()`, to scoped users. Private keys would
+make the NetBox database a concentration of secrets.
+
+**Decision.** The database stores no private keys, encrypted or otherwise.
+The parser actively rejects input containing any private-key header.
+A free-text `private_key_location` field holds an operator-provided hint
+pointing at the secrets manager that *does* own the key.
+
+**Consequences.** The NetBox database cannot be used to decrypt traffic,
+impersonate endpoints, or forge certificates. The plugin avoids an entire
+class of compliance obligations around key management. Operators must run
+a separate secrets manager — which they typically already do.
+
+**Alternatives considered.**
+- *Encrypted key storage with per-tenant keys.* Rejected — moves the
+  secret one level, does not remove it.
+- *Write-only API for private keys.* Rejected — still a honeypot from
+  the perspective of anyone who compromises the NetBox host.
+- *Optional per-install toggle.* Rejected — makes the security story
+  conditional and undermines the "never a honeypot" guarantee.
+
+### 5.3 ADR-03: Replace & Archive (Janus Workflow)
+
+**Status:** Accepted 2026-01-17.
+
+**Context.** When an operator renews a certificate, two data models are
+possible: update the existing record with the new attributes, or create
+a new record and archive the old one.
+
+**Decision.** Renewal creates a new `Certificate` record, copies every
+`CertificateAssignment` to the new record, and marks the old certificate
+as `Replaced`. Both live in the database forever; the relationship is
+captured by `CertificateLifecycleEvent` entries linking old and new.
+
+**Consequences.** Certificate history is complete: operators can answer
+"what certificate was on endpoint X on date Y?" without archaeology.
+Rollback is first-class — if the new certificate is bad, flip the old
+one back to `Active` and re-point assignments. Storage cost grows
+linearly with renewal count; at typical inventory sizes (hundreds to
+low thousands) this is negligible, and the v0.8 auto-archive policy
+lets operators prune very old records when desired.
+
+**Alternatives considered.**
+- *In-place UPDATE.* Rejected — destroys audit trail; rollback becomes
+  archaeology from the changelog.
+- *Soft-delete with a flag.* Rejected — does not solve the renewal
+  chain problem; the new and old certificates still need distinct
+  identities.
+
+### 5.4 ADR-04: Chain as Metadata, Not Entities
+
+**Status:** Accepted 2026-01-17.
+
+**Context.** Certificates have intermediate and root CAs. One option is
+to model each CA as a first-class database object; another is to store
+the chain as metadata on the leaf certificate.
+
+**Decision.** The chain is stored as plain metadata (JSON/text) on the
+leaf certificate. Intermediate CAs are not first-class entities, though
+a `CertificateAuthority` model exists for *issuing* CAs that the operator
+wants to track explicitly.
+
+**Consequences.** Imports stay simple — no recursive parent-lookup. The
+database is not polluted with certificates the operator doesn't manage.
+Search and filter still work ("show me all certificates from DigiCert
+G2") because issuer strings are indexed. The downside: no graph view of
+intermediate CA relationships. Acceptable at the current scope.
+
+**Alternatives considered.**
+- *Full PKI hierarchy as entities.* Rejected — recursive lookups on
+  every import, database growth driven by non-operator certificates,
+  complexity without proportional value.
+- *No chain storage at all.* Rejected — operators often need chain
+  validation results, which require the chain to be present.
+
+### 5.5 ADR-05: GenericForeignKey for Assignments
+
+**Status:** Accepted 2026-01-17.
+
+**Context.** A certificate can be assigned to a Service, a Device, or a
+Virtual Machine. Modelling this as three parallel M2M tables would
+duplicate logic and make "show all assignments for certificate X" harder.
+
+**Decision.** `CertificateAssignment` uses a `GenericForeignKey` so one
+table can point at any of the three target types. The recommended
+assignment target is `Service` (port-level granularity), because a
+Device-only assignment cannot distinguish between certificates on
+different ports.
+
+**Consequences.** One table, one query for "all assignments of
+certificate X". Reverse lookups ("what certificates are on this device?")
+work through NetBox's `GenericRelation`. The trade-off: ordering by
+`assigned_object` needs `orderable=False` in django-tables2 because
+`GenericForeignKey` has no reverse relation that django-tables2 can
+use for SQL ORDER BY. Documented workaround.
+
+**Alternatives considered.**
+- *Three parallel M2M tables (cert↔service, cert↔device, cert↔vm).*
+  Rejected — three times the schema, three times the views, three
+  times the filter logic.
+- *Single target-ID column with a type enum.* Rejected — loses Django's
+  integrity checks; we'd hand-roll them.
+
+### 5.6 ADR-06: External Sources as Read-Only Sync
+
+**Status:** Accepted 2026-03-09 (introduced in v0.8).
+
+**Context.** Many organisations already run certificate managers (Lemur,
+DigiCert CertCentral, Venafi). Manual re-entry of every certificate into
+NetBox SSL would make the plugin dead weight; an active two-way sync
+would violate passive administration.
+
+**Decision.** The External Source framework provides **read-only**
+ingestion from external systems. Adapters fetch certificate metadata,
+never private keys (enforced in code), under shared SSRF controls. Sync
+runs in four phases (FETCH → DIFF → APPLY → LOG) inside a single
+transaction.
+
+**Consequences.** Operators can keep their existing issuance workflow
+and still get NetBox SSL inventory. The upstream system remains the
+authority for the certificate; the plugin is the authority for
+assignments and context within NetBox. If the upstream is removed,
+NetBox SSL does *not* auto-delete — it flags the record with
+`source_removed` for operator review.
+
+**Alternatives considered.**
+- *Two-way sync.* Rejected — conflict resolution, write credentials
+  upstream, and violation of passive administration.
+- *Manual CSV re-export.* Rejected — operator-hostile, doesn't scale.
+- *No sync, Smart Paste only.* Rejected — limits the plugin's
+  usefulness in existing deployments.
+
+### 5.7 ADR-07: Versioned Documentation Site
+
+**Status:** Accepted 2026-04-16 (introduced at v1.0.0 GA).
+
+**Context.** The plugin's documentation initially lived as flat Markdown
+in `docs/`. As the plugin matured toward GA, the community needed a
+searchable, navigable, versioned documentation site that could serve
+multiple plugin versions concurrently.
+
+**Decision.** Documentation uses [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)
+with [mike](https://github.com/jimporter/mike) for version management,
+deployed to GitHub Pages on every tagged release. Structure follows the
+[Diátaxis framework](https://diataxis.fr/) hybrid: Tutorials, How-To,
+Reference, Operations, Development, Explanation.
+
+**Consequences.** Documentation is searchable, dark-mode capable, and
+version-switching works from any page. Published at
+`https://ctrl-alt-automate.github.io/netbox-ssl/`. Build is enforced
+strict in CI (`mkdocs build --strict`) so broken links never ship.
+
+**Alternatives considered.**
+- *Read the Docs.* Rejected — GitHub Pages is already the deployment
+  target for CI artefacts and requires no external account.
+- *Flat Markdown in `docs/`.* Rejected at v1.0 — no search, no version
+  switching, no cross-linked navigation.
+- *Docusaurus or VitePress.* Rejected — MkDocs Material is the
+  standard in the Python documentation ecosystem; NetBox itself uses
+  MkDocs.
+
+---
+
+## 6. Data Model Overview
+
+### 6.1 Core Entities
+
+- **Certificate** — a unique X.509 certificate record; the library item that assignments and lifecycle events point at.
+- **CertificateAssignment** — links a Certificate to a target via `GenericForeignKey` (Service, Device, VirtualMachine).
+- **CertificateAuthority** — issuing CA record, with auto-detection from the issuer string.
+- **CertificateSigningRequest** — tracked CSR, optionally linked to the Certificate it produced.
+- **CertificateLifecycleEvent** — append-only log of status transitions, renewals, assignment changes.
+- **CertificateEventLog** — idempotency tracker for the expiry scan (prevents duplicate events within a cooldown window).
+- **CompliancePolicy** / **ComplianceResult** / **ComplianceTrendSnapshot** — per-policy checks, historical outcomes, and time-series trend data.
+- **ExternalSource** / **ExternalSourceSyncLog** — read-only sync configuration and per-run audit log for third-party certificate managers.
+
+### 6.2 Relationship Diagram
+
+```mermaid
+erDiagram
+    Certificate ||--o{ CertificateAssignment : has
+    Certificate ||--o{ CertificateLifecycleEvent : logs
+    CertificateAssignment }o--|| Service : assigned_to
+    CertificateAssignment }o--|| Device : assigned_to
+    CertificateAssignment }o--|| VirtualMachine : assigned_to
+    Certificate }o--o| CertificateAuthority : issued_by
+    Certificate }o--o| Tenant : tenant
+    ExternalSource ||--o{ ExternalSourceSyncLog : produces
+    ExternalSource ||--o{ Certificate : sources
+    Certificate ||--o{ CertificateEventLog : tracks_events
+    CompliancePolicy ||--o{ ComplianceResult : produces
+    Certificate ||--o{ ComplianceResult : evaluates
+```
+
+### 6.3 Field-Level Details
+
+Field definitions, choices, constraints, and indexes are documented in
+the [data models reference](https://ctrl-alt-automate.github.io/netbox-ssl/reference/data-models/)
+on the documentation site. This PRD does not duplicate that content.
+
+---
+
+## 7. Core Workflows
+
+### 7.1 Smart Paste Import
+
+Operator pastes raw PEM into a single text area. The backend rejects any
+input containing a private-key header, then uses the Python `cryptography`
+library to extract CN, SANs, validity window, issuer, fingerprint,
+algorithm, and key size. Duplicate detection is by `serial_number + issuer`.
+Parsed metadata is presented in a preview before the record is created.
+
+→ [Tutorial: Your First Certificate Import](https://ctrl-alt-automate.github.io/netbox-ssl/tutorials/01-first-import/)
+
+### 7.2 Janus Renewal
+
+When an imported PEM has the same Common Name as an existing `Active`
+certificate, the UI surfaces the Janus dialog. "Renew & Transfer" creates
+the new record, migrates every assignment to it, and marks the old record
+as `Replaced` — all inside one database transaction. Both records stay in
+the history.
+
+→ [Tutorial: Janus Renewal Workflow](https://ctrl-alt-automate.github.io/netbox-ssl/tutorials/02-renewal-workflow/)
+
+### 7.3 Expiry Monitoring
+
+A scheduled `CertificateExpiryScan` script computes `days_remaining` for
+every `Active` certificate. Certificates crossing a configured threshold
+fire a NetBox event, which Event Rules route to webhooks (Slack, Teams,
+PagerDuty). An idempotency log (`CertificateEventLog`) prevents duplicate
+alerts within a cooldown window.
+
+→ [Tutorial: Expiry Monitoring](https://ctrl-alt-automate.github.io/netbox-ssl/tutorials/03-expiry-monitoring/)
+
+### 7.4 External Source Sync
+
+Operators register an `ExternalSource` (e.g., Lemur, or a generic REST
+endpoint). A scheduled `ExternalSourceSync` script runs the adapter's
+four-phase sync: FETCH upstream metadata, DIFF against local state,
+APPLY changes inside a transaction, LOG the outcome. Credentials use the
+`env:VAR_NAME` pattern; private keys are never fetched.
+
+→ [How-to: External Sources](https://ctrl-alt-automate.github.io/netbox-ssl/how-to/external-sources/)
+
+### 7.5 Bulk Operations
+
+CSV, JSON, PEM, DER, and PKCS#7 bulk imports go through the bulk import
+page with a preview-before-confirm flow. Bulk status updates, bulk
+assignments, bulk compliance checks, and bulk chain validation all
+enforce per-operation custom permissions (introduced in v0.9) and are
+available via both UI and API.
+
+→ [How-to: Bulk Import](https://ctrl-alt-automate.github.io/netbox-ssl/how-to/bulk-import/)
+
+---
+
+## 8. Non-Functional Requirements
+
+### 8.1 Security
+
+Layered controls, each enforced independently:
+
+- **Private-key rejection** — parser refuses any input containing a private-key header (broad regex match across RSA, EC, Ed25519, and generic PRIVATE KEY forms).
+- **PEM size cap** — `max_length=65536` on form fields plus a size guard in the parser.
+- **SSRF guards** — shared `utils/url_validation.py` enforces HTTPS-only, DNS resolution to public IPs only, no redirect following, and streaming-response size caps on all outbound calls (ARI polling, external-source sync).
+- **Permission model** — all views inherit `LoginRequiredMixin`; all querysets use `.restrict(request.user, "view"/"change")`; all write actions check `has_perm()`; custom permissions (`import_certificate`, `renew_certificate`, `bulk_operations`, `manage_compliance`) enable granular RBAC.
+- **CSV injection prevention** — export sanitises formula-triggering characters in CSV values.
+- **Credential pattern** — external-source credentials reference `env:VAR_NAME` only; raw credentials are rejected by validation and never appear in API responses (serializer field is `write_only`).
+
+### 8.2 Performance
+
+Targets, validated by the Locust load-test suite documented in
+[operations/load-testing](https://ctrl-alt-automate.github.io/netbox-ssl/operations/load-testing/):
+
+- List endpoint p95 < 500 ms at 50 concurrent users
+- Filter endpoint p95 < 500 ms at 25 concurrent users
+- Import endpoint p95 < 500 ms at 10 concurrent users
+- Success rate ≥ 95% for all scenarios
+
+Implementation details: 9 database indexes on `Certificate` covering common filter combinations; conditional field deferral (heavy PEM content omitted on list views); connection pooling inherits from NetBox.
+
+### 8.3 Compatibility
+
+- **NetBox:** primary 4.5.x, supported 4.4.x (N and N-1 strategy). Earlier versions unsupported.
+- **Python:** 3.10, 3.11, 3.12 (all tested in CI).
+- **Platforms:** macOS and Linux for development; runs anywhere NetBox runs.
+- **Browser:** Chrome, Safari, Firefox desktop. Mobile best-effort.
+
+### 8.4 Observability
+
+- NetBox Event Rules pick up `certificate.imported`, `certificate.renewed`, `certificate.expired`, `certificate.expiring_soon`, `certificate.revoked`, and `certificate.ari_window_shift` events.
+- Every external-source sync writes an `ExternalSourceSyncLog` with run counts and duration.
+- The expiry scan writes `CertificateEventLog` entries for idempotency and audit.
+- Django-level logging is structured; no `print()` calls in production code paths.
+
+### 8.5 Deployability
+
+- Published on PyPI (`pip install netbox-ssl`).
+- No external services required beyond what NetBox itself needs (PostgreSQL, Redis).
+- Plugin settings fully in `PLUGINS_CONFIG`; no environment-variable requirements for the plugin to start.
+- Zero-downtime upgrade path for every release documented in
+  [operations/upgrading](https://ctrl-alt-automate.github.io/netbox-ssl/operations/upgrading/).
+
+---
+
+## 9. Success Metrics
+
+### 9.1 Adoption
+
+| Metric | Current (2026-04-17) | Target |
+|--------|----------------------|--------|
+| PyPI package published | ✓ v1.0.0 | — |
+| PyPI downloads per month | Track post-v1.0 | ≥ 500 within 12 months |
+| GitHub stars | Track | ≥ 50 within 12 months |
+| GitHub forks | Track | ≥ 10 within 12 months |
+
+### 9.2 Quality
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| Unit test coverage on `netbox_ssl/utils/` | 72% | ≥ 70% CI gate |
+| Integration tests in CI | NetBox 4.4 + 4.5 | — |
+| Bandit findings (high / medium) | 0 | 0 |
+| Known CVEs in declared dependencies | 0 | 0 |
+| Security review checklist | Living | Reviewed per minor release |
+
+### 9.3 Release Cadence
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| SemVer adherence | ✓ | — |
+| CHANGELOG entry per release | ✓ | — |
+| Time-to-patch a high-severity issue | Baseline at v1.0 | ≤ 14 days |
+
+### 9.4 Community
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| External contributors | Tracked | ≥ 3 within 12 months |
+| Median issue turnaround | Tracked | ≤ 5 business days |
+| `good-first-issue` labelled issues open | ✓ | Keep ≥ 3 available |
+
+---
+
+## 10. Document Governance
+
+### 10.1 Update Triggers
+
+| Trigger | Action |
+|---------|--------|
+| New minor release (v1.1, v1.2, …) | Review PRD: any ADR added? scope change? |
+| New major release (v2.0, …) | Full review + version bump in metadata |
+| New architectural decision | Add ADR to §5 + CHANGELOG entry |
+| Docs site restructure | Update links in §6 and §7 |
+
+### 10.2 Version Field Convention
+
+The "Applies to plugin version" field in the metadata block tracks the
+plugin version. No separate PRD semver — single source of truth is the
+plugin version. "Last updated" is maintained manually with each change.
+
+### 10.3 Relationship to Other Documents
+
+```
+PRD.md (stable)                 → why + principles + ADRs
+ROADMAP.md (living)             → what comes next
+CHANGELOG.md (append-only)      → what has shipped
+docs/ (MkDocs site)             → how to use it
+docs/superpowers/specs/         → brainstorm artefacts
+docs/superpowers/plans/         → implementation plans
+```
+
+Each layer has one purpose; overlap is the exception, not the rule.
+
+### 10.4 Document Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-04-17 | Initial consolidation from legacy PRDs v1.1 and v2.0 (now in `archive/`). Charter structure with ADR log. |

--- a/project-requirement-document/ROADMAP.md
+++ b/project-requirement-document/ROADMAP.md
@@ -1,0 +1,297 @@
+# NetBox SSL — Roadmap
+
+**Status:** Living document
+**Last reviewed:** 2026-04-17
+**Plugin version at publication:** v1.0.0
+**Owner:** NetBox SSL team (see `CONTRIBUTING.md`)
+
+> This roadmap sketches what *may* come after v1.0.0. It is deliberately
+> vague on timing: a solo or small-team project misses hard dates more
+> often than it hits them, and Now/Next/Later is an honest taxonomy.
+>
+> For current product specification, see [PRD.md](PRD.md). For shipped
+> work, see [CHANGELOG.md](../CHANGELOG.md).
+
+---
+
+## 1. Metadata
+
+**Governance:** Reviewed per release cycle; annually pruned of stale
+`Later` and `Deferred` items (every April).
+
+**Change log of this document:**
+
+| Date | Change |
+|------|--------|
+| 2026-04-17 | Initial roadmap post-v1.0 GA. |
+
+---
+
+## 2. How to Read This Roadmap
+
+No hard dates. Items live in one of five buckets:
+
+| Bucket | Meaning | Matches GitHub milestone? |
+|--------|---------|---------------------------|
+| **Now** | In active development | Open milestone |
+| **Next** | Committed, scoped, not yet started | Backlog with label |
+| **Later** | Under consideration | Open issue, no milestone |
+| **Deferred** | Considered, not pursued for now | Closed as "wontfix for v1.x" |
+| **Rejected** | Actively not building, with rationale | Closed with the reasoning preserved |
+
+Items move between buckets as priorities shift. A feature in Later may
+become Next (or Rejected), never "missed deadline" — only "different
+priority now".
+
+**Every Now item requires a reference issue.** Next and Later items
+should have reference issues when they become committed.
+
+---
+
+## 3. Now — In Active Development
+
+*Empty at v1.0.0 ship. Items appear here when an issue is assigned a
+milestone and work has started.*
+
+---
+
+## 4. Next — Committed, Scoped, Not Yet Started
+
+### 4.1 Vault Read-Only Integration
+
+**Goal.** Resolve `private_key_location` breadcrumbs against a HashiCorp
+Vault instance to confirm the key is where the operator says it is,
+without retrieving the key material itself.
+
+**Scope boundary.** The plugin performs only existence checks (e.g., a
+`LIST` or `HEAD` against the path). The plugin never reads key contents,
+even if Vault permissions would allow it — enforced in code, mirroring
+the PEM parser's private-key rejection.
+
+**Reference issue.** To be filed.
+
+### 4.2 DigiCert CertCentral Adapter
+
+**Goal.** Add a first-party External Source adapter for DigiCert
+CertCentral. Reads certificate metadata only, never private keys.
+
+**Scope boundary.** Same as the existing Lemur adapter: read-only,
+HTTPS-only, `env:VAR_NAME` credentials, no redirect following. The
+adapter joins the existing `GenericRESTAdapter` in the registry.
+
+**Reference issue.** To be filed.
+
+### 4.3 Performance Scaling Pass (> 10 000 Certificates)
+
+**Goal.** Validate and tune plugin behaviour at 10 000 and 50 000
+certificates. Profile slow queries, tune index usage, add benchmark
+assertions to CI.
+
+**Scope boundary.** No architectural changes — this is tuning, not
+redesign. If a redesign turns out to be needed, it gets promoted to a
+design spec and a separate plan.
+
+**Reference issue.** To be filed.
+
+---
+
+## 5. Later — Under Consideration
+
+### 5.1 Git-backed Audit Trail
+
+Export certificate state to a Git repository for version control outside
+NetBox. Aligns with the passive philosophy (read-only export, no active
+control).
+
+### 5.2 Certificate Transparency Log Monitoring
+
+Use Certificate Transparency logs to detect certificates issued for the
+organisation's domains outside the tracked inventory. Passive monitoring
+of public data — aligns with the principle.
+
+### 5.3 SLA Tracking
+
+Define SLAs per tenant or CA ("renewal must land within X days of
+warning"). Purely administrative — tracks the human workflow, does not
+automate it.
+
+### 5.4 AWS ACM Read-Only Adapter
+
+External Source adapter for AWS Certificate Manager. Read-only via
+`list-certificates` / `describe-certificate`. Private keys never
+fetched, even when IAM permissions would allow.
+
+### 5.5 Azure Key Vault Read-Only Adapter
+
+External Source adapter for Azure Key Vault certificates. Public
+metadata only.
+
+### 5.6 Scan-Result Ingestion
+
+Import output from `nmap`, `sslyze`, or similar passive scanners. Dedupes
+against the existing inventory and flags discrepancies. The scanner
+remains the active component; the plugin ingests the results.
+
+### 5.7 Multi-Language Documentation
+
+Dutch translation of the docs site (currently English only). Possibly
+other languages if contributors step up. The PRD itself stays English
+as the canonical reference.
+
+### 5.8 Per-Tenant Alerting Policies
+
+Different expiry thresholds and notification channels for different
+parts of the organisation. Currently thresholds are global.
+
+---
+
+## 6. Deferred — Considered, Not Pursued For Now
+
+### 6.1 Multi-Instance Sync
+
+Synchronising certificate data between NetBox deployments introduces
+conflict resolution, ownership, and trust questions that exceed the
+current scope. Revisit only if there is a clear operational case and a
+design spec that addresses those questions.
+
+### 6.2 AI-Powered Expiry Prediction
+
+Machine-learning-driven predictions (e.g., "cert X is likely to be
+renewed late based on historical patterns") are an interesting research
+topic but not a short-term priority. The deterministic threshold model
+is sufficient for the current audience.
+
+### 6.3 Commercial PKI UI Embedding
+
+Embedding CA-provider dashboards (e.g., DigiCert web UI, Venafi console)
+inside NetBox. Marginal value over the external-source metadata sync
+already in place, at significant UI complexity cost.
+
+### 6.4 Certificate Graph Visualisation
+
+Beyond the tree-shaped topology, show certificate relationships as a
+graph (shared SANs, shared CAs, sibling services). Interesting idea;
+the current topology view covers the primary need.
+
+---
+
+## 7. Rejected — Actively Not Building
+
+These are not "yet to be reconsidered" — they conflict with a design
+principle. Reconsideration requires a convincing argument that the
+principle itself should change.
+
+### 7.1 Active ACME Client
+
+Violates ADR-01 (Passive over Active). The certificate issuance and
+deployment domain is owned by specialised tooling (Certbot, acme.sh,
+Caddy, Traefik, cert-manager). NetBox SSL observes and documents; it
+does not run ACME.
+
+### 7.2 Private Key Storage
+
+Violates ADR-02 (No Private Key Storage). Even encrypted, keys in the
+plugin database create a concentration of secrets inside a non-secrets-
+manager system. Use a secrets manager (HashiCorp Vault, AWS Secrets
+Manager, Azure Key Vault) and record the *location* in the plugin.
+
+### 7.3 Automatic Certificate Deployment to Devices
+
+Violates ADR-01 and expands the plugin's trust boundary to SSH keys,
+kubeconfigs, and device credentials. Dedicated deployment tooling
+(Ansible, Salt, Terraform, Kubernetes) owns this, and their access
+models are built for it.
+
+### 7.4 Active Network Scanning
+
+Running outbound scans to discover certificates conflicts with passive
+administration and introduces false-positive risk. Passive ingestion
+from an existing scanner's output (see §5.6) is the correct pattern.
+
+### 7.5 TLS Traffic Inspection or Interception
+
+Categorically out of scope. The plugin never handles live traffic —
+only certificate metadata.
+
+### 7.6 Two-Way External-Source Sync
+
+External sources are read-only by design (ADR-06). Pushing updates
+upstream would require write credentials on the external system and
+introduces conflict-resolution problems that specialised certificate
+managers already solve.
+
+---
+
+## 8. Planned Breaking Changes (v2.0+)
+
+SemVer requires that breaking changes land in a major release. This
+section lists deprecations that will become removals.
+
+### 8.1 Removal of `add_certificate` Permission Fallback
+
+- **Deprecated in:** v1.0.0 (2026-04-16)
+- **Removal target:** v2.0.0
+
+Import endpoints currently accept either `import_certificate` (the
+custom permission introduced in v0.9) or the legacy `add_certificate`
+permission. The legacy fallback will be removed in v2.0.
+
+**Operator action.** Assign `import_certificate` to the appropriate
+roles before upgrading to v2.0. See
+[permissions reference](https://ctrl-alt-automate.github.io/netbox-ssl/reference/permissions/).
+
+---
+
+## 9. Community Input
+
+### 9.1 Proposing a Feature
+
+Open a GitHub issue using the feature-request template:
+
+https://github.com/ctrl-alt-automate/netbox-ssl/issues/new?template=feature_request.yml
+
+Good feature requests include:
+
+- A concrete use case ("team X needs to do Y")
+- Why the existing capabilities are insufficient
+- How the proposed feature fits the passive-administration principle
+- Optional: a proof-of-concept or adapter stub
+
+### 9.2 Track Record
+
+Past community requests and how they were handled:
+
+| Issue | Topic | Outcome |
+|-------|-------|---------|
+| #30 | Template packaging | Accepted as bug, fixed in v0.4.2 |
+| #47 | Renewal reminders | Accepted as feature, shipped in v0.8 |
+| #67 | `snapshot()` TypeError | Accepted as bug, fixed in v0.7.1 |
+| #81 | Test refactoring | Accepted as chore, fixed 2026-03-23 |
+| #84 | ARI monitoring | Accepted as feature, shipped in v0.9 |
+| #85 | Assignment edit save | Accepted as bug, fixed in v0.8.1 |
+| #86 | Assignment list FieldError | Accepted as bug, fixed in v0.8.1 |
+
+---
+
+## 10. Post-v2.0 Horizon
+
+Directional bets, not commitments:
+
+- **Compliance-as-code** — policy definitions in a standard format
+  (Rego / OPA) rather than per-policy-type rows in a table.
+- **Delta-based external-source sync** — most adapters currently fetch
+  full lists on every run; incremental sync reduces API quota and
+  improves latency.
+- **Certificate relationship graph** — a graph-shaped view across the
+  inventory (shared SANs, shared CAs, sibling services).
+- **First-party integrations with infrastructure-as-code platforms** —
+  Terraform data sources for read-only consumption of certificate
+  metadata from the plugin.
+- **Standalone container deployment** — a lightweight runner that
+  presents the plugin as a stand-alone web app for non-NetBox users.
+  *(Explicit caveat: this would compete with the NetBox-native
+  principle; only pursued if there is clear demand.)*
+
+None of the above is committed. The Horizon section exists for
+visibility so that contributors thinking long-term know where the
+product might go.

--- a/project-requirement-document/archive/2026-01-17-prd-v1-mvp.md
+++ b/project-requirement-document/archive/2026-01-17-prd-v1-mvp.md
@@ -1,0 +1,206 @@
+# **Product Requirements Document (PRD): NetBox SSL Plugin**
+
+Project Code: JANUS  
+Versie: 1.1 (Definitief Ontwerp \+ Dev Stack)  
+Status: Ready for Development  
+Doelgroep: Backend Developers, Frontend Developers, DevOps Engineers
+
+## **1\. Executive Summary**
+
+We ontwikkelen een NetBox plugin genaamd **"NetBox SSL"**. Het doel van deze plugin is het bieden van een "Single Source of Truth" (SSOT) voor TLS/SSL certificaten binnen de infrastructuur.
+
+De filosofie is **"Passieve Administratie"**. De plugin fungeert als een inventaris en monitoringssysteem, maar grijpt niet actief in op het netwerk (geen deployment/ACME-bot).
+
+Kernconcept: Project "Janus".  
+Het logo en de workflow zijn gebaseerd op Janus, de god van begin en eind, doorgangen en dualiteit. Dit symboliseert de focus van de plugin op de levenscyclus (Renewal) en de koppeling aan poorten (Services).
+
+## **2\. Functionele Filosofie & Scope**
+
+### **2.1 Scope (In / Out)**
+
+| In Scope (MVP) | Out of Scope |
+| :---- | :---- |
+| Handmatige import via "Paste & Parse" (PEM text) | Actieve deployment van keys naar servers |
+| Automatische parsing van X.509 attributen | Opslag van onversleutelde Private Keys |
+| Many-to-Many relaties naar Services/Devices | Full PKI Management (CA functionaliteit) |
+| Smart Renewal Workflow (Vervang & Archiveer) | Automatische scanning van netwerk (Active Probing) |
+| Dashboard Widget voor Expiry Alerts | API integraties met externe CA's (Let's Encrypt) |
+
+### **2.2 Architecturaal Besluit: De Rol van de Plugin**
+
+**Besluit:** De plugin is passief (Inventory/Audit) en niet actief (Automation/Deployment).
+
+**Onderbouwing:**
+
+* **Veiligheid:** Het opslaan van bruikbare private keys in de database creëert een onaanvaardbaar risico ("Honey Pot").  
+* **Complexiteit:** Actief certificaten deployen vereist integraties met duizenden verschillende device-types.  
+* **Focus:** De kracht van NetBox is "Documentation". De plugin moet de *bedoelde staat* (Intended State) en *administratieve staat* van certificaten vastleggen.
+
+## **3\. Data Modellen**
+
+### **3.1 Model: Certificate (De Asset)**
+
+Dit model vertegenwoordigt een uniek certificaat. Het functioneert als een "Library Item" dat meermalen gebruikt kan worden.
+
+**Velden:**
+
+* common\_name (String): De primaire CN (bijv. www.bedrijf.nl).  
+* serial\_number (String): Uniek serienummer van de CA (hex/decimaal).  
+* issuer (String): Naam van de uitgevende instantie (bijv. Let's Encrypt R3).  
+* valid\_from (DateTime): Startdatum.  
+* valid\_to (DateTime): Einddatum (Expiration).  
+* sans (Array/JSON): Subject Alternative Names. Cruciaal voor zoekbaarheid.  
+* key\_size (Integer): Bijv. 2048, 4096\.  
+* algorithm (String): Bijv. RSA, ECDSA.  
+* fingerprint\_sha256 (String): Voor snelle verificatie.  
+* issuer\_chain (TextField/JSON): *Zie* besluit *3.1.1*.  
+* private\_key\_location (String): *Zie besluit 3.1.2*.  
+* tenant (ForeignKey): Optioneel, link naar NetBox Tenant model.
+
+#### **3.1.1 Besluit: Opslag van Chain of Trust**
+
+**Besluit:** We slaan de volledige Chain (Intermediates & Root) op als platte **Metadata** (JSON/Text) binnen het Leaf-object. We maken **geen** aparte database-objecten aan voor Intermediate CA's.
+
+**Onderbouwing:**
+
+* **Alternatief (Full PKI):** Zou betekenen dat bij elke import recursief gezocht moet worden naar Parents. Dit leidt tot enorme complexiteit en databasevervuiling met certificaten die niet door de gebruiker beheerd worden.  
+* **Onze keuze (Metadata):** Biedt de CISO wel de mogelijkheid om via Search te zoeken ("Toon alle certs van 'DigiCert G2'"), maar houdt het datamodel plat en beheerbaar.
+
+#### **3.1.2 Besluit: Private Key Opslag**
+
+**Besluit:** We slaan **geen** Private Key blob op. We voegen wel een vrij tekstveld Private Key Location toe.
+
+**Onderbouwing:**
+
+* Dit veld dient als "Breadcrumb" voor de engineer in nood (bijv: "Zie Vault path: /secret/prod/web/"). Het verhoogt de bruikbaarheid zonder de veiligheid in gevaar te brengen.
+
+### **3.2 Model: CertificateAssignment (De Relatie)**
+
+De koppeltabel tussen een certificaat en de infrastructuur.
+
+**Relaties:**
+
+* certificate (ForeignKey): Link naar het Certificaat model.  
+* object\_id (GenericForeignKey): Link naar het doelsysteem.  
+* content\_type: Type van het doelsysteem (Service, Device, VM).
+
+#### **3.2.1 Besluit: Granulariteit van Koppeling**
+
+**Besluit:** We ondersteunen koppelingen aan **Devices** én **Virtual Machines**, maar de primaire (en aanbevolen) koppeling is aan een **Service** (poort).
+
+**Onderbouwing:**
+
+* Een koppeling aan alleen een *Device* is te grofmazig. Een server kan op poort 443 een publiek certificaat hebben en op poort 8443 een intern certificaat. Alleen koppelen aan de *Service* maakt de administratie accuraat.
+
+## **4\. Workflows & Logica**
+
+### **4.1 Import Workflow ("Smart Paste")**
+
+1. **UI:** Gebruiker opent "Add Certificate".  
+2. **Input:** Gebruiker plakt ruwe tekst (PEM format) in een tekstveld.  
+3. **Security Check:** Backend scant input op \-----BEGIN PRIVATE KEY-----.  
+   * *Actie:* Indien aanwezig \-\> Directe reject/foutmelding of silent stripping.  
+4. **Parsing:** Backend (Python cryptography lib) extract alle velden.  
+5. **Duplicaat Check:** Check op Serial Number \+ Issuer.  
+   * *Indien bestaand:* Foutmelding "Certificate already exists".
+
+### **4.2 Renewal Workflow ("Janus Logic")**
+
+Dit is de belangrijkste feature voor gebruiksgemak.
+
+**Scenario:** Gebruiker plakt een nieuw certificaat dat een bestaand certificaat moet vervangen.
+
+1. **Detectie:** Systeem ziet dat de Common Name overeenkomt met een bestaand, bijna verlopen certificaat.  
+2. **Prompt:** UI vraagt: *"Is* dit een renewal van *\[Oud Certificaat\]?"*  
+3. **Atomic Action:** Bij bevestiging:  
+   * Nieuw Certificaat object wordt aangemaakt.  
+   * Alle CertificateAssignment relaties worden gekopieerd van Oud naar Nieuw.  
+   * Oud Certificaat status gaat naar Replaced (Archief).  
+   * *Resultaat:* Geen verlies van relaties, naadloze overgang.
+
+#### **4.2.1 Besluit: Renewal Strategie**
+
+**Besluit:** We kiezen voor "Replace & Archive" in plaats van het updaten van het bestaande database object.
+
+**Onderbouwing:**
+
+* Audit Trail is essentieel. Je wilt historisch kunnen terugkijken welk certificaat vorig jaar op de server stond. Een simpel UPDATE statement zou de geschiedenis wissen.
+
+### **4.3 Multi-Tenancy**
+
+* Als een Tenant is toegewezen aan een Certificaat, mag dit certificaat in de UI **alleen** gekoppeld worden aan Devices/Services die tot **dezelfde Tenant** behoren.
+
+## **5\. User Interface (UX)**
+
+### **5.1 Dashboard Widget**
+
+Een widget op de NetBox homepage.
+
+* **Sortering:** Op 'Days Remaining' (oplopend).  
+* **Categorisering:**  
+  * 🔴 **Critical:** \< 14 dagen.  
+  * 🟠 **Warning:** \< 30 dagen.  
+  * 🔵 **Info:** \> 30 dagen.  
+* **Orphan Filter:** Aparte sectie voor ongekoppelde certificaten.
+
+### **5.2 Assignment UI (Tweetraps-raket)**
+
+1. **Stap 1:** Gebruiker kiest Device of VM.  
+2. **Stap 2:** De Service dropdown wordt dynamisch (via HTMX/API) gefilterd en toont alleen services van dat device.
+
+## **6\. Technische Requirements & Compatibility**
+
+### **6.1 Stack**
+
+* **Framework:** NetBox Plugin Framework (Django).  
+* **Library:** cryptography (Python) voor X.509 parsing.  
+* **Database:** PostgreSQL (standaard NetBox).
+
+### **6.2 Supported Versions**
+
+**Besluit:** N en N-1 Strategie.
+
+* **Primary Target:** NetBox **4.5.x**  
+* **Supported:** NetBox **4.4.x**  
+* **Unsupported:** NetBox 4.3.x en ouder.
+
+**Onderbouwing:**
+
+* We leunen zwaar op moderne **HTMX** functionaliteit voor de dynamische UI (Service filtering). NetBox 4.4+ heeft hiervoor een gestandaardiseerde aanpak. Ondersteuning voor 4.3 zou leiden tot complexe legacy-code en "technical debt" in de MVP fase.
+
+## **7\. Developer Environment (Nix & Direnv)**
+
+Het development team werkt op macOS (Apple Silicon). Om consistentie te garanderen, gebruiken we **Nix** voor package management en **direnv** voor environment loading.
+
+### **7.1 Nix Flake Requirements (flake.nix)**
+
+De devShell moet de volgende dependencies bevatten, los van het OS:
+
+* **Python 3.12** (Primary dev version).  
+* **Poetry** of **uv** (Voor dependency management van de plugin).  
+* **PostgreSQL Client** (libpq / postgresql\_16) \- Nodig voor psycopg2 build.  
+* **Redis** (Optioneel, handig voor lokale queue debugging).  
+* **Docker & Docker Compose** (Voor het draaien van de NetBox instanties).  
+* **Pre-commit** (Voor linting/formatting hooks).
+
+### **7.2 Direnv Configuratie (.envrc)**
+
+* Moet use flake bevatten om de Nix omgeving automatisch te laden.  
+* Moet environment variabelen zetten voor lokale NetBox plugin development (bijv. NETBOX\_DEV\_CONFIG=./development/configuration.py).
+
+## **8\. Testing Strategy**
+
+### **8.1 Fase 1: Lokale Docker Validatie**
+
+We gebruiken **geen** zware CI in de eerste bouwfase. Developers testen lokaal tegen Docker containers.
+
+* **Docker Compose Setup:**  
+  * Er moet een docker-compose.yml aanwezig zijn in de root van het project.  
+  * Deze moet eenvoudig kunnen switchen tussen NetBox images:  
+    * image: netboxcommunity/netbox:v4.5-latest (Default)  
+    * image: netboxcommunity/netbox:v4.4-latest (Compatibility Check)  
+* **Mounting:** De plugin source code moet gemount worden in de container (/opt/netbox/netbox/netbox-ssl/) zodat wijzigingen direct zichtbaar zijn (hot-reloading indien mogelijk).
+
+### **8.2 Fase 2: GitHub Actions (Later)**
+
+* Pas na oplevering MVP (v1.0) inrichten we een CI pipeline in die de unittests draait tegen de matrix van ondersteunde versies.

--- a/project-requirement-document/archive/2026-03-09-prd-v2-roadmap.md
+++ b/project-requirement-document/archive/2026-03-09-prd-v2-roadmap.md
@@ -1,0 +1,484 @@
+# **Product Requirements Document v2: NetBox SSL Plugin — Roadmap & Volgende Fasen**
+
+Project Code: JANUS
+Versie: 2.0 (Roadmap Document)
+Status: Draft — Ter Bespreking
+Voorganger: PRD v1.1 (MVP, volledig geïmplementeerd als v0.5.0)
+Doelgroep: Backend Developers, Plugin Maintainers, Infrastructure Teams
+
+---
+
+## **1. Context & Uitgangspunten**
+
+### 1.1 Wat is er bereikt (v0.1–v0.5)
+
+De MVP en eerste iteraties zijn volledig geïmplementeerd. De plugin biedt op dit moment:
+
+- Certificate model met volledige X.509 attributen, ACME tracking en chain validatie
+- CertificateAssignment met GenericForeignKey (Device, VM, Service)
+- CertificateAuthority met auto-detectie op basis van issuer patterns
+- CertificateSigningRequest tracking
+- CompliancePolicy & ComplianceCheck framework (10 policy types)
+- Smart Paste Import met private key rejection en renewal detectie
+- Janus Renewal workflow (Replace & Archive, atomair)
+- Bulk import via PEM, CSV en JSON met preview workflow
+- Multi-format export (CSV, JSON, YAML, PEM)
+- Chain validation (signatuur, geldigheid, self-signed detectie)
+- REST API met 15+ custom actions en 6 ViewSets
+- GraphQL schema
+- Dashboard widget (Expired, Critical, Warning, Orphan)
+- Email notificaties voor verlopen certificaten
+- ACME auto-detectie (15+ providers)
+- CI/CD pipeline voor NetBox 4.4 en 4.5
+- Template extensions op Device, VM en Service detail pagina's
+
+### 1.2 Onveranderde Principes
+
+De volgende architecturale beslissingen uit PRD v1 blijven ongewijzigd:
+
+| Principe | Toelichting |
+|:---|:---|
+| **Passieve Administratie** | De plugin blijft een inventaris- en monitoringsysteem. Geen actieve deployment, geen ACME-bot die certificaten uitrolt. |
+| **Geen Private Key Opslag** | Er worden geen private keys opgeslagen. Het `private_key_location` veld blijft een "breadcrumb" — een hint, geen secret. |
+| **Geen Honey Pot** | De database bevat nooit bruikbaar cryptografisch materiaal. Dit is een fundamentele veiligheidsgarantie. |
+| **Replace & Archive** | Renewal gebeurt altijd via nieuw object + archivering. Nooit een UPDATE op een bestaand certificaat. Audit trail is heilig. |
+| **N en N-1 Versie Support** | Primair NetBox 4.5.x, secundair 4.4.x. Oudere versies worden niet ondersteund. |
+
+### 1.3 Nieuwe Richtlijnen voor v2
+
+- **Incrementele releases** — Elke release heeft een duidelijk thema en is zelfstandig bruikbaar.
+- **Backward compatible** — Migraties mogen bestaande data niet breken. Nieuwe velden krijgen defaults.
+- **API-first** — Elke nieuwe feature moet een REST API endpoint hebben voordat de UI gebouwd wordt.
+- **Configureerbaar** — Features worden aangestuurd via plugin settings, niet hardcoded.
+
+---
+
+## **2. Release Roadmap Overzicht**
+
+| Release | Thema | Focus |
+|:---|:---|:---|
+| **v0.6** | Observability & Webhooks | Event-driven notificaties, integratie met externe systemen |
+| **v0.7** | Certificate Landscape | Visueel inzicht, analytics, rapportages |
+| **v0.8** | Workflow Automation & External Sources | Lifecycle management, scheduled jobs, externe bronkoppelingen |
+| **v0.9** | Enterprise & Hardening | RBAC verfijning, performance, import/export uitbreiding |
+| **v1.0** | General Availability | Stabiliteit, documentatie, community-ready |
+
+---
+
+## **3. Release v0.6 — Observability & Webhooks**
+
+### 3.1 Doel
+
+De plugin moet "luidruchtig" zijn wanneer er actie nodig is. Teams die niet dagelijks in NetBox kijken, moeten toch gewaarschuwd worden via hun bestaande tooling (Slack, Teams, PagerDuty, etc.).
+
+### 3.2 Features
+
+#### 3.2.1 NetBox Event Rules Integratie
+
+**Beschrijving:** Certificaat-events (aanmaken, verwijderen, status wijziging, expiry threshold) moeten NetBox Event Rules triggeren. Dit maakt het mogelijk om via de standaard NetBox webhook/script engine notificaties te sturen.
+
+**Requirements:**
+
+- Certificate model events (create, update, delete) triggeren NetBox's ingebouwde Event Rules
+- Custom events voor: `certificate_expired`, `certificate_expiring_soon`, `certificate_renewed`, `certificate_revoked`
+- Event payload bevat: certificate ID, common_name, days_remaining, status, assigned objects
+- Documentatie met voorbeelden voor Slack, Teams en PagerDuty webhook configuratie
+
+**Besluit:** We bouwen geen eigen notificatie-integraties. We leunen op NetBox's Event Rules systeem, zodat gebruikers hun eigen endpoints configureren. Dit houdt de plugin simpel en flexibel.
+
+#### 3.2.2 Scheduled Expiry Scanning
+
+**Beschrijving:** Een NetBox scheduled job die periodiek alle actieve certificaten scant en events genereert voor certificaten die een drempelwaarde naderen of passeren.
+
+**Requirements:**
+
+- NetBox Script/Job dat als scheduled task kan draaien
+- Configureerbare thresholds via plugin settings (standaard: 14/30/60/90 dagen)
+- Genereert events die door Event Rules opgepakt worden
+- Idempotent: dezelfde scan twee keer draaien levert geen dubbele notificaties
+- Log output voor audit doeleinden
+- Optie om per-tenant te filteren
+
+#### 3.2.3 Certificate Changelog Verrijking
+
+**Beschrijving:** Uitgebreidere changelog entries zodat wijzigingen in certificaatstatus, assignments en renewals duidelijk terug te vinden zijn.
+
+**Requirements:**
+
+- Changelog entries bij: status wijzigingen, assignment toevoegen/verwijderen, renewal events
+- Duidelijke "before → after" weergave bij status transities
+- Link naar gerelateerde objecten in changelog (bijv. "Replaced by Certificate #123")
+
+---
+
+## **4. Release v0.7 — Certificate Landscape**
+
+### 4.1 Doel
+
+Teams moeten in één oogopslag hun certificaatlandschap begrijpen. Niet alleen "wat verloopt binnenkort?" maar ook "hoe ziet ons totaalbeeld eruit?"
+
+### 4.2 Features
+
+#### 4.2.1 Certificate Analytics Dashboard
+
+**Beschrijving:** Een uitgebreide dashboard pagina (los van de homepage widget) met statistieken en grafieken over het certificaatlandschap.
+
+**Requirements:**
+
+- Overzichtspagina bereikbaar via het navigatiemenu
+- Statistieken:
+  - Totaal actieve certificaten
+  - Verdeling per status (Active, Expired, Replaced, Revoked)
+  - Verdeling per CA (issuer)
+  - Verdeling per algoritme (RSA vs ECDSA vs Ed25519)
+  - Gemiddelde resterende geldigheidsduur
+  - Certificaten zonder assignments (orphans)
+  - ACME vs non-ACME verdeling
+- Tijdlijn: "Expiry Forecast" — hoeveel certificaten verlopen per maand in de komende 12 maanden
+- Filterbaar per tenant
+
+**Technisch:** Server-side aggregatie via Django ORM. Geen zware client-side rendering. Grafieken via NetBox's bestaande charting aanpak of lichtgewicht SVG.
+
+#### 4.2.2 Compliance Rapportage
+
+**Beschrijving:** Een overzicht van compliance-resultaten dat als rapport geëxporteerd kan worden.
+
+**Requirements:**
+
+- Compliance score per certificaat (percentage passed checks)
+- Compliance overzicht per tenant
+- Compliance trend over tijd (opslaan van historische check results)
+- Export als CSV of JSON voor externe rapportage tools
+- API endpoint: `GET /api/plugins/netbox-ssl/compliance-report/`
+
+#### 4.2.3 Certificate Map (Topology View)
+
+**Beschrijving:** Een visuele weergave van welke certificaten waar gekoppeld zijn, gegroepeerd per device/cluster.
+
+**Requirements:**
+
+- Boomstructuur: Tenant → Device/VM → Service → Certificate(s)
+- Kleurcodering op basis van expiry status (groen/oranje/rood)
+- Klikbaar: navigeer door naar detail pagina's
+- Filterbaar op tenant, status, CA
+
+**Besluit:** Dit wordt een read-only view. Geen drag-and-drop assignment. De bestaande assignment workflow via formulieren blijft de primaire manier om koppelingen te beheren.
+
+---
+
+## **5. Release v0.8 — Workflow Automation**
+
+### 5.1 Doel
+
+Repetitieve taken automatiseren zonder de passieve filosofie te verlaten. De plugin helpt bij het *administreren* van de lifecycle, niet bij het *uitvoeren* ervan.
+
+### 5.2 Features
+
+#### 5.2.1 Renewal Reminders & Runbooks
+
+**Beschrijving:** Geautomatiseerde herinneringen die niet alleen waarschuwen maar ook context bieden: "Dit certificaat verloopt over 30 dagen. Hier is wat je moet doen."
+
+**Requirements:**
+
+- Per CertificateAuthority configureerbare renewal instructies (Markdown tekstveld)
+- Per Certificate optioneel een custom renewal note
+- Bij expiry events wordt de relevante renewal instructie meegestuurd in de event payload
+- UI: Op de certificate detail pagina een "Renewal Guide" sectie die de CA-instructies toont
+
+#### 5.2.2 Bulk Operations Uitbreiding
+
+**Beschrijving:** Uitbreiding van bulk acties voor efficiënt beheer van grote certificaatbestanden.
+
+**Requirements:**
+
+- Bulk status wijziging (bijv. selecteer 20 certificaten → markeer als Revoked)
+- Bulk assignment: wijs meerdere certificaten toe aan dezelfde service/device
+- Bulk compliance check: draai alle policies tegen een selectie certificaten
+- Bulk chain validation: valideer chains voor een selectie
+- Alle bulk operaties beschikbaar via zowel UI als API
+
+#### 5.2.3 Certificate Lifecycle Tracking
+
+**Beschrijving:** Volg de volledige levenscyclus van een certificaat van aanvraag tot archivering.
+
+**Requirements:**
+
+- Lifecycle states: Requested (CSR) → Issued → Active → Expiring → Expired/Renewed/Revoked
+- Automatische state transitions op basis van valid_from/valid_to
+- Timeline view op certificate detail pagina: wanneer is het aangemaakt, geïmporteerd, gerenewed, etc.
+- Koppeling CSR → Certificate versterken: bij import checken of er een matching CSR bestaat
+- Lifecycle duration statistieken (gemiddelde levensduur per CA, per type)
+
+#### 5.2.4 Auto-Archive Policy
+
+**Beschrijving:** Automatisch verlopen certificaten archiveren na een configureerbare periode.
+
+**Requirements:**
+
+- Plugin setting: `auto_archive_after_days` (standaard: 90 dagen na expiry)
+- Scheduled job die verlopen certificaten met status "Expired" omzet naar "Archived" (nieuwe status)
+- Archived certificaten worden niet getoond in standaard lijsten (filterbaar)
+- Nooit automatisch verwijderen — alleen status wijzigen
+- Handmatige override mogelijk: certificaat kan "vastgepind" worden om auto-archive te voorkomen
+
+#### 5.2.5 External Source Framework
+
+**Beschrijving:** Een generiek framework waarmee externe certificaatbeheersystemen als read-only bron gekoppeld kunnen worden aan NetBox SSL. De plugin haalt periodiek certificaat-metadata op en synchroniseert deze naar de lokale inventaris.
+
+**Filosofie:** Dit is de "passieve import" tegenhanger van handmatige Smart Paste. Waar Smart Paste geschikt is voor incidentele imports, dekt het External Source framework de structurele sync met systemen die elders het productieproces van certificaten aansturen. NetBox SSL blijft het administratiesysteem — de externe bron is het productiesysteem.
+
+**Requirements — Abstractie (ExternalSource model):**
+
+- Nieuw model `ExternalSource` met velden:
+  - `name` (String) — Herkenbare naam (bijv. "Productie Lemur", "DigiCert CertCentral")
+  - `source_type` (ChoiceField) — Type backend (Lemur, DigiCert, Venafi, Generic REST)
+  - `base_url` (URLField) — API endpoint van de externe bron
+  - `auth_method` (ChoiceField) — Bearer Token, API Key, OAuth2 Client Credentials
+  - `auth_credentials_reference` (String) — Verwijzing naar credential opslag (bijv. NetBox Secrets, environment variable naam). **Geen plaintext credentials in de database.**
+  - `sync_interval_minutes` (Integer) — Hoe vaak synchroniseren (standaard: 360)
+  - `enabled` (Boolean) — Aan/uit schakelaar
+  - `tenant` (ForeignKey, optioneel) — Geïmporteerde certificaten krijgen deze tenant
+  - `last_sync_at` (DateTime) — Tijdstip van laatste succesvolle sync
+  - `last_sync_status` (ChoiceField) — Success, Partial, Failed
+  - `last_sync_message` (TextField) — Foutmelding of samenvatting
+  - `certificate_count` (Integer) — Aantal certificaten van deze bron
+  - `tags` (TagField) — Automatisch toegevoegd aan geïmporteerde certificaten
+- Elk geïmporteerd certificaat krijgt een `external_source` ForeignKey en een `external_id` (String) voor deduplicatie
+- CRUD views en API endpoints voor ExternalSource beheer
+
+**Requirements — Sync Engine:**
+
+- Scheduled NetBox Job dat alle actieve ExternalSources pollt
+- Per sync-run:
+  1. Ophalen van certificaat-metadata via de bron-specifieke adapter
+  2. Matching op `external_source` + `external_id` (update) of `fingerprint_sha256` (deduplicatie)
+  3. Nieuwe certificaten → aanmaken met status Active
+  4. Gewijzigde certificaten → Janus Renewal patroon volgen als serial_number verschilt (nieuw object, assignments kopiëren, oud → Replaced). Metadata-updates (bijv. gewijzigde tags) → in-place update
+  5. Verwijderde certificaten in de bron → **niet** automatisch verwijderen in NetBox SSL, maar markeren met een `source_removed` flag zodat de beheerder kan beslissen
+- Dry-run modus: toon wat er zou veranderen zonder daadwerkelijk te synchroniseren
+- Sync log per run (aantal nieuw, bijgewerkt, ongewijzigd, verwijderd-in-bron, fouten)
+- API endpoint: `POST /api/plugins/netbox-ssl/external-sources/{id}/sync/` voor handmatige trigger
+
+**Requirements — Veiligheid:**
+
+- Alleen publieke certificaat-metadata ophalen. Nooit private keys opvragen, zelfs als de bron-API het ondersteunt
+- Adapter implementaties moeten expliciet de op te halen velden definiëren (allowlist, geen blocklist)
+- Credentials worden nooit gelogd of getoond in de UI (gemaskeerd)
+- TLS verificatie verplicht bij communicatie met externe bronnen (insecure optie alleen via expliciete setting)
+
+**Requirements — Adapter Interface:**
+
+Een Python abstract base class `ExternalSourceAdapter` met de volgende interface:
+
+- `test_connection() → bool` — Verbindingstest
+- `fetch_certificates(since: datetime | None) → list[ParsedCertificate]` — Ophalen van certificaten, optioneel incrementeel
+- `get_certificate_detail(external_id: str) → ParsedCertificate` — Enkel certificaat ophalen
+- `map_to_parsed_certificate(raw_data: dict) → ParsedCertificate` — Vertaling van bron-specifiek formaat naar ons datamodel
+
+Adapters worden geregistreerd via een registry pattern, vergelijkbaar met NetBox's eigen plugin systeem.
+
+**Meegeleverde Adapters (initieel):**
+
+| Adapter | Bron | Bijzonderheden |
+|:---|:---|:---|
+| `LemurAdapter` | Netflix Lemur | JWT authenticatie, `GET /certificates` endpoint, filtert private key velden uit response |
+| `GenericRESTAdapter` | Willekeurige REST API | Configureerbare field mapping (JSON path expressies voor CN, SANs, issuer, validity, etc.) |
+
+**Toekomstige Adapters (post-v0.8, community of zelf):**
+
+| Adapter | Bron | Status |
+|:---|:---|:---|
+| `DigiCertAdapter` | DigiCert CertCentral | Kandidaat voor v0.9 of community bijdrage |
+| `VenafiAdapter` | Venafi Trust Protection Platform | Kandidaat voor v0.9 of community bijdrage |
+| `AWSACMAdapter` | AWS Certificate Manager | Read-only via `list-certificates` / `describe-certificate` API |
+| `AzureKeyVaultAdapter` | Azure Key Vault (Certificates) | Read-only, alleen publieke metadata |
+| `ScanResultAdapter` | Nmap/sslyze output (JSON/XML) | Passieve import van scan-resultaten, geen actieve scanning |
+
+**Besluit:** Adapters voor commerciële platforms (DigiCert, Venafi) worden niet in de eerste release meegeleverd. De `GenericRESTAdapter` met configureerbare field mapping dekt veel use cases af. Community bijdragen voor specifieke adapters worden aangemoedigd via een gedocumenteerd adapter development guide.
+
+**UI:**
+
+- ExternalSource list view met sync status indicators (groen/oranje/rood)
+- ExternalSource detail view met: configuratie, laatste sync log, gekoppelde certificaten
+- "Sync Now" knop voor handmatige trigger
+- Certificaat list view: filterbaar op `external_source`
+- Certificaat detail view: badge/label die aangeeft uit welke externe bron het certificaat afkomstig is
+
+---
+
+## **6. Release v0.9 — Enterprise & Hardening**
+
+### 6.1 Doel
+
+Klaar maken voor gebruik in grotere organisaties met strikte toegangscontrole en hoge volumes.
+
+### 6.2 Features
+
+#### 6.2.1 Granulaire Permissies
+
+**Beschrijving:** Fijnmaziger toegangscontrole bovenop NetBox's standaard permission model.
+
+**Requirements:**
+
+- Object-level permissions via NetBox's ingebouwde ObjectPermission model
+- Tenant-scoped views: gebruikers zien alleen certificaten van hun eigen tenant(s)
+- Separate permissies voor: import, renewal, bulk operaties, compliance beheer
+- Read-only mode voor audit gebruikers (kunnen alles zien, niets wijzigen)
+
+#### 6.2.2 Performance Optimalisatie
+
+**Beschrijving:** De plugin moet performant blijven bij grote aantallen certificaten (10.000+).
+
+**Requirements:**
+
+- Database indexen op veelgebruikte filtervelden (valid_to, status, tenant, issuer)
+- Prefetch/select_related optimalisatie op list views en API endpoints
+- Paginatie op alle list endpoints (API en UI)
+- Lazy loading van zware velden (pem_content, issuer_chain) in list views
+- Benchmark tests: list view < 500ms bij 10.000 certificaten
+
+#### 6.2.3 Import/Export Uitbreiding
+
+**Beschrijving:** Ondersteuning voor meer formaten en bronnen.
+
+**Requirements:**
+
+- Import van PKCS#7 (.p7b) bestanden — extractie van certificaten uit chain bundles
+- Import vanuit DER/binary format (naast PEM)
+- Export met volledige assignment data (welk certificaat zit op welk device/service)
+- Scheduled export: periodiek een rapport genereren en opslaan (bijv. voor compliance audits)
+- API endpoint voor "diff" tussen twee exports (wat is er veranderd sinds vorige week?)
+
+#### 6.2.4 Custom Fields & Tags Verdieping
+
+**Beschrijving:** Betere integratie met NetBox's custom fields en tagging systeem.
+
+**Requirements:**
+
+- Custom fields ondersteuning op alle plugin models (niet alleen Certificate)
+- Tag-based filtering in alle views en API endpoints
+- Mogelijkheid om compliance policies te koppelen aan tags (bijv. "alle certificaten met tag 'production' moeten minimaal 4096-bit key hebben")
+- Export bevat custom field waarden
+
+---
+
+## **7. Release v1.0 — General Availability**
+
+### 7.1 Doel
+
+De plugin is stabiel, goed gedocumenteerd en klaar voor brede adoptie door de NetBox community.
+
+### 7.2 Features
+
+#### 7.2.1 Documentatie
+
+**Requirements:**
+
+- Volledige gebruikershandleiding (installatie, configuratie, workflows)
+- API documentatie met voorbeelden (curl, Python requests)
+- Administrator guide (plugin settings, scheduled jobs, Event Rules setup)
+- Contribution guide voor externe ontwikkelaars
+- Publicatie op Read the Docs of vergelijkbaar platform
+
+#### 7.2.2 Migration & Upgrade Tooling
+
+**Requirements:**
+
+- Geautomatiseerde data migratie bij plugin upgrades
+- Rollback instructies bij elke release
+- Health check commando: `manage.py check --tag netbox_ssl` uitbreiden met database integriteit checks
+- Versie compatibility matrix in documentatie
+
+#### 7.2.3 Community & Packaging
+
+**Requirements:**
+
+- Publicatie op PyPI (`pip install netbox-ssl`)
+- Nette README met badges (CI status, PyPI versie, NetBox compatibility)
+- Issue templates op GitHub (bug report, feature request)
+- CHANGELOG.md met alle releases
+- Semantic versioning beleid documenteren
+
+#### 7.2.4 Stabiliteit & Testing
+
+**Requirements:**
+
+- Test coverage > 80% op alle modules
+- E2E tests voor alle primaire workflows (import, renewal, bulk, compliance)
+- Load tests voor API endpoints bij hoog volume
+- Geen bekende data-verlies scenario's
+- Security review: geen injection mogelijkheden in import/parse flows
+
+---
+
+## **8. Toekomstige Verkenningen (Post v1.0)**
+
+De volgende ideeën vallen buiten de v1.0 scope maar zijn het verkennen waard voor een eventuele v1.x of v2.0:
+
+| Idee | Beschrijving | Passieve Filosofie? |
+|:---|:---|:---|
+| **Git-backed Audit Trail** | Exporteer certificaat state naar een Git repository voor versiebeheer buiten NetBox | ✅ Ja — read-only export |
+| **Multi-Instance Sync** | Synchronisatie van certificaatdata tussen meerdere NetBox instanties | ⚠️ Complex — vereist conflict resolution |
+| **Vault Integratie (Read-Only)** | Haal `private_key_location` metadata op uit HashiCorp Vault (geen keys, alleen paden) | ✅ Ja — alleen metadata, geen secrets |
+| **CT Log Monitoring** | Gebruik Certificate Transparency logs om te detecteren of er certificaten zijn uitgegeven voor jouw domeinen | ✅ Ja — passieve monitoring van publieke data |
+| **SLA Tracking** | Definieer SLA's per tenant/CA: "Renewal moet binnen X dagen na melding afgehandeld zijn" | ✅ Ja — administratief |
+| **Community Adapters** | Extra External Source adapters (DigiCert, Venafi, AWS ACM, Azure Key Vault) via community bijdragen | ✅ Ja — read-only sync |
+
+---
+
+## **9. Technische Overwegingen**
+
+### 9.1 Database Migraties
+
+Elke release moet:
+- Reversible migraties bevatten (RunSQL met reverse_sql)
+- Nieuwe velden altijd met `default` of `null=True`
+- Data migraties los van schema migraties
+- Getest tegen zowel NetBox 4.4 als 4.5
+
+### 9.2 API Versioning
+
+- Huidige API endpoints blijven backward compatible
+- Breaking changes (indien nodig) worden geïntroduceerd onder een versioned prefix
+- Deprecation warnings minimaal één release voor verwijdering
+
+### 9.3 Plugin Settings Uitbreiding
+
+Verwachte nieuwe settings per release:
+
+```python
+# v0.6
+'expiry_scan_thresholds': [14, 30, 60, 90],  # dagen
+'event_deduplication_hours': 24,
+
+# v0.8
+'auto_archive_after_days': 90,
+'auto_archive_enabled': False,
+'lifecycle_tracking_enabled': True,
+'external_source_sync_enabled': True,
+'external_source_default_interval': 360,       # minuten
+'external_source_tls_verify': True,
+'external_source_never_fetch_keys': True,       # safety lock, niet configureerbaar via UI
+
+# v0.9
+'performance_prefetch_limit': 1000,
+'lazy_load_pem_content': True,
+```
+
+---
+
+## **10. Succescriteria**
+
+| Criterium | Meetbaar |
+|:---|:---|
+| Plugin is installeerbaar via `pip install` | PyPI publicatie |
+| Geen data verlies bij upgrade van v0.5 → v1.0 | Migratie tests |
+| API response time < 500ms bij 10.000 certificaten | Load tests |
+| Test coverage > 80% | Coverage rapport |
+| Documentatie beschikbaar voor alle features | Review checklist |
+| Community adoptie: 10+ GitHub stars binnen 3 maanden na v1.0 | GitHub metrics |
+| Nul security vulnerabilities in import/parse flows | Security review |
+
+---
+
+*Dit document is een levend document en wordt bijgewerkt naarmate releases worden opgeleverd.*

--- a/project-requirement-document/archive/README.md
+++ b/project-requirement-document/archive/README.md
@@ -1,0 +1,40 @@
+# Archived Product Requirements Documents
+
+This folder holds historical PRDs preserved for provenance. **They are out
+of date.** For current specification, see:
+
+- [PRD.md](../PRD.md) — canonical product charter
+- [ROADMAP.md](../ROADMAP.md) — forward-looking plans
+
+## Index
+
+| File | Date | Role | Status at write time |
+|------|------|------|----------------------|
+| [2026-01-17-prd-v1-mvp.md](2026-01-17-prd-v1-mvp.md) | 2026-01-17 | MVP scope spec | Pre-implementation (v0.x) |
+| [2026-03-09-prd-v2-roadmap.md](2026-03-09-prd-v2-roadmap.md) | 2026-03-09 | Roadmap v0.6 → v1.0 | Mid-implementation |
+
+## Why archive, not delete?
+
+- **Rationale preservation** — architectural decisions are first
+  articulated here; the current PRD references them.
+- **Historical provenance** — audit questions about decision origin can
+  be answered from this folder.
+- **Honest evolution** — shows how thinking developed; useful for
+  contributors learning why the product looks the way it does.
+
+## Should I read these?
+
+No, unless you need a historical perspective. Current-product content
+lives in `PRD.md` or the
+[documentation site](https://ctrl-alt-automate.github.io/netbox-ssl/).
+
+Both archived documents are in Dutch — the original working language of
+the project. The canonical `PRD.md` is in English for community
+accessibility.
+
+## Where were these files before?
+
+These documents originally lived in a sibling folder outside the git
+repository. They were imported into the git-tracked repo on 2026-04-17
+as part of the PRD consolidation work. Any remaining copy outside the
+repository is stale after this date and can be removed.


### PR DESCRIPTION
Promotes the PRD consolidation (PR #93) from \`dev\` to \`main\`.

Documentation-only change. No code, no migrations, no release bump. The next plugin release will pick these up automatically.

### What's in this promotion

- Canonical \`PRD.md\` (product charter, 7 ADRs, 616 lines) replacing the two legacy Dutch PRDs
- Forward-looking \`ROADMAP.md\` (Now/Next/Later/Deferred/Rejected taxonomy, 297 lines)
- Archived originals under \`project-requirement-document/archive/\` with dated filenames
- CHANGELOG fix: \`add_certificate\` fallback removal target corrected from v1.1 → v2.0.0 (SemVer alignment)