### PR TITLE
Release v1.0.1: compliance-trend migration + external-sources list fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-20
+
+**Patch release** — two post-GA bugfixes surfaced while producing fresh
+documentation screenshots against a fully seeded NetBox 4.5 environment.
+
+### Fixed
+
+- **`ComplianceTrendSnapshot` schema drift**: migration `0009` originally created
+  the model without the `custom_field_data` and `tags` fields that `NetBoxModel`
+  requires. Any access to `ComplianceTrendSnapshot.objects` raised
+  `ProgrammingError: column ... custom_field_data does not exist`, which broke
+  the compliance report view (`get_trend()`) and `ComplianceReporter.create_snapshot()`
+  (used by the scheduled compliance script). New migration
+  `0020_compliancetrendsnapshot_netboxmodel_fields` backfills both columns.
+- **External Sources list view 500**: the list view annotated the queryset with
+  `certificate_count=Count("certificates")`, shadowing the model's
+  `certificate_count` `@property`. When Django hydrated the annotated objects
+  it attempted `setattr(instance, "certificate_count", value)` and raised
+  `AttributeError: property 'certificate_count' of 'ExternalSource' object has no setter`.
+  The annotation is now exposed as `_annotated_cert_count` and
+  `ExternalSourceTable.render_certificate_count()` prefers it, falling back to
+  the property for contexts that don't annotate.
+
+### Migration notes
+
+Run `python manage.py migrate netbox_ssl` after upgrading — one new migration
+(`0020`) adds two columns to `netbox_ssl_compliancetrendsnapshot`. Downgrade
+is safe; the columns are additive.
+
 ## [1.0.0] - 2026-04-16
 
 **GA Release** — NetBox SSL is now Generally Available. Full documentation at

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/netbox_ssl/migrations/0020_compliancetrendsnapshot_netboxmodel_fields.py
+++ b/netbox_ssl/migrations/0020_compliancetrendsnapshot_netboxmodel_fields.py
@@ -1,0 +1,36 @@
+"""
+Backfill NetBoxModel fields that were omitted when migration 0009 created
+ComplianceTrendSnapshot. The model inherits from NetBoxModel, which provides
+``custom_field_data`` and ``tags``, but those were never migrated.
+"""
+
+import taggit.managers
+import utilities.json
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("extras", "0001_initial"),
+        ("netbox_ssl", "0019_merge_v090"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="compliancetrendsnapshot",
+            name="custom_field_data",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                encoder=utilities.json.CustomFieldJSONEncoder,
+            ),
+        ),
+        migrations.AddField(
+            model_name="compliancetrendsnapshot",
+            name="tags",
+            field=taggit.managers.TaggableManager(
+                through="extras.TaggedItem",
+                to="extras.Tag",
+            ),
+        ),
+    ]

--- a/netbox_ssl/tables/external_sources.py
+++ b/netbox_ssl/tables/external_sources.py
@@ -87,5 +87,5 @@ class ExternalSourceTable(NetBoxTable):
         )
 
     def render_certificate_count(self, value, record):
-        """Render certificate count."""
-        return record.certificate_count
+        """Render certificate count, preferring the list-view annotation."""
+        return getattr(record, "_annotated_cert_count", record.certificate_count)

--- a/netbox_ssl/views/external_sources.py
+++ b/netbox_ssl/views/external_sources.py
@@ -18,8 +18,10 @@ from ..tables import ExternalSourceTable
 class ExternalSourceListView(generic.ObjectListView):
     """List all External Sources."""
 
-    queryset = ExternalSource.objects.prefetch_related("tenant", "tags").annotate(
-        _annotated_cert_count=Count("certificates")
+    queryset = (
+        ExternalSource.objects.select_related("tenant")
+        .prefetch_related("tags")
+        .annotate(_annotated_cert_count=Count("certificates"))
     )
     filterset = ExternalSourceFilterSet
     filterset_form = ExternalSourceFilterForm

--- a/netbox_ssl/views/external_sources.py
+++ b/netbox_ssl/views/external_sources.py
@@ -19,7 +19,7 @@ class ExternalSourceListView(generic.ObjectListView):
     """List all External Sources."""
 
     queryset = ExternalSource.objects.prefetch_related("tenant", "tags").annotate(
-        certificate_count=Count("certificates")
+        _annotated_cert_count=Count("certificates")
     )
     filterset = ExternalSourceFilterSet
     filterset_form = ExternalSourceFilterForm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "1.0.0"
+version = "1.0.1"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Patch release bundling two post-GA bugfixes that surfaced while regenerating documentation screenshots against a freshly seeded NetBox 4.5 environment.

- **Fix `ComplianceTrendSnapshot` schema drift** — migration `0009` created the model without the `custom_field_data` and `tags` columns that `NetBoxModel` requires. Any queryset access raised `ProgrammingError: column ... custom_field_data does not exist`, which broke the compliance report view (`ComplianceReporter.get_trend()`) and `ComplianceReporter.create_snapshot()` (used by the scheduled compliance script). New migration `0020_compliancetrendsnapshot_netboxmodel_fields` backfills both columns.
- **Fix External Sources list view 500** — `ExternalSourceListView` annotated the queryset with `certificate_count=Count("certificates")`, shadowing the model's `@property certificate_count`. Django raised `AttributeError: property 'certificate_count' of 'ExternalSource' object has no setter` while hydrating annotated rows. Annotation is now exposed as `_annotated_cert_count`; `ExternalSourceTable.render_certificate_count` prefers it and falls back to the property for non-list contexts.

Version bumped to `1.0.1` in `pyproject.toml` and `netbox_ssl/__init__.py`; `CHANGELOG.md` updated with a dedicated `[1.0.1]` section.

## Why bundle into 1.0.1

Both bugs break user-facing pages (compliance report, external-sources list) with HTTP 500s on what should be post-install / post-upgrade smoke-test URLs. Keeping them in a patch release rather than queueing for the next minor keeps GA-quality promises intact and avoids asking users to ship workarounds.

## Migration notes

One new migration (`0020`) adds two columns to `netbox_ssl_compliancetrendsnapshot`. Run:

```bash
python manage.py migrate netbox_ssl
```

The migration is additive; downgrade by reverting to `0019_merge_v090` is safe.

## Test plan

- [ ] `ruff check netbox_ssl/` passes
- [ ] `ruff format --check netbox_ssl/` passes
- [ ] `python -m pytest tests/ -m unit -v -p no:django` passes
- [ ] Integration matrix (NetBox 4.4 and 4.5) passes in CI
- [ ] Manually verify `/plugins/ssl/compliance-report/` renders after `manage.py migrate netbox_ssl`
- [ ] Manually verify `/plugins/ssl/external-sources/` lists without 500
- [ ] Manually verify `ComplianceReporter().create_snapshot()` succeeds in Django shell
- [ ] Confirm `ExternalSource` detail view (`/plugins/ssl/external-sources/<pk>/`) still reports `certificate_count` correctly

## Release checklist

Following `docs/development/contributing.md`:

- [x] Create `release/v1.0.1` branch from `dev`
- [x] Bump version in `pyproject.toml` and `netbox_ssl/__init__.py`
- [x] Add CHANGELOG `[1.0.1]` section
- [ ] Admin-merge after CI + review
- [ ] Open follow-up PR `dev → main`
- [ ] Tag `v1.0.1` on `main` (signed annotated)
- [ ] Push tag → triggers `publish.yml` (PyPI) and `docs.yml` (GH Pages)