### PR TITLE
feat: multi-credential auth pattern for External Sources (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-credential auth pattern for External Sources** ([#99](https://github.com/ctrl-alt-automate/netbox-ssl/issues/99)):
+  new `ExternalSource.auth_credentials` JSONField stores credential-component
+  references (e.g., `{"access_key_id": "env:AWS_KEY", "secret_access_key": "env:AWS_SECRET"}`)
+  instead of a single-string token. Enables first-class role-based auth
+  (`aws_instance_role`, `azure_managed_identity`) where the cloud SDK resolves
+  credentials via the host identity and `auth_credentials` stays empty.
+- **Per-adapter credential schemas** — each adapter class declares a
+  `credential_schema(auth_method)` classmethod; the ExternalSource form
+  and API serializer validate submitted credentials against the schema
+  at save time, surfacing field-specific errors (missing required key,
+  unknown key, unsupported reference scheme).
+- **Four new `auth_method` values**: `aws_explicit`, `aws_instance_role`,
+  `azure_explicit`, `azure_managed_identity`. Form dropdowns filter
+  per-source-type automatically via the adapter's `SUPPORTED_AUTH_METHODS`.
+- **`has_credentials` computed field** on the GraphQL type + API serializer —
+  returns `True` for role-based auth methods even when `auth_credentials`
+  is empty, so UI consumers can show "configured" state without seeing
+  reference values.
+- **`ExternalSource.snapshot()` credential redaction** — changelog entries
+  redact reference values to `<redacted>` while preserving key-level audit
+  trail (adds/removes of credential components stay visible).
+
+### Deprecated
+
+- **`ExternalSource.auth_credentials_reference`** (single-string CharField
+  from v0.8) deprecated in favor of the new JSONField. Migration 0021
+  auto-wraps existing values as `{"token": "..."}`. Field stays functional
+  through v1.1.x; removed in v2.0.0 — see [ROADMAP §8.2](project-requirement-document/ROADMAP.md#82-removal-of-auth_credentials_reference-field-on-externalsource).
+
+### Migration notes
+
+One new migration (`0021_external_source_auth_credentials`) adds the field
+and backfills it from the legacy CharField. Run:
+
+```bash
+python manage.py migrate netbox_ssl
+```
+
+The migration is idempotent (safe to re-run) and additive (safe to downgrade to v1.0.x — the old field remains).
+
 ## [1.0.1] - 2026-04-20
 
 **Patch release** — two post-GA bugfixes surfaced while producing fresh

--- a/docs/how-to/external-sources.md
+++ b/docs/how-to/external-sources.md
@@ -73,7 +73,7 @@ Supported role-based `auth_method` values:
 
 The legacy single-string `auth_credentials_reference` field (v0.8 – v1.0) remains functional through v1.1.x for backward compatibility. Migration 0021 auto-wraps existing values as `{"token": "..."}` in `auth_credentials`; operators need take no action.
 
-**`auth_credentials_reference` is removed in v2.0.0.** See [ROADMAP §8.2](../../project-requirement-document/ROADMAP.md#82-removal-of-auth_credentials_reference-field-on-externalsource).
+**`auth_credentials_reference` is removed in v2.0.0.** See [ROADMAP §8.2](https://github.com/ctrl-alt-automate/netbox-ssl/blob/main/project-requirement-document/ROADMAP.md#82-removal-of-auth_credentials_reference-field-on-externalsource).
 
 ## Step 1 — Create an ExternalSource record
 

--- a/docs/how-to/external-sources.md
+++ b/docs/how-to/external-sources.md
@@ -22,6 +22,59 @@ endpoint — without manual CSV exports.
 Adapters live under `netbox_ssl/adapters/`. New adapters can be added by
 subclassing `BaseAdapter`.
 
+## Credentials reference format (v1.1+)
+
+As of v1.1.0, credentials are stored in the `auth_credentials` JSONField, which maps credential component names to environment-variable references. This supports both simple single-token adapters (Lemur, Generic REST) and multi-component cloud adapters (AWS ACM, Azure Key Vault).
+
+### Single-token adapters (Lemur, Generic REST)
+
+```json
+{"token": "env:LEMUR_API_TOKEN"}
+```
+
+The operator sets `LEMUR_API_TOKEN=<value>` in the NetBox process environment; the plugin reads the env var at sync time, never stores the value.
+
+### Multi-component adapters (AWS ACM, Azure Key Vault)
+
+AWS ACM with explicit credentials:
+
+```json
+{
+  "access_key_id": "env:AWS_ACCESS_KEY_ID",
+  "secret_access_key": "env:AWS_SECRET_ACCESS_KEY",
+  "session_token": "env:AWS_SESSION_TOKEN"
+}
+```
+
+Azure Key Vault with explicit service-principal credentials:
+
+```json
+{
+  "tenant_id": "env:AZURE_TENANT_ID",
+  "client_id": "env:AZURE_CLIENT_ID",
+  "client_secret": "env:AZURE_CLIENT_SECRET"
+}
+```
+
+### Role-based auth (cloud-native)
+
+When NetBox runs on an AWS EC2 instance with an IAM role or on Azure with a Managed Identity, `auth_credentials` is left **empty** and the adapter uses the host identity. This is the recommended production pattern.
+
+```json
+{}
+```
+
+Supported role-based `auth_method` values:
+
+- `aws_instance_role` — AWS IAM role attached to the NetBox host (EC2, ECS, Lambda). Requires IMDSv2 enabled.
+- `azure_managed_identity` — Azure Managed Identity (system- or user-assigned). For user-assigned, include `client_id` pointing at the identity's client-ID.
+
+### Deprecated — `auth_credentials_reference`
+
+The legacy single-string `auth_credentials_reference` field (v0.8 – v1.0) remains functional through v1.1.x for backward compatibility. Migration 0021 auto-wraps existing values as `{"token": "..."}` in `auth_credentials`; operators need take no action.
+
+**`auth_credentials_reference` is removed in v2.0.0.** See [ROADMAP §8.2](../../project-requirement-document/ROADMAP.md#82-removal-of-auth_credentials_reference-field-on-externalsource).
+
 ## Step 1 — Create an ExternalSource record
 
 Navigate to **Admin → NetBox SSL → External Sources → + Add**.

--- a/netbox_ssl/adapters/__init__.py
+++ b/netbox_ssl/adapters/__init__.py
@@ -1,6 +1,6 @@
 """External source adapter framework."""
 
-from .base import BaseAdapter, FetchedCertificate
+from .base import BaseAdapter, CredentialField, FetchedCertificate
 from .generic_rest import GenericRESTAdapter
 from .lemur import LemurAdapter
 
@@ -8,6 +8,24 @@ _REGISTRY: dict[str, type[BaseAdapter]] = {
     "lemur": LemurAdapter,
     "generic_rest": GenericRESTAdapter,
 }
+
+
+def get_adapter_class(source_type: str) -> type[BaseAdapter]:
+    """Lookup adapter class for a given source_type.
+
+    Args:
+        source_type: The ExternalSource.source_type value.
+
+    Returns:
+        The registered adapter class.
+
+    Raises:
+        KeyError: If no adapter is registered for the source_type.
+    """
+    adapter_cls = _REGISTRY.get(source_type)
+    if adapter_cls is None:
+        raise KeyError(f"No adapter registered for source type '{source_type}'")
+    return adapter_cls
 
 
 def get_adapter_for_source(source) -> BaseAdapter:
@@ -22,10 +40,48 @@ def get_adapter_for_source(source) -> BaseAdapter:
     Raises:
         ValueError: If no adapter is registered for the source type.
     """
-    adapter_cls = _REGISTRY.get(source.source_type)
-    if adapter_cls is None:
-        raise ValueError(f"No adapter registered for source type '{source.source_type}'")
+    try:
+        adapter_cls = get_adapter_class(source.source_type)
+    except KeyError as e:
+        raise ValueError(str(e)) from e
     return adapter_cls(source)
 
 
-__all__ = ["BaseAdapter", "FetchedCertificate", "get_adapter_for_source"]
+def get_supported_auth_methods(source_type: str) -> tuple[str, ...]:
+    """Return the auth_method values the adapter for source_type accepts.
+
+    Args:
+        source_type: The ExternalSource.source_type value.
+
+    Returns:
+        Tuple of auth_method identifiers in form-dropdown order.
+    """
+    return get_adapter_class(source_type).SUPPORTED_AUTH_METHODS
+
+
+def get_credential_schema(source_type: str, auth_method: str) -> dict[str, CredentialField]:
+    """Return the credential schema for a (source_type, auth_method) pair.
+
+    Args:
+        source_type: The ExternalSource.source_type value.
+        auth_method: The auth_method identifier.
+
+    Returns:
+        Mapping of component name -> CredentialField.
+
+    Raises:
+        KeyError: If source_type is not registered.
+        ValueError: If auth_method is not supported by that adapter.
+    """
+    return get_adapter_class(source_type).credential_schema(auth_method)
+
+
+__all__ = [
+    "BaseAdapter",
+    "CredentialField",
+    "FetchedCertificate",
+    "get_adapter_class",
+    "get_adapter_for_source",
+    "get_credential_schema",
+    "get_supported_auth_methods",
+]

--- a/netbox_ssl/adapters/base.py
+++ b/netbox_ssl/adapters/base.py
@@ -90,6 +90,41 @@ class FetchedCertificate:
 class BaseAdapter(ABC):
     """Abstract base class for external source adapters."""
 
+    # Tuple of auth_method identifiers this adapter supports. Order is
+    # meaningful — the first entry is used as the default in the
+    # ExternalSource form dropdown for this adapter.
+    SUPPORTED_AUTH_METHODS: tuple[str, ...] = ()
+
+    # Adapter endpoint requirements consumed by ExternalSourceSchemaValidator.
+    # Lemur / Generic REST / Azure KV set REQUIRES_BASE_URL (inherited default).
+    # AWS ACM overrides to REQUIRES_BASE_URL = False, REQUIRES_REGION = True
+    # because boto3 derives endpoints from the region + service.
+    REQUIRES_BASE_URL: bool = True
+    REQUIRES_REGION: bool = False
+
+    @classmethod
+    def credential_schema(cls, auth_method: str) -> dict[str, CredentialField]:
+        """Return the credential component schema for a given auth_method.
+
+        Concrete adapters override this; the default implementation
+        raises for any auth_method not in SUPPORTED_AUTH_METHODS.
+
+        Args:
+            auth_method: The auth method identifier (e.g. "bearer", "aws_explicit").
+
+        Returns:
+            Mapping of component name -> CredentialField.
+
+        Raises:
+            ValueError: If auth_method is not in SUPPORTED_AUTH_METHODS.
+        """
+        if auth_method not in cls.SUPPORTED_AUTH_METHODS:
+            raise ValueError(
+                f"{cls.__name__} does not support auth_method '{auth_method}'. "
+                f"Supported: {list(cls.SUPPORTED_AUTH_METHODS)}"
+            )
+        return {}
+
     def __init__(self, source) -> None:
         self.source = source
         self._credentials: str | None = None

--- a/netbox_ssl/adapters/base.py
+++ b/netbox_ssl/adapters/base.py
@@ -127,31 +127,37 @@ class BaseAdapter(ABC):
 
     def __init__(self, source) -> None:
         self.source = source
-        self._credentials: str | None = None
+        self._credentials: dict[str, str] | None = None
 
-    def resolve_credentials(self) -> str:
-        """Resolve the credential reference to an actual value.
+    def resolve_credentials(self) -> dict[str, str]:
+        """Resolve all credential components from auth_credentials.
 
         Returns:
-            The resolved credential string.
+            Mapping of component name -> resolved value. Cached per
+            adapter instance for the duration of one sync run.
         """
         if self._credentials is None:
             from ..utils.credential_resolver import CredentialResolver
 
-            self._credentials = CredentialResolver.resolve(self.source.auth_credentials_reference)
+            self._credentials = CredentialResolver.resolve_many(self.source.auth_credentials or {})
         return self._credentials
 
     def _get_headers(self) -> dict[str, str]:
         """Build HTTP headers with authentication.
 
+        For bearer and api_key auth methods, reads the "token" credential.
+        Subclasses override for adapter-specific auth (AWS SigV4, Azure
+        OAuth2) that does not use HTTP headers.
+
         Returns:
             Dictionary of HTTP headers including auth and accept headers.
         """
-        cred = self.resolve_credentials()
+        creds = self.resolve_credentials()
+        token = creds.get("token", "")
         if self.source.auth_method == "bearer":
-            return {"Authorization": f"Bearer {cred}", "Accept": "application/json"}
-        elif self.source.auth_method == "api_key":
-            return {"X-API-Key": cred, "Accept": "application/json"}
+            return {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+        if self.source.auth_method == "api_key":
+            return {"X-API-Key": token, "Accept": "application/json"}
         return {"Accept": "application/json"}
 
     def _make_request(self, url: str, params: dict | None = None) -> requests.Response:

--- a/netbox_ssl/adapters/base.py
+++ b/netbox_ssl/adapters/base.py
@@ -11,14 +11,21 @@ import requests
 
 logger = logging.getLogger("netbox_ssl.adapters")
 
-# Fields that must never be accepted from external sources
+# Fields that must never be accepted from external sources.
+# Enforcement lives in each adapter's response-parsing code; this list
+# is the single source of truth consulted by those assertions.
 PROHIBITED_SYNC_FIELDS: frozenset[str] = frozenset(
     {
+        # Pre-v1.1 entries
         "private_key",
         "key_material",
         "p12",
         "pfx",
         "pkcs12",
+        # v1.1 additions for AWS ACM and Azure Key Vault parity
+        "pem_bundle",  # AWS ACM export-certificate bundle form
+        "secret_value",  # Azure Key Vault secret attribute
+        "key",  # Azure Key Vault certificate.key shortcut
     }
 )
 

--- a/netbox_ssl/adapters/base.py
+++ b/netbox_ssl/adapters/base.py
@@ -34,6 +34,35 @@ _STREAM_CHUNK_SIZE: int = 8192
 
 
 @dataclass(frozen=True)
+class CredentialField:
+    """Metadata for one credential component declared by an adapter.
+
+    Adapters use a mapping of name -> CredentialField to describe the
+    credentials required for a given auth_method. The form and serializer
+    consume this mapping to validate user-submitted auth_credentials.
+
+    Attributes:
+        required: Must be present in auth_credentials at form-save time.
+        label:    User-facing label used by the form / UI.
+        secret:   If True, component is high-sensitivity — drives UI
+                  masking and may restrict allowed reference schemes.
+        help_text: Short description shown by the form.
+
+    Note:
+        ``required=True`` is the default because required components are the
+        common case. There is intentionally no ``default`` attribute:
+        credential values must always be explicit; a silent default would
+        mask misconfiguration at form-save time and is incompatible with
+        the validator's missing-required = error assumption.
+    """
+
+    required: bool = True
+    label: str = ""
+    secret: bool = False
+    help_text: str = ""
+
+
+@dataclass(frozen=True)
 class FetchedCertificate:
     """Normalized certificate data from an external source."""
 

--- a/netbox_ssl/adapters/base.py
+++ b/netbox_ssl/adapters/base.py
@@ -102,6 +102,14 @@ class BaseAdapter(ABC):
     REQUIRES_BASE_URL: bool = True
     REQUIRES_REGION: bool = False
 
+    # Auth methods that authorize via host identity (cloud instance role,
+    # managed identity) and therefore do NOT require auth_credentials to be
+    # populated. Used by serializers/GraphQL to derive `has_credentials`
+    # without hardcoding specific auth-method names.
+    # Phase 1 adapters (Lemur, GenericREST) have none. AWS ACM (#100) will
+    # override to ("aws_instance_role",); Azure KV (#101) to ("azure_managed_identity",).
+    IMPLICIT_AUTH_METHODS: tuple[str, ...] = ()
+
     @classmethod
     def credential_schema(cls, auth_method: str) -> dict[str, CredentialField]:
         """Return the credential component schema for a given auth_method.

--- a/netbox_ssl/adapters/generic_rest.py
+++ b/netbox_ssl/adapters/generic_rest.py
@@ -15,6 +15,7 @@ import requests
 
 from .base import (
     BaseAdapter,
+    CredentialField,
     FetchedCertificate,
 )
 
@@ -83,6 +84,25 @@ class GenericRESTAdapter(BaseAdapter):
     If the external API paginates its results, only the first page is
     consumed.  Pagination support is planned for v0.9.
     """
+
+    SUPPORTED_AUTH_METHODS: tuple[str, ...] = ("bearer", "api_key")
+
+    @classmethod
+    def credential_schema(cls, auth_method: str) -> dict[str, CredentialField]:
+        """Generic REST uses one token for either bearer or api-key headers."""
+        if auth_method not in cls.SUPPORTED_AUTH_METHODS:
+            raise ValueError(
+                f"GenericRESTAdapter does not support auth_method '{auth_method}'. "
+                f"Supported: {list(cls.SUPPORTED_AUTH_METHODS)}"
+            )
+        return {
+            "token": CredentialField(
+                required=True,
+                label="API Token / Key",
+                secret=True,
+                help_text="Bearer token or API key value (same component, different header)",
+            ),
+        }
 
     def __init__(self, source) -> None:
         super().__init__(source)

--- a/netbox_ssl/adapters/lemur.py
+++ b/netbox_ssl/adapters/lemur.py
@@ -9,6 +9,7 @@ import requests
 
 from .base import (
     BaseAdapter,
+    CredentialField,
     FetchedCertificate,
 )
 
@@ -24,6 +25,25 @@ class LemurAdapter(BaseAdapter):
     Lemur API docs: https://lemur.readthedocs.io/
     Uses GET {base_url}/api/1/certificates with Bearer auth.
     """
+
+    SUPPORTED_AUTH_METHODS: tuple[str, ...] = ("bearer",)
+
+    @classmethod
+    def credential_schema(cls, auth_method: str) -> dict[str, CredentialField]:
+        """Lemur uses a single bearer token — one credential component."""
+        if auth_method != "bearer":
+            raise ValueError(
+                f"LemurAdapter does not support auth_method '{auth_method}'. "
+                f"Supported: {list(cls.SUPPORTED_AUTH_METHODS)}"
+            )
+        return {
+            "token": CredentialField(
+                required=True,
+                label="API Token",
+                secret=True,
+                help_text="Lemur API bearer token",
+            ),
+        }
 
     def _validate_pagination_url(self, next_url: str) -> bool:
         """Validate that a pagination URL shares the same origin as the base URL.

--- a/netbox_ssl/api/serializers/external_sources.py
+++ b/netbox_ssl/api/serializers/external_sources.py
@@ -81,11 +81,17 @@ class ExternalSourceSerializer(NetBoxModelSerializer):
     def get_has_credentials(self, obj) -> bool:
         """Indicate whether the source is authorized to run.
 
-        Role-based auth (AWS instance role, Azure Managed Identity)
-        needs no stored credentials but still has valid auth.
+        Role-based auth (e.g., AWS instance role, Azure Managed Identity)
+        needs no stored credentials but still has valid auth. The set of
+        role-based methods is declared per-adapter via IMPLICIT_AUTH_METHODS.
         """
-        if obj.auth_method in {"aws_instance_role", "azure_managed_identity"}:
-            return True
+        from ...adapters import get_adapter_class
+
+        try:
+            if obj.auth_method in get_adapter_class(obj.source_type).IMPLICIT_AUTH_METHODS:
+                return True
+        except KeyError:
+            pass
         return bool(obj.auth_credentials or obj.auth_credentials_reference)
 
     def validate(self, attrs):

--- a/netbox_ssl/api/serializers/external_sources.py
+++ b/netbox_ssl/api/serializers/external_sources.py
@@ -27,6 +27,14 @@ class ExternalSourceSerializer(NetBoxModelSerializer):
         allow_blank=True,
         max_length=512,
     )
+    auth_credentials = serializers.JSONField(
+        write_only=True,
+        required=False,
+        default=dict,
+        help_text=(
+            "Mapping of credential component name to env-var reference. See ExternalSource model help for format."
+        ),
+    )
 
     class Meta:
         model = ExternalSource
@@ -37,7 +45,9 @@ class ExternalSourceSerializer(NetBoxModelSerializer):
             "name",
             "source_type",
             "base_url",
+            "region",
             "auth_method",
+            "auth_credentials",
             "auth_credentials_reference",
             "has_credentials",
             "field_mapping",
@@ -69,8 +79,42 @@ class ExternalSourceSerializer(NetBoxModelSerializer):
         return obj.certificates.count()
 
     def get_has_credentials(self, obj) -> bool:
-        """Check if the source has credential references configured."""
-        return bool(obj.auth_credentials_reference)
+        """Indicate whether the source is authorized to run.
+
+        Role-based auth (AWS instance role, Azure Managed Identity)
+        needs no stored credentials but still has valid auth.
+        """
+        if obj.auth_method in {"aws_instance_role", "azure_managed_identity"}:
+            return True
+        return bool(obj.auth_credentials or obj.auth_credentials_reference)
+
+    def validate(self, attrs):
+        """Validate credential payload against adapter schema + requirements."""
+        from ...utils.external_source_validator import ExternalSourceSchemaValidator
+
+        source_type = attrs.get("source_type")
+        auth_method = attrs.get("auth_method")
+        auth_credentials = attrs.get("auth_credentials") or {}
+        base_url = attrs.get("base_url")
+        region = attrs.get("region")
+
+        # On PATCH, instance fields fill in missing attrs
+        if self.instance is not None:
+            source_type = source_type or self.instance.source_type
+            auth_method = auth_method or self.instance.auth_method
+            if base_url is None:
+                base_url = self.instance.base_url
+            if region is None:
+                region = self.instance.region
+
+        ExternalSourceSchemaValidator.validate(
+            source_type=source_type,
+            auth_method=auth_method,
+            auth_credentials=auth_credentials,
+            base_url=base_url or "",
+            region=region or "",
+        )
+        return attrs
 
 
 class ExternalSourceSyncLogSerializer(serializers.ModelSerializer):

--- a/netbox_ssl/forms/external_sources.py
+++ b/netbox_ssl/forms/external_sources.py
@@ -13,12 +13,23 @@ from ..models import (
     ExternalSourceTypeChoices,
     SyncStatusChoices,
 )
+from ..utils.external_source_validator import ExternalSourceSchemaValidator
 
 
 class ExternalSourceForm(NetBoxModelForm):
     """Form for creating/editing External Sources."""
 
     comments = CommentField()
+
+    auth_credentials = forms.JSONField(
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 5, "class": "font-monospace"}),
+        help_text=(
+            "JSON mapping of credential component name to an env-var reference. "
+            'Example: {"access_key_id": "env:AWS_KEY"}. '
+            "Leave empty for role-based auth methods."
+        ),
+    )
 
     fieldsets = (
         FieldSet(
@@ -31,6 +42,8 @@ class ExternalSourceForm(NetBoxModelForm):
         ),
         FieldSet(
             "auth_method",
+            "auth_credentials",
+            "region",
             "auth_credentials_reference",
             name=_("Authentication"),
         ),
@@ -52,7 +65,9 @@ class ExternalSourceForm(NetBoxModelForm):
             "name",
             "source_type",
             "base_url",
+            "region",
             "auth_method",
+            "auth_credentials",
             "auth_credentials_reference",
             "field_mapping",
             "sync_interval_minutes",
@@ -67,6 +82,17 @@ class ExternalSourceForm(NetBoxModelForm):
                 attrs={"placeholder": "env:MY_API_TOKEN"},
             ),
         }
+
+    def clean(self) -> dict:
+        cleaned = super().clean()
+        ExternalSourceSchemaValidator.validate(
+            source_type=cleaned.get("source_type"),
+            auth_method=cleaned.get("auth_method"),
+            auth_credentials=cleaned.get("auth_credentials") or {},
+            base_url=cleaned.get("base_url") or "",
+            region=cleaned.get("region") or "",
+        )
+        return cleaned
 
 
 class ExternalSourceFilterForm(NetBoxModelFilterSetForm):

--- a/netbox_ssl/forms/external_sources.py
+++ b/netbox_ssl/forms/external_sources.py
@@ -84,7 +84,7 @@ class ExternalSourceForm(NetBoxModelForm):
         }
 
     def clean(self) -> dict:
-        cleaned = super().clean()
+        cleaned = super().clean() or {}
         ExternalSourceSchemaValidator.validate(
             source_type=cleaned.get("source_type"),
             auth_method=cleaned.get("auth_method"),

--- a/netbox_ssl/forms/external_sources.py
+++ b/netbox_ssl/forms/external_sources.py
@@ -84,7 +84,8 @@ class ExternalSourceForm(NetBoxModelForm):
         }
 
     def clean(self) -> dict:
-        cleaned = super().clean() or {}
+        super().clean()
+        cleaned = self.cleaned_data
         ExternalSourceSchemaValidator.validate(
             source_type=cleaned.get("source_type"),
             auth_method=cleaned.get("auth_method"),

--- a/netbox_ssl/graphql/types.py
+++ b/netbox_ssl/graphql/types.py
@@ -60,6 +60,7 @@ class CertificateAuthorityType(NetBoxObjectType):
         "name",
         "source_type",
         "base_url",
+        "region",
         "auth_method",
         "sync_interval_minutes",
         "enabled",
@@ -75,12 +76,16 @@ class CertificateAuthorityType(NetBoxObjectType):
 class ExternalSourceType(NetBoxObjectType):
     """GraphQL type for ExternalSource model.
 
-    Note: auth_credentials_reference is intentionally excluded for security.
+    Note: auth_credentials and auth_credentials_reference are intentionally
+    excluded for security — both hold env-var references that would be a
+    reconnaissance leak if exposed. Use has_credentials to check
+    configuration presence.
     """
 
     name: str
     source_type: str
     base_url: str
+    region: str
     auth_method: str
     sync_interval_minutes: int
     enabled: bool
@@ -90,6 +95,17 @@ class ExternalSourceType(NetBoxObjectType):
     @strawberry_django.field
     def certificate_count(self) -> int:
         return self.certificates.count()
+
+    @strawberry_django.field
+    def has_credentials(self) -> bool:
+        """Are credentials configured for this source?
+
+        True for role-based auth (AWS instance role, Azure MI) even when
+        auth_credentials is empty — those methods authorize via host identity.
+        """
+        if self.auth_method in ("aws_instance_role", "azure_managed_identity"):
+            return True
+        return bool(self.auth_credentials) or bool(self.auth_credentials_reference)
 
 
 @strawberry_django.type(

--- a/netbox_ssl/graphql/types.py
+++ b/netbox_ssl/graphql/types.py
@@ -100,11 +100,18 @@ class ExternalSourceType(NetBoxObjectType):
     def has_credentials(self) -> bool:
         """Are credentials configured for this source?
 
-        True for role-based auth (AWS instance role, Azure MI) even when
-        auth_credentials is empty — those methods authorize via host identity.
+        True for role-based auth (e.g., AWS instance role, Azure Managed Identity)
+        even when auth_credentials is empty — those methods authorize via host
+        identity. The set of role-based methods is declared per-adapter via
+        IMPLICIT_AUTH_METHODS.
         """
-        if self.auth_method in ("aws_instance_role", "azure_managed_identity"):
-            return True
+        from ..adapters import get_adapter_class
+
+        try:
+            if self.auth_method in get_adapter_class(self.source_type).IMPLICIT_AUTH_METHODS:
+                return True
+        except KeyError:
+            pass
         return bool(self.auth_credentials) or bool(self.auth_credentials_reference)
 
 

--- a/netbox_ssl/migrations/0021_external_source_auth_credentials_and_region.py
+++ b/netbox_ssl/migrations/0021_external_source_auth_credentials_and_region.py
@@ -35,6 +35,22 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.AlterField(
+            model_name="externalsource",
+            name="auth_method",
+            field=models.CharField(
+                choices=[
+                    ("bearer", "Bearer Token"),
+                    ("api_key", "API Key (Header)"),
+                    ("aws_explicit", "AWS Explicit Credentials"),
+                    ("aws_instance_role", "AWS Instance Role"),
+                    ("azure_explicit", "Azure Service Principal"),
+                    ("azure_managed_identity", "Azure Managed Identity"),
+                ],
+                help_text="Authentication method for the external source",
+                max_length=30,
+            ),
+        ),
         migrations.AddField(
             model_name="externalsource",
             name="auth_credentials",

--- a/netbox_ssl/migrations/0021_external_source_auth_credentials_and_region.py
+++ b/netbox_ssl/migrations/0021_external_source_auth_credentials_and_region.py
@@ -1,0 +1,61 @@
+"""Add auth_credentials JSONField + region CharField to ExternalSource;
+relax base_url to blank=True for region-scoped adapters (AWS ACM).
+
+Backfills auth_credentials from the deprecated auth_credentials_reference
+CharField so existing Lemur / Generic REST configurations continue to
+work without operator action.
+
+Per the spec at docs/superpowers/specs/2026-04-21-multi-credential-auth-pattern-design.md,
+auth_credentials_reference is kept for one minor cycle and removed in v2.0.0.
+"""
+
+from django.db import migrations, models
+
+import netbox_ssl.models.external_source  # for validate_external_source_url
+
+
+def _migrate_auth_credentials(apps, schema_editor):
+    """Copy each auth_credentials_reference string into auth_credentials['token'].
+
+    Idempotent: re-running the migration is safe. Rows where
+    auth_credentials is already populated are skipped.
+    """
+    ExternalSource = apps.get_model("netbox_ssl", "ExternalSource")
+    for source in ExternalSource.objects.all():
+        if source.auth_credentials:
+            continue  # already migrated
+        if source.auth_credentials_reference:
+            source.auth_credentials = {"token": source.auth_credentials_reference}
+            source.save(update_fields=["auth_credentials"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_ssl", "0020_compliancetrendsnapshot_netboxmodel_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="externalsource",
+            name="auth_credentials",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="externalsource",
+            name="region",
+            field=models.CharField(blank=True, max_length=32),
+        ),
+        migrations.AlterField(
+            model_name="externalsource",
+            name="base_url",
+            field=models.URLField(
+                blank=True,
+                max_length=500,
+                validators=[netbox_ssl.models.external_source.validate_external_source_url],
+            ),
+        ),
+        migrations.RunPython(
+            _migrate_auth_credentials,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/netbox_ssl/models/external_source.py
+++ b/netbox_ssl/models/external_source.py
@@ -247,19 +247,22 @@ class ExternalSource(NetBoxModel):
             )
         super().save(*args, **kwargs)
 
-    def snapshot(self) -> dict | None:
+    def snapshot(self) -> None:
         """Override changelog snapshot to redact credential values.
 
         Key-level audit trail is preserved (adds/removes of credential
         components show in diffs) but reference strings are redacted to
-        prevent historical env-var-name leakage.
+        prevent historical env-var-name leakage. NetBox stores the snapshot
+        as self._prechange_snapshot; we mutate it in-place after super().
         """
-        data = super().snapshot() or {}
-        if isinstance(data.get("auth_credentials"), dict):
-            data["auth_credentials"] = dict.fromkeys(data["auth_credentials"], "<redacted>")
-        if data.get("auth_credentials_reference"):
-            data["auth_credentials_reference"] = "<redacted>"
-        return data
+        super().snapshot()
+        if self._prechange_snapshot is None:
+            return
+        creds = self._prechange_snapshot.get("auth_credentials")
+        if isinstance(creds, dict):
+            self._prechange_snapshot["auth_credentials"] = dict.fromkeys(creds, "<redacted>")
+        if self._prechange_snapshot.get("auth_credentials_reference"):
+            self._prechange_snapshot["auth_credentials_reference"] = "<redacted>"
 
     @property
     def certificate_count(self) -> int:

--- a/netbox_ssl/models/external_source.py
+++ b/netbox_ssl/models/external_source.py
@@ -19,13 +19,19 @@ from utilities.choices import ChoiceSet
 logger = logging.getLogger("netbox_ssl.models")
 
 # Fields that must never appear in field_mapping (mirrors adapters.base.PROHIBITED_SYNC_FIELDS).
+# Keep in sync with adapters/base.py — a mismatch allows sensitive keys in field_mapping.
 _PROHIBITED_MAPPING_KEYS: frozenset[str] = frozenset(
     {
+        # Pre-v1.1 entries
         "private_key",
         "key_material",
         "p12",
         "pfx",
         "pkcs12",
+        # v1.1 additions for AWS ACM and Azure Key Vault parity
+        "pem_bundle",
+        "secret_value",
+        "key",
     }
 )
 

--- a/netbox_ssl/models/external_source.py
+++ b/netbox_ssl/models/external_source.py
@@ -247,6 +247,20 @@ class ExternalSource(NetBoxModel):
             )
         super().save(*args, **kwargs)
 
+    def snapshot(self) -> dict | None:
+        """Override changelog snapshot to redact credential values.
+
+        Key-level audit trail is preserved (adds/removes of credential
+        components show in diffs) but reference strings are redacted to
+        prevent historical env-var-name leakage.
+        """
+        data = super().snapshot() or {}
+        if isinstance(data.get("auth_credentials"), dict):
+            data["auth_credentials"] = dict.fromkeys(data["auth_credentials"], "<redacted>")
+        if data.get("auth_credentials_reference"):
+            data["auth_credentials_reference"] = "<redacted>"
+        return data
+
     @property
     def certificate_count(self) -> int:
         """Return the number of certificates synced from this source.

--- a/netbox_ssl/models/external_source.py
+++ b/netbox_ssl/models/external_source.py
@@ -138,7 +138,7 @@ class ExternalSource(NetBoxModel):
         help_text=("HTTPS API endpoint of the external source. Not required for region-scoped adapters (AWS ACM)."),
     )
     auth_method = models.CharField(
-        max_length=20,
+        max_length=30,
         choices=AuthMethodChoices,
         help_text="Authentication method for the external source",
     )

--- a/netbox_ssl/models/external_source.py
+++ b/netbox_ssl/models/external_source.py
@@ -87,10 +87,18 @@ class AuthMethodChoices(ChoiceSet):
 
     AUTH_BEARER = "bearer"
     AUTH_API_KEY = "api_key"
+    AUTH_AWS_EXPLICIT = "aws_explicit"
+    AUTH_AWS_INSTANCE_ROLE = "aws_instance_role"
+    AUTH_AZURE_EXPLICIT = "azure_explicit"
+    AUTH_AZURE_MANAGED_IDENTITY = "azure_managed_identity"
 
     CHOICES = [
         (AUTH_BEARER, "Bearer Token", "blue"),
         (AUTH_API_KEY, "API Key (Header)", "yellow"),
+        (AUTH_AWS_EXPLICIT, "AWS Explicit Credentials", "orange"),
+        (AUTH_AWS_INSTANCE_ROLE, "AWS Instance Role", "green"),
+        (AUTH_AZURE_EXPLICIT, "Azure Service Principal", "blue"),
+        (AUTH_AZURE_MANAGED_IDENTITY, "Azure Managed Identity", "green"),
     ]
 
 
@@ -125,18 +133,42 @@ class ExternalSource(NetBoxModel):
     )
     base_url = models.URLField(
         max_length=500,
+        blank=True,
         validators=[validate_external_source_url],
-        help_text="HTTPS API endpoint of the external source",
+        help_text=("HTTPS API endpoint of the external source. Not required for region-scoped adapters (AWS ACM)."),
     )
     auth_method = models.CharField(
         max_length=20,
         choices=AuthMethodChoices,
         help_text="Authentication method for the external source",
     )
+    auth_credentials = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text=(
+            "Mapping of credential component name to a reference string "
+            "(e.g. {'access_key_id': 'env:AWS_KEY'}). "
+            "Leave empty for role-based auth methods "
+            "(aws_instance_role, azure_managed_identity)."
+        ),
+    )
+
+    region = models.CharField(
+        max_length=32,
+        blank=True,
+        help_text=(
+            "Cloud region identifier (e.g., 'us-east-1'). "
+            "Required for region-scoped adapters such as AWS ACM; "
+            "ignored by others."
+        ),
+    )
+
     auth_credentials_reference = models.CharField(
         max_length=512,
         blank=True,
-        help_text='Credential reference (e.g., "env:LEMUR_API_TOKEN"). Never store actual secrets.',
+        help_text=(
+            "DEPRECATED in v1.1, removed in v2.0. Use auth_credentials instead — existing rows auto-migrate via 0021."
+        ),
     )
     field_mapping = models.JSONField(
         blank=True,

--- a/netbox_ssl/utils/credential_resolver.py
+++ b/netbox_ssl/utils/credential_resolver.py
@@ -6,7 +6,14 @@ import re
 
 logger = logging.getLogger("netbox_ssl.credentials")
 
-_ENV_VAR_PATTERN = re.compile(r"^[A-Z_][A-Z0-9_]{0,254}$")
+# Public: re-used by ExternalSourceSchemaValidator for early form-time
+# validation. Must match the resolver's own accepted format so runtime
+# resolution cannot fail on names the form silently accepted.
+ENV_VAR_PATTERN = re.compile(r"^[A-Z_][A-Z0-9_]{0,254}$")
+
+# Backward-compatible alias — keep until v2.0.0 in case any custom
+# subclass reads the private name.
+_ENV_VAR_PATTERN = ENV_VAR_PATTERN
 
 
 class CredentialResolveError(Exception):
@@ -58,6 +65,28 @@ class CredentialResolver:
         )
 
     @classmethod
+    def resolve_many(cls, references: dict[str, str]) -> dict[str, str]:
+        """Resolve every reference in the dict; fail fast on the first error.
+
+        Args:
+            references: Mapping of component name -> reference string.
+                        Empty dict returns an empty dict.
+
+        Returns:
+            Parallel dict of component name -> resolved value.
+
+        Raises:
+            CredentialResolveError: On the first reference that cannot
+                be resolved (missing env var, invalid format, unsupported
+                scheme). Does NOT attempt to resolve remaining refs.
+        """
+        # Sequential dict comprehension — Python 3.7+ preserves insertion order
+        # and raises immediately on the first failed resolve(), which is the
+        # fail-fast contract promised by the docstring. Do NOT parallelize
+        # without re-reading that contract.
+        return {name: cls.resolve(ref) for name, ref in references.items()}
+
+    @classmethod
     def _resolve_env(cls, var_name: str) -> str:
         """Resolve an environment variable credential.
 
@@ -70,7 +99,7 @@ class CredentialResolver:
         Raises:
             CredentialResolveError: If the variable name is invalid or not set.
         """
-        if not _ENV_VAR_PATTERN.match(var_name):
+        if not ENV_VAR_PATTERN.match(var_name):
             raise CredentialResolveError("Invalid environment variable name format")
         value = os.environ.get(var_name)
         if value is None:

--- a/netbox_ssl/utils/external_source_validator.py
+++ b/netbox_ssl/utils/external_source_validator.py
@@ -1,0 +1,138 @@
+"""Schema-compliance validation for ExternalSource credentials.
+
+Shared by forms, serializers, and any other caller that needs to validate
+an auth_credentials dict against an adapter's declared schema. Keeps
+validation logic in one place so form and API cannot drift.
+"""
+
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError
+
+from ..adapters import get_adapter_class
+from .credential_resolver import ENV_VAR_PATTERN, CredentialResolver
+
+
+class ExternalSourceSchemaValidator:
+    """Validate an ExternalSource payload against adapter requirements.
+
+    All validation methods raise Django ValidationError with a dict of
+    field-specific errors so callers (form, serializer) can surface them
+    at the right field in their UI.
+    """
+
+    @staticmethod
+    def validate(
+        source_type: str,
+        auth_method: str,
+        auth_credentials: dict,
+        base_url: str | None = None,
+        region: str | None = None,
+    ) -> None:
+        """Validate credential payload + adapter requirements.
+
+        Args:
+            source_type:      The ExternalSource.source_type value.
+            auth_method:      The auth_method identifier.
+            auth_credentials: The credential references dict to validate.
+            base_url:         The ExternalSource.base_url value.
+                              Pass an empty string ``""`` to trigger the
+                              "required but missing" validation check.
+                              Omit (or pass ``None``) to skip the check.
+            region:           The ExternalSource.region value.
+                              Same sentinel convention as base_url.
+
+        Raises:
+            ValidationError: With a field-specific error dict.
+        """
+        # 1. source_type must be known
+        try:
+            adapter_cls = get_adapter_class(source_type)
+        except KeyError:
+            raise ValidationError({"source_type": f"Unknown source_type '{source_type}'"}) from None
+
+        # 2. auth_method must be supported by this adapter
+        if auth_method not in adapter_cls.SUPPORTED_AUTH_METHODS:
+            raise ValidationError(
+                {
+                    "auth_method": (
+                        f"{adapter_cls.__name__} does not support auth_method "
+                        f"'{auth_method}'. "
+                        f"Supported: {list(adapter_cls.SUPPORTED_AUTH_METHODS)}"
+                    )
+                }
+            )
+
+        # 3. Adapter endpoint requirements (base_url, region)
+        # Only checked when the caller explicitly supplies the value (not None).
+        # An empty string triggers the "required but missing" error; None skips.
+        if base_url is not None and adapter_cls.REQUIRES_BASE_URL and not base_url:
+            raise ValidationError({"base_url": f"{adapter_cls.__name__} requires a base URL."})
+        if region is not None and adapter_cls.REQUIRES_REGION and not region:
+            raise ValidationError({"region": (f"{adapter_cls.__name__} requires a region (e.g., 'us-east-1').")})
+
+        # 4. Schema compliance for auth_credentials
+        schema = adapter_cls.credential_schema(auth_method)
+
+        extra_keys = set(auth_credentials.keys()) - set(schema.keys())
+        if extra_keys:
+            raise ValidationError(
+                {
+                    "auth_credentials": (
+                        f"Unknown credential keys: {sorted(extra_keys)}. Allowed: {sorted(schema.keys())}"
+                    )
+                }
+            )
+
+        for key, field_spec in schema.items():
+            if field_spec.required and key not in auth_credentials:
+                raise ValidationError(
+                    {"auth_credentials": (f"Missing required credential '{key}' ({field_spec.label or key})")}
+                )
+
+        # 5. Reference format — strict match against ENV_VAR_PATTERN
+        for key, ref in auth_credentials.items():
+            if not isinstance(ref, str) or not ref.strip():
+                raise ValidationError(
+                    {"auth_credentials": (f"Credential '{key}' must be a non-empty string reference")}
+                )
+
+            if ":" in ref:
+                scheme, _, path = ref.partition(":")
+                scheme = scheme.strip().lower()
+                path = path.strip()
+                if scheme not in CredentialResolver.SUPPORTED_SCHEMES:
+                    raise ValidationError(
+                        {
+                            "auth_credentials": (
+                                f"Credential '{key}' uses unsupported scheme "
+                                f"'{scheme}'. "
+                                f"Supported: {sorted(CredentialResolver.SUPPORTED_SCHEMES)}"
+                            )
+                        }
+                    )
+                if not path:
+                    raise ValidationError(
+                        {
+                            "auth_credentials": (
+                                f"Credential '{key}' has an empty path after "
+                                f"'{scheme}:'. Provide an env-var name, e.g. 'env:MY_TOKEN'."
+                            )
+                        }
+                    )
+                var_name = path
+            else:
+                var_name = ref.strip()
+
+            # 6. Env-var name must match the resolver's allowed pattern
+            if not ENV_VAR_PATTERN.match(var_name):
+                raise ValidationError(
+                    {
+                        "auth_credentials": (
+                            f"Credential '{key}' references '{var_name}', which is "
+                            "not a valid environment variable name. "
+                            "Names must start with an uppercase letter or underscore "
+                            "and contain only uppercase letters, digits, and underscores."
+                        )
+                    }
+                )

--- a/project-requirement-document/ROADMAP.md
+++ b/project-requirement-document/ROADMAP.md
@@ -24,7 +24,7 @@
 | Date | Change |
 |------|--------|
 | 2026-04-17 | Initial roadmap post-v1.0 GA. |
-| 2026-04-21 | Post-v1.0.1 review. Promoted **AWS ACM** and **Azure Key Vault** read-only adapters from Later (§5.4, §5.5) to Next (now §4.1, §4.2). Demoted **DigiCert CertCentral Adapter** from Next (§4.2) to Later (§5.5), narrowed scope to a GenericRESTAdapter preset + how-to guide because a reliable first-party adapter requires a live DigiCert account the maintainer does not hold. Renumbered §4.1 Vault → §4.3 (scope unchanged), §4.3 Performance Scaling Pass → §4.4 (scope unchanged). |
+| 2026-04-21 | Post-v1.0.1 review. Promoted **AWS ACM** and **Azure Key Vault** read-only adapters from Later (§5.4, §5.5) to Next (now §4.1, §4.2). Demoted **DigiCert CertCentral Adapter** from Next (§4.2) to Later (§5.5), narrowed scope to a GenericRESTAdapter preset + how-to guide because a reliable first-party adapter requires a live DigiCert account the maintainer does not hold. Renumbered §4.1 Vault → §4.3 (scope unchanged), §4.3 Performance Scaling Pass → §4.4 (scope unchanged). Added §8.2 for `auth_credentials_reference` deprecation (landing with multi-credential auth pattern in v1.1.0). |
 
 ---
 
@@ -273,6 +273,15 @@ permission. The legacy fallback will be removed in v2.0.
 **Operator action.** Assign `import_certificate` to the appropriate
 roles before upgrading to v2.0. See
 [permissions reference](https://ctrl-alt-automate.github.io/netbox-ssl/reference/permissions/).
+
+### 8.2 Removal of auth_credentials_reference field on ExternalSource
+
+- **Deprecated in:** v1.1.0
+- **Removal target:** v2.0.0
+
+The `ExternalSource.auth_credentials_reference` CharField stored single-string credential references. v1.1 adds a structured `auth_credentials` JSONField that supersedes it; migration 0021 wraps existing single strings as `{"token": "env:..."}`.
+
+**Operator action.** No code change needed IF you've run `manage.py migrate` on v1.1 (the field content is already copied to `auth_credentials["token"]`). If you still rely on `auth_credentials_reference` in custom code (e.g. reading it from the database directly in a script), switch to `auth_credentials` before upgrading to v2.0.
 
 ---
 

--- a/tests/test_credential_resolver_many.py
+++ b/tests/test_credential_resolver_many.py
@@ -1,0 +1,95 @@
+"""Unit tests for CredentialResolver.resolve_many()."""
+
+import importlib.util
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Mock Django/NetBox before importing plugin code
+# ---------------------------------------------------------------------------
+try:
+    _spec = importlib.util.find_spec("netbox")
+    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    _NETBOX_AVAILABLE = False
+
+if not _NETBOX_AVAILABLE and "netbox" not in sys.modules:
+    for mod in [
+        "django",
+        "django.conf",
+        "django.db",
+        "django.db.models",
+        "django.db.models.functions",
+        "django.utils",
+        "django.utils.timezone",
+        "django.utils.translation",
+        "django.contrib",
+        "django.contrib.contenttypes",
+        "django.contrib.contenttypes.fields",
+        "django.contrib.contenttypes.models",
+        "django.contrib.postgres",
+        "django.contrib.postgres.fields",
+        "django.contrib.postgres.indexes",
+        "django.core",
+        "django.core.exceptions",
+        "django.urls",
+        "netbox",
+        "netbox.models",
+        "netbox.plugins",
+        "utilities",
+        "utilities.choices",
+    ]:
+        sys.modules.setdefault(mod, MagicMock())
+
+pytestmark = pytest.mark.unit
+
+
+def test_resolve_many_empty_dict_returns_empty_dict():
+    from netbox_ssl.utils.credential_resolver import CredentialResolver
+
+    assert CredentialResolver.resolve_many({}) == {}
+
+
+def test_resolve_many_resolves_each_env_ref():
+    from netbox_ssl.utils.credential_resolver import CredentialResolver
+
+    refs = {"access_key_id": "env:TEST_KEY_ID", "secret_access_key": "env:TEST_SECRET"}
+    with patch.dict(os.environ, {"TEST_KEY_ID": "AKIATEST", "TEST_SECRET": "secretval"}):
+        result = CredentialResolver.resolve_many(refs)
+    assert result == {"access_key_id": "AKIATEST", "secret_access_key": "secretval"}
+
+
+def test_resolve_many_accepts_bare_varname_as_env():
+    from netbox_ssl.utils.credential_resolver import CredentialResolver
+
+    refs = {"token": "LEGACY_BARE_VAR"}
+    with patch.dict(os.environ, {"LEGACY_BARE_VAR": "legacy_value"}):
+        result = CredentialResolver.resolve_many(refs)
+    assert result == {"token": "legacy_value"}
+
+
+def test_resolve_many_fails_fast_on_missing_env_var():
+    from netbox_ssl.utils.credential_resolver import (
+        CredentialResolveError,
+        CredentialResolver,
+    )
+
+    refs = {"present": "env:PRESENT_VAR", "missing": "env:MISSING_VAR_12345"}
+    with patch.dict(os.environ, {"PRESENT_VAR": "x"}, clear=False):
+        os.environ.pop("MISSING_VAR_12345", None)
+        with pytest.raises(CredentialResolveError, match="MISSING_VAR_12345"):
+            CredentialResolver.resolve_many(refs)
+
+
+def test_resolve_many_rejects_unsupported_scheme():
+    from netbox_ssl.utils.credential_resolver import (
+        CredentialResolveError,
+        CredentialResolver,
+    )
+
+    refs = {"token": "vault:secret/foo"}
+    with pytest.raises(CredentialResolveError, match="Unsupported"):
+        CredentialResolver.resolve_many(refs)

--- a/tests/test_credential_schema.py
+++ b/tests/test_credential_schema.py
@@ -61,3 +61,20 @@ def test_credential_field_all_attributes():
     assert field.label == "Session Token"
     assert field.secret is True
     assert field.help_text == "Only for temporary credentials"
+
+
+def test_prohibited_sync_fields_includes_cloud_aliases():
+    """v1.1 extends the safe-list with AWS/Azure key-material aliases."""
+    from netbox_ssl.adapters.base import PROHIBITED_SYNC_FIELDS
+
+    # Pre-existing entries — must stay.
+    assert "private_key" in PROHIBITED_SYNC_FIELDS
+    assert "key_material" in PROHIBITED_SYNC_FIELDS
+    assert "p12" in PROHIBITED_SYNC_FIELDS
+    assert "pfx" in PROHIBITED_SYNC_FIELDS
+    assert "pkcs12" in PROHIBITED_SYNC_FIELDS
+
+    # v1.1 additions — Azure Key Vault + AWS ACM aliases.
+    assert "pem_bundle" in PROHIBITED_SYNC_FIELDS
+    assert "secret_value" in PROHIBITED_SYNC_FIELDS
+    assert "key" in PROHIBITED_SYNC_FIELDS

--- a/tests/test_credential_schema.py
+++ b/tests/test_credential_schema.py
@@ -1,0 +1,63 @@
+"""Unit tests for CredentialField dataclass and per-adapter credential schemas."""
+
+import importlib.util
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Mock Django/NetBox before importing plugin code
+# ---------------------------------------------------------------------------
+try:
+    _spec = importlib.util.find_spec("netbox")
+    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    _NETBOX_AVAILABLE = False
+
+if not _NETBOX_AVAILABLE:
+    for _mod in [
+        "django",
+        "django.conf",
+        "django.db",
+        "django.db.models",
+        "django.utils",
+        "django.utils.translation",
+        "netbox",
+        "netbox.plugins",
+    ]:
+        sys.modules.setdefault(_mod, MagicMock())
+
+from netbox_ssl.adapters.base import CredentialField  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_credential_field_is_frozen():
+    """Assignment to a frozen-dataclass field must raise with the dataclasses
+    message, narrowing the catch so an accidental AttributeError elsewhere
+    cannot silently pass this test."""
+    field = CredentialField(required=True, label="API Token")
+    with pytest.raises(Exception, match="cannot assign to field"):
+        field.required = False  # type: ignore[misc]
+
+
+def test_credential_field_defaults():
+    field = CredentialField()
+    assert field.required is True
+    assert field.label == ""
+    assert field.secret is False
+    assert field.help_text == ""
+
+
+def test_credential_field_all_attributes():
+    field = CredentialField(
+        required=False,
+        label="Session Token",
+        secret=True,
+        help_text="Only for temporary credentials",
+    )
+    assert field.required is False
+    assert field.label == "Session Token"
+    assert field.secret is True
+    assert field.help_text == "Only for temporary credentials"

--- a/tests/test_credential_schema.py
+++ b/tests/test_credential_schema.py
@@ -78,3 +78,23 @@ def test_prohibited_sync_fields_includes_cloud_aliases():
     assert "pem_bundle" in PROHIBITED_SYNC_FIELDS
     assert "secret_value" in PROHIBITED_SYNC_FIELDS
     assert "key" in PROHIBITED_SYNC_FIELDS
+
+
+def test_base_adapter_has_empty_supported_auth_methods():
+    from netbox_ssl.adapters.base import BaseAdapter
+
+    assert BaseAdapter.SUPPORTED_AUTH_METHODS == ()
+
+
+def test_base_adapter_default_requires_base_url():
+    from netbox_ssl.adapters.base import BaseAdapter
+
+    assert BaseAdapter.REQUIRES_BASE_URL is True
+    assert BaseAdapter.REQUIRES_REGION is False
+
+
+def test_base_adapter_credential_schema_rejects_unknown_auth_method():
+    from netbox_ssl.adapters.base import BaseAdapter
+
+    with pytest.raises(ValueError, match="does not support"):
+        BaseAdapter.credential_schema("anything")

--- a/tests/test_credential_schema.py
+++ b/tests/test_credential_schema.py
@@ -121,3 +121,27 @@ def test_lemur_credential_schema_rejects_non_bearer():
 
     with pytest.raises(ValueError, match="does not support"):
         LemurAdapter.credential_schema("api_key")
+
+
+def test_generic_rest_supports_bearer_and_api_key():
+    from netbox_ssl.adapters.generic_rest import GenericRESTAdapter
+
+    assert GenericRESTAdapter.SUPPORTED_AUTH_METHODS == ("bearer", "api_key")
+
+
+def test_generic_rest_schema_is_single_token_for_both_methods():
+    from netbox_ssl.adapters.generic_rest import GenericRESTAdapter
+
+    for method in ("bearer", "api_key"):
+        schema = GenericRESTAdapter.credential_schema(method)
+        assert set(schema.keys()) == {"token"}
+        assert schema["token"].required is True
+        assert schema["token"].secret is True
+
+
+def test_generic_rest_schema_rejects_cloud_methods():
+    from netbox_ssl.adapters.generic_rest import GenericRESTAdapter
+
+    for method in ("aws_explicit", "azure_managed_identity"):
+        with pytest.raises(ValueError, match="does not support"):
+            GenericRESTAdapter.credential_schema(method)

--- a/tests/test_credential_schema.py
+++ b/tests/test_credential_schema.py
@@ -21,7 +21,9 @@ if not _NETBOX_AVAILABLE:
         "django.conf",
         "django.db",
         "django.db.models",
+        "django.db.models.functions",
         "django.utils",
+        "django.utils.timezone",
         "django.utils.translation",
         "netbox",
         "netbox.plugins",
@@ -145,3 +147,56 @@ def test_generic_rest_schema_rejects_cloud_methods():
     for method in ("aws_explicit", "azure_managed_identity"):
         with pytest.raises(ValueError, match="does not support"):
             GenericRESTAdapter.credential_schema(method)
+
+
+def test_base_adapter_resolve_credentials_returns_dict():
+    """resolve_credentials must return dict[str, str] for multi-cred support."""
+    import os
+    from unittest.mock import MagicMock, patch
+
+    from netbox_ssl.adapters.lemur import LemurAdapter
+
+    source = MagicMock()
+    source.auth_credentials = {"token": "env:LEMUR_TEST_TOKEN"}
+    adapter = LemurAdapter(source)
+
+    with patch.dict(os.environ, {"LEMUR_TEST_TOKEN": "t0ken"}):
+        result = adapter.resolve_credentials()
+
+    assert isinstance(result, dict)
+    assert result == {"token": "t0ken"}
+
+
+def test_get_headers_bearer_reads_token_from_dict():
+    import os
+    from unittest.mock import MagicMock, patch
+
+    from netbox_ssl.adapters.lemur import LemurAdapter
+
+    source = MagicMock()
+    source.auth_credentials = {"token": "env:MY_TOKEN"}
+    source.auth_method = "bearer"
+    adapter = LemurAdapter(source)
+
+    with patch.dict(os.environ, {"MY_TOKEN": "bearer_value"}):
+        headers = adapter._get_headers()
+
+    assert headers["Authorization"] == "Bearer bearer_value"
+    assert headers["Accept"] == "application/json"
+
+
+def test_get_headers_api_key_reads_token_from_dict():
+    import os
+    from unittest.mock import MagicMock, patch
+
+    from netbox_ssl.adapters.generic_rest import GenericRESTAdapter
+
+    source = MagicMock()
+    source.auth_credentials = {"token": "env:MY_KEY"}
+    source.auth_method = "api_key"
+    adapter = GenericRESTAdapter(source)
+
+    with patch.dict(os.environ, {"MY_KEY": "apikey_value"}):
+        headers = adapter._get_headers()
+
+    assert headers["X-API-Key"] == "apikey_value"

--- a/tests/test_credential_schema.py
+++ b/tests/test_credential_schema.py
@@ -98,3 +98,26 @@ def test_base_adapter_credential_schema_rejects_unknown_auth_method():
 
     with pytest.raises(ValueError, match="does not support"):
         BaseAdapter.credential_schema("anything")
+
+
+def test_lemur_supports_bearer_only():
+    from netbox_ssl.adapters.lemur import LemurAdapter
+
+    assert LemurAdapter.SUPPORTED_AUTH_METHODS == ("bearer",)
+
+
+def test_lemur_credential_schema_has_single_token_field():
+    from netbox_ssl.adapters.lemur import LemurAdapter
+
+    schema = LemurAdapter.credential_schema("bearer")
+    assert set(schema.keys()) == {"token"}
+    assert schema["token"].required is True
+    assert schema["token"].secret is True
+    assert schema["token"].label == "API Token"
+
+
+def test_lemur_credential_schema_rejects_non_bearer():
+    from netbox_ssl.adapters.lemur import LemurAdapter
+
+    with pytest.raises(ValueError, match="does not support"):
+        LemurAdapter.credential_schema("api_key")

--- a/tests/test_credential_schema.py
+++ b/tests/test_credential_schema.py
@@ -204,8 +204,8 @@ def test_get_headers_api_key_reads_token_from_dict():
 
 def test_get_adapter_class_returns_correct_class():
     from netbox_ssl.adapters import get_adapter_class
-    from netbox_ssl.adapters.lemur import LemurAdapter
     from netbox_ssl.adapters.generic_rest import GenericRESTAdapter
+    from netbox_ssl.adapters.lemur import LemurAdapter
 
     assert get_adapter_class("lemur") is LemurAdapter
     assert get_adapter_class("generic_rest") is GenericRESTAdapter
@@ -231,3 +231,21 @@ def test_get_credential_schema_for_lemur():
     schema = get_credential_schema("lemur", "bearer")
     assert "token" in schema
     assert schema["token"].required is True
+
+
+def test_base_adapter_default_implicit_auth_methods_is_empty():
+    from netbox_ssl.adapters.base import BaseAdapter
+
+    assert BaseAdapter.IMPLICIT_AUTH_METHODS == ()
+
+
+def test_lemur_does_not_declare_implicit_auth():
+    from netbox_ssl.adapters.lemur import LemurAdapter
+
+    assert LemurAdapter.IMPLICIT_AUTH_METHODS == ()
+
+
+def test_generic_rest_does_not_declare_implicit_auth():
+    from netbox_ssl.adapters.generic_rest import GenericRESTAdapter
+
+    assert GenericRESTAdapter.IMPLICIT_AUTH_METHODS == ()

--- a/tests/test_credential_schema.py
+++ b/tests/test_credential_schema.py
@@ -200,3 +200,34 @@ def test_get_headers_api_key_reads_token_from_dict():
         headers = adapter._get_headers()
 
     assert headers["X-API-Key"] == "apikey_value"
+
+
+def test_get_adapter_class_returns_correct_class():
+    from netbox_ssl.adapters import get_adapter_class
+    from netbox_ssl.adapters.lemur import LemurAdapter
+    from netbox_ssl.adapters.generic_rest import GenericRESTAdapter
+
+    assert get_adapter_class("lemur") is LemurAdapter
+    assert get_adapter_class("generic_rest") is GenericRESTAdapter
+
+
+def test_get_adapter_class_raises_for_unknown():
+    from netbox_ssl.adapters import get_adapter_class
+
+    with pytest.raises(KeyError, match="No adapter registered"):
+        get_adapter_class("nonexistent")
+
+
+def test_get_supported_auth_methods():
+    from netbox_ssl.adapters import get_supported_auth_methods
+
+    assert get_supported_auth_methods("lemur") == ("bearer",)
+    assert get_supported_auth_methods("generic_rest") == ("bearer", "api_key")
+
+
+def test_get_credential_schema_for_lemur():
+    from netbox_ssl.adapters import get_credential_schema
+
+    schema = get_credential_schema("lemur", "bearer")
+    assert "token" in schema
+    assert schema["token"].required is True

--- a/tests/test_external_source.py
+++ b/tests/test_external_source.py
@@ -268,3 +268,48 @@ class TestPluginSettings:
         assert "external_source_sync_enabled" in content
         assert "external_source_default_interval" in content
         assert "external_source_never_fetch_keys" in content
+
+
+@pytest.mark.unit
+def test_auth_method_choices_include_cloud_methods():
+    from netbox_ssl.models.external_source import AuthMethodChoices
+
+    values = [choice[0] for choice in AuthMethodChoices.CHOICES]
+    assert "bearer" in values
+    assert "api_key" in values
+    assert "aws_explicit" in values
+    assert "aws_instance_role" in values
+    assert "azure_explicit" in values
+    assert "azure_managed_identity" in values
+
+
+@pytest.mark.unit
+def test_external_source_has_auth_credentials_field():
+    if not _NETBOX_AVAILABLE:
+        pytest.skip("requires Django+NetBox metaclass infrastructure")
+    from netbox_ssl.models.external_source import ExternalSource
+
+    field_names = [f.name for f in ExternalSource._meta.get_fields() if not f.many_to_many and not f.one_to_many]
+    assert "auth_credentials" in field_names
+    assert "auth_credentials_reference" in field_names  # still present, deprecated
+
+
+@pytest.mark.unit
+def test_external_source_has_region_field():
+    if not _NETBOX_AVAILABLE:
+        pytest.skip("requires Django+NetBox metaclass infrastructure")
+    from netbox_ssl.models.external_source import ExternalSource
+
+    field_names = [f.name for f in ExternalSource._meta.get_fields() if not f.many_to_many and not f.one_to_many]
+    assert "region" in field_names
+
+
+@pytest.mark.unit
+def test_external_source_base_url_is_optional():
+    """base_url becomes optional in v1.1 so AWS ACM sources can omit it."""
+    if not _NETBOX_AVAILABLE:
+        pytest.skip("requires Django+NetBox metaclass infrastructure")
+    from netbox_ssl.models.external_source import ExternalSource
+
+    base_url_field = ExternalSource._meta.get_field("base_url")
+    assert base_url_field.blank is True

--- a/tests/test_external_source_form.py
+++ b/tests/test_external_source_form.py
@@ -1,0 +1,73 @@
+"""Unit tests for ExternalSourceForm.clean() validation."""
+
+import importlib.util
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+try:
+    _spec = importlib.util.find_spec("netbox")
+    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    _NETBOX_AVAILABLE = False
+
+
+def _base_form_data(**overrides):
+    data = {
+        "name": "test",
+        "source_type": "lemur",
+        "base_url": "https://example.com",
+        "auth_method": "bearer",
+        "auth_credentials": {"token": "env:LEMUR_TOKEN"},
+        "field_mapping": {},
+        "sync_interval_minutes": 60,
+        "enabled": True,
+        "verify_ssl": True,
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_form_accepts_valid_lemur_config():
+    from netbox_ssl.forms.external_sources import ExternalSourceForm
+
+    form = ExternalSourceForm(data=_base_form_data())
+    assert form.is_valid(), form.errors
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_form_rejects_unknown_credential_key():
+    from netbox_ssl.forms.external_sources import ExternalSourceForm
+
+    form = ExternalSourceForm(
+        data=_base_form_data(
+            auth_credentials={"token": "env:OK", "extra": "env:BAD"},
+        )
+    )
+    assert not form.is_valid()
+    assert "Unknown credential keys" in str(form.errors)
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_form_rejects_missing_required_credential():
+    from netbox_ssl.forms.external_sources import ExternalSourceForm
+
+    form = ExternalSourceForm(data=_base_form_data(auth_credentials={}))
+    assert not form.is_valid()
+    assert "Missing required credential" in str(form.errors)
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_form_rejects_auth_method_not_supported_by_source_type():
+    from netbox_ssl.forms.external_sources import ExternalSourceForm
+
+    form = ExternalSourceForm(
+        data=_base_form_data(
+            source_type="lemur",
+            auth_method="aws_explicit",
+        )
+    )
+    assert not form.is_valid()
+    assert "does not support" in str(form.errors)

--- a/tests/test_external_source_graphql.py
+++ b/tests/test_external_source_graphql.py
@@ -1,0 +1,31 @@
+"""Unit tests verifying GraphQL scrubbing of ExternalSource credentials."""
+
+import importlib.util
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+try:
+    _spec = importlib.util.find_spec("netbox")
+    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    _NETBOX_AVAILABLE = False
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_external_source_type_has_no_auth_credentials_field():
+    from netbox_ssl.graphql.types import ExternalSourceType
+
+    # Inspect the class annotations (strawberry/strawberry-django uses these)
+    annotations = getattr(ExternalSourceType, "__annotations__", {})
+    assert "auth_credentials" not in annotations
+    assert "auth_credentials_reference" not in annotations
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_external_source_type_has_has_credentials_field():
+    from netbox_ssl.graphql.types import ExternalSourceType
+
+    # has_credentials is exposed as a strawberry_django.field
+    assert hasattr(ExternalSourceType, "has_credentials")

--- a/tests/test_external_source_snapshot.py
+++ b/tests/test_external_source_snapshot.py
@@ -14,25 +14,37 @@ except (ValueError, ModuleNotFoundError):
     _NETBOX_AVAILABLE = False
 
 
-def _make_source_with_snapshot_method(auth_credentials=None, auth_ref=""):
-    """Build a mocked ExternalSource-like object with the real snapshot() override."""
+def _make_source_and_call_snapshot(auth_credentials=None, auth_ref=""):
+    """Build a mocked ExternalSource, call snapshot(), return the prechange dict.
+
+    Simulates NetBox's contract: super().snapshot() sets
+    self._prechange_snapshot; returns None.
+    """
     from netbox_ssl.models.external_source import ExternalSource
 
     source = MagicMock(spec=ExternalSource)
     source.auth_credentials = auth_credentials or {}
     source.auth_credentials_reference = auth_ref
+    source._prechange_snapshot = None
+
     base_snapshot = {
         "name": "test-source",
         "auth_credentials": source.auth_credentials,
         "auth_credentials_reference": source.auth_credentials_reference,
     }
-    with patch("netbox_ssl.models.external_source.NetBoxModel.snapshot", return_value=base_snapshot):
-        return ExternalSource.snapshot(source)
+
+    def _side_effect(self=source):
+        source._prechange_snapshot = base_snapshot
+
+    with patch("netbox_ssl.models.external_source.NetBoxModel.snapshot", side_effect=_side_effect):
+        ExternalSource.snapshot(source)
+
+    return source._prechange_snapshot
 
 
 @pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
 def test_snapshot_redacts_auth_credentials_values():
-    result = _make_source_with_snapshot_method(
+    result = _make_source_and_call_snapshot(
         auth_credentials={"access_key_id": "env:AWS_KEY", "secret_access_key": "env:AWS_SECRET"},
     )
     assert result["auth_credentials"] == {
@@ -44,33 +56,33 @@ def test_snapshot_redacts_auth_credentials_values():
 @pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
 def test_snapshot_preserves_keys_for_audit():
     """Key additions/removals must be visible in diffs; values are not."""
-    result = _make_source_with_snapshot_method(auth_credentials={"token": "env:FOO"})
+    result = _make_source_and_call_snapshot(auth_credentials={"token": "env:FOO"})
     assert "token" in result["auth_credentials"]
     assert result["auth_credentials"]["token"] == "<redacted>"
 
 
 @pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
 def test_snapshot_redacts_legacy_reference():
-    result = _make_source_with_snapshot_method(auth_ref="env:OLD_TOKEN")
+    result = _make_source_and_call_snapshot(auth_ref="env:OLD_TOKEN")
     assert result["auth_credentials_reference"] == "<redacted>"
 
 
 @pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
 def test_snapshot_leaves_empty_reference_empty():
-    result = _make_source_with_snapshot_method(auth_ref="")
+    result = _make_source_and_call_snapshot(auth_ref="")
     assert result["auth_credentials_reference"] == ""
 
 
 @pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
 def test_snapshot_empty_credentials_dict_stays_empty():
-    result = _make_source_with_snapshot_method(auth_credentials={})
+    result = _make_source_and_call_snapshot(auth_credentials={})
     assert result["auth_credentials"] == {}
 
 
 @pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
 def test_snapshot_never_leaks_env_var_names():
     """Full security assertion: no env var name must appear in the snapshot."""
-    result = _make_source_with_snapshot_method(
+    result = _make_source_and_call_snapshot(
         auth_credentials={"token": "env:SUPER_SECRET_VAR_NAME"},
         auth_ref="env:ANOTHER_SECRET",
     )

--- a/tests/test_external_source_snapshot.py
+++ b/tests/test_external_source_snapshot.py
@@ -1,0 +1,79 @@
+"""Unit tests for ExternalSource.snapshot() credential scrubbing."""
+
+import importlib.util
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+try:
+    _spec = importlib.util.find_spec("netbox")
+    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    _NETBOX_AVAILABLE = False
+
+
+def _make_source_with_snapshot_method(auth_credentials=None, auth_ref=""):
+    """Build a mocked ExternalSource-like object with the real snapshot() override."""
+    from netbox_ssl.models.external_source import ExternalSource
+
+    source = MagicMock(spec=ExternalSource)
+    source.auth_credentials = auth_credentials or {}
+    source.auth_credentials_reference = auth_ref
+    base_snapshot = {
+        "name": "test-source",
+        "auth_credentials": source.auth_credentials,
+        "auth_credentials_reference": source.auth_credentials_reference,
+    }
+    with patch("netbox_ssl.models.external_source.NetBoxModel.snapshot", return_value=base_snapshot):
+        return ExternalSource.snapshot(source)
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_snapshot_redacts_auth_credentials_values():
+    result = _make_source_with_snapshot_method(
+        auth_credentials={"access_key_id": "env:AWS_KEY", "secret_access_key": "env:AWS_SECRET"},
+    )
+    assert result["auth_credentials"] == {
+        "access_key_id": "<redacted>",
+        "secret_access_key": "<redacted>",
+    }
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_snapshot_preserves_keys_for_audit():
+    """Key additions/removals must be visible in diffs; values are not."""
+    result = _make_source_with_snapshot_method(auth_credentials={"token": "env:FOO"})
+    assert "token" in result["auth_credentials"]
+    assert result["auth_credentials"]["token"] == "<redacted>"
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_snapshot_redacts_legacy_reference():
+    result = _make_source_with_snapshot_method(auth_ref="env:OLD_TOKEN")
+    assert result["auth_credentials_reference"] == "<redacted>"
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_snapshot_leaves_empty_reference_empty():
+    result = _make_source_with_snapshot_method(auth_ref="")
+    assert result["auth_credentials_reference"] == ""
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_snapshot_empty_credentials_dict_stays_empty():
+    result = _make_source_with_snapshot_method(auth_credentials={})
+    assert result["auth_credentials"] == {}
+
+
+@pytest.mark.skipif(not _NETBOX_AVAILABLE, reason="NetBox not available locally (tests run in Docker CI)")
+def test_snapshot_never_leaks_env_var_names():
+    """Full security assertion: no env var name must appear in the snapshot."""
+    result = _make_source_with_snapshot_method(
+        auth_credentials={"token": "env:SUPER_SECRET_VAR_NAME"},
+        auth_ref="env:ANOTHER_SECRET",
+    )
+    snapshot_repr = str(result)
+    assert "SUPER_SECRET_VAR_NAME" not in snapshot_repr
+    assert "ANOTHER_SECRET" not in snapshot_repr

--- a/tests/test_external_source_validator.py
+++ b/tests/test_external_source_validator.py
@@ -1,0 +1,281 @@
+"""Unit tests for ExternalSourceSchemaValidator."""
+
+import importlib.util
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Mock Django/NetBox before importing plugin code
+# ---------------------------------------------------------------------------
+try:
+    _spec = importlib.util.find_spec("netbox")
+    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    _NETBOX_AVAILABLE = False
+
+if not _NETBOX_AVAILABLE:
+    for _mod in [
+        "django",
+        "django.conf",
+        "django.db",
+        "django.db.models",
+        "django.db.models.functions",
+        "django.utils",
+        "django.utils.timezone",
+        "django.utils.translation",
+        "django.contrib",
+        "django.contrib.contenttypes",
+        "django.contrib.contenttypes.fields",
+        "django.contrib.contenttypes.models",
+        "django.contrib.postgres",
+        "django.contrib.postgres.fields",
+        "django.contrib.postgres.indexes",
+        "django.core",
+        "django.core.exceptions",
+        "django.urls",
+        "netbox",
+        "netbox.models",
+        "netbox.plugins",
+        "utilities",
+        "utilities.choices",
+    ]:
+        sys.modules.setdefault(_mod, MagicMock())
+
+    # ValidationError needs a real class so pytest.raises() can catch it by type.
+    class _FakeValidationError(Exception):
+        """Minimal stand-in for django.core.exceptions.ValidationError."""
+
+        def __init__(self, message, *args, **kwargs):
+            self.message = message
+            if isinstance(message, dict):
+                self.message_dict = message
+            super().__init__(str(message))
+
+    sys.modules["django.core.exceptions"].ValidationError = _FakeValidationError
+
+pytestmark = pytest.mark.unit
+
+
+def test_validator_accepts_valid_lemur_config():
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    ExternalSourceSchemaValidator.validate(
+        source_type="lemur",
+        auth_method="bearer",
+        auth_credentials={"token": "env:LEMUR_TOKEN"},
+    )  # should not raise
+
+
+def test_validator_accepts_valid_generic_rest_api_key():
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    ExternalSourceSchemaValidator.validate(
+        source_type="generic_rest",
+        auth_method="api_key",
+        auth_credentials={"token": "env:MY_API_KEY"},
+    )
+
+
+def test_validator_rejects_unknown_source_type():
+    from django.core.exceptions import ValidationError
+
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        ExternalSourceSchemaValidator.validate(
+            source_type="totally_made_up",
+            auth_method="bearer",
+            auth_credentials={},
+        )
+    assert "source_type" in str(exc.value)
+
+
+def test_validator_rejects_auth_method_not_supported():
+    from django.core.exceptions import ValidationError
+
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        ExternalSourceSchemaValidator.validate(
+            source_type="lemur",
+            auth_method="aws_explicit",  # not supported by Lemur
+            auth_credentials={},
+        )
+    assert "does not support" in str(exc.value)
+
+
+def test_validator_rejects_unknown_credential_keys():
+    from django.core.exceptions import ValidationError
+
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        ExternalSourceSchemaValidator.validate(
+            source_type="lemur",
+            auth_method="bearer",
+            auth_credentials={"token": "env:OK", "extra": "env:UNEXPECTED"},
+        )
+    assert "Unknown credential keys" in str(exc.value)
+
+
+def test_validator_rejects_missing_required_credential():
+    from django.core.exceptions import ValidationError
+
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        ExternalSourceSchemaValidator.validate(
+            source_type="lemur",
+            auth_method="bearer",
+            auth_credentials={},  # token missing
+        )
+    assert "Missing required credential" in str(exc.value)
+
+
+def test_validator_rejects_non_string_reference():
+    from django.core.exceptions import ValidationError
+
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    with pytest.raises(ValidationError):
+        ExternalSourceSchemaValidator.validate(
+            source_type="lemur",
+            auth_method="bearer",
+            auth_credentials={"token": 12345},
+        )
+
+
+def test_validator_rejects_unsupported_scheme():
+    from django.core.exceptions import ValidationError
+
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        ExternalSourceSchemaValidator.validate(
+            source_type="lemur",
+            auth_method="bearer",
+            auth_credentials={"token": "vault:secret/foo"},
+        )
+    assert "unsupported scheme" in str(exc.value).lower()
+
+
+def test_validator_accepts_bare_varname_as_env_ref():
+    """Backward-compat path: CredentialResolver treats bare strings as env vars."""
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    ExternalSourceSchemaValidator.validate(
+        source_type="lemur",
+        auth_method="bearer",
+        auth_credentials={"token": "LEGACY_BARE_VAR_NAME"},
+        base_url="https://example.com",
+    )  # should not raise
+
+
+def test_validator_rejects_empty_path_after_scheme():
+    """env: with nothing after must be rejected at form time."""
+    from django.core.exceptions import ValidationError
+
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        ExternalSourceSchemaValidator.validate(
+            source_type="lemur",
+            auth_method="bearer",
+            auth_credentials={"token": "env:"},
+            base_url="https://example.com",
+        )
+    assert "empty path" in str(exc.value).lower()
+
+
+def test_validator_rejects_invalid_env_var_name():
+    """Env var names must match ENV_VAR_PATTERN (uppercase, digits, underscore)."""
+    from django.core.exceptions import ValidationError
+
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    # lowercase letters not allowed
+    with pytest.raises(ValidationError) as exc:
+        ExternalSourceSchemaValidator.validate(
+            source_type="lemur",
+            auth_method="bearer",
+            auth_credentials={"token": "env:lowercase_var"},
+            base_url="https://example.com",
+        )
+    assert "valid environment variable name" in str(exc.value).lower()
+
+    # Hyphens not allowed
+    with pytest.raises(ValidationError):
+        ExternalSourceSchemaValidator.validate(
+            source_type="lemur",
+            auth_method="bearer",
+            auth_credentials={"token": "env:HAS-HYPHENS"},
+            base_url="https://example.com",
+        )
+
+
+def test_validator_rejects_missing_base_url_when_required():
+    """Lemur requires base_url — empty string must be rejected."""
+    from django.core.exceptions import ValidationError
+
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        ExternalSourceSchemaValidator.validate(
+            source_type="lemur",
+            auth_method="bearer",
+            auth_credentials={"token": "env:TOKEN"},
+            base_url="",  # missing
+        )
+    assert "base_url" in exc.value.message_dict
+
+
+def test_validator_accepts_base_url_omitted_when_not_required():
+    """AWS ACM (hypothetical) would have REQUIRES_BASE_URL=False. Since Task 3
+    set the default to True, this test uses LemurAdapter; intended behavior is
+    covered by Phase 2 once AWS adapter ships. Skeleton for coverage."""
+    # Phase 1 adapters (Lemur, Generic REST) all require base_url.
+    # This test is a placeholder for the AWS path; full assertion
+    # lives in #100's implementation PR.
+    pass
+
+
+def test_validator_does_not_require_region_for_lemur():
+    """region check only fires for adapters with REQUIRES_REGION = True."""
+    from netbox_ssl.utils.external_source_validator import (
+        ExternalSourceSchemaValidator,
+    )
+
+    # Should not raise — Lemur.REQUIRES_REGION is False (default).
+    ExternalSourceSchemaValidator.validate(
+        source_type="lemur",
+        auth_method="bearer",
+        auth_credentials={"token": "env:TOKEN"},
+        base_url="https://example.com",
+        region="",
+    )

--- a/tests/test_migration_0021.py
+++ b/tests/test_migration_0021.py
@@ -76,9 +76,9 @@ def test_migration_defines_expected_operations():
     module = _load_migration()
 
     operation_types = [type(op).__name__ for op in module.Migration.operations]
-    # Two AddFields (auth_credentials, region), one AlterField (base_url), one RunPython (backfill).
+    # Two AddFields (auth_credentials, region), two AlterFields (auth_method, base_url), one RunPython (backfill).
     assert operation_types.count("AddField") == 2
-    assert operation_types.count("AlterField") == 1
+    assert operation_types.count("AlterField") == 2
     assert operation_types.count("RunPython") == 1
 
 

--- a/tests/test_migration_0021.py
+++ b/tests/test_migration_0021.py
@@ -1,0 +1,98 @@
+"""Smoke test that migration 0021 exists and declares the expected operations.
+
+Full data-migration behavior is tested in the Docker integration suite
+(tests that run inside the NetBox container with a real Django DB).
+"""
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "netbox_ssl"
+    / "migrations"
+    / "0021_external_source_auth_credentials_and_region.py"
+)
+
+# ---------------------------------------------------------------------------
+# Guard: when running outside a NetBox container, stub out
+# netbox_ssl.models.external_source in sys.modules before the migration
+# module is imported. The migration does:
+#
+#   import netbox_ssl.models.external_source  # for validate_external_source_url
+#
+# Without the stub, importing the package triggers netbox_ssl/__init__.py
+# and the full Django model metaclass machinery, which requires a configured
+# Django settings environment.
+# ---------------------------------------------------------------------------
+try:
+    _spec = importlib.util.find_spec("netbox")
+    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    _NETBOX_AVAILABLE = False
+
+if not _NETBOX_AVAILABLE:
+    # Stub the external_source module with only what the migration references:
+    # the validate_external_source_url callable (used as a field validator).
+    def _stub_validate_external_source_url(value: str) -> None:  # noqa: D401
+        """Stub validator — no-op in unit test environment."""
+
+    _es_stub = MagicMock()
+    _es_stub.validate_external_source_url = _stub_validate_external_source_url
+
+    sys.modules.setdefault("netbox_ssl.models.external_source", _es_stub)
+
+    # Also ensure the package namespace resolves so attribute access
+    # `netbox_ssl.models.external_source` on the module object works.
+    _netbox_ssl_stub = sys.modules.get("netbox_ssl", MagicMock())
+    if not hasattr(_netbox_ssl_stub, "models"):
+        _netbox_ssl_stub.models = MagicMock()
+    _netbox_ssl_stub.models.external_source = _es_stub
+    sys.modules.setdefault("netbox_ssl", _netbox_ssl_stub)
+    sys.modules.setdefault("netbox_ssl.models", _netbox_ssl_stub.models)
+
+
+def _load_migration():
+    """Load the migration module via importlib, bypassing Django's app registry."""
+    spec = importlib.util.spec_from_file_location("mig0021", MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_migration_file_exists():
+    assert MIGRATION_PATH.is_file(), f"Migration not found at {MIGRATION_PATH}"
+
+
+def test_migration_defines_expected_operations():
+    module = _load_migration()
+
+    operation_types = [type(op).__name__ for op in module.Migration.operations]
+    # Two AddFields (auth_credentials, region), one AlterField (base_url), one RunPython (backfill).
+    assert operation_types.count("AddField") == 2
+    assert operation_types.count("AlterField") == 1
+    assert operation_types.count("RunPython") == 1
+
+
+def test_migration_adds_auth_credentials_and_region():
+    module = _load_migration()
+
+    addfield_names = [op.name for op in module.Migration.operations if type(op).__name__ == "AddField"]
+    assert set(addfield_names) == {"auth_credentials", "region"}
+
+
+def test_migration_depends_on_0020():
+    module = _load_migration()
+
+    assert (
+        "netbox_ssl",
+        "0020_compliancetrendsnapshot_netboxmodel_fields",
+    ) in module.Migration.dependencies

--- a/tests/test_migration_0021.py
+++ b/tests/test_migration_0021.py
@@ -14,12 +14,19 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
-MIGRATION_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "netbox_ssl"
-    / "migrations"
-    / "0021_external_source_auth_credentials_and_region.py"
-)
+
+def _get_plugin_source_dir():
+    """Find the netbox_ssl source directory (local or Docker CI)."""
+    local = Path(__file__).resolve().parent.parent / "netbox_ssl"
+    if local.is_dir():
+        return local
+    docker = Path("/opt/netbox/netbox/netbox_ssl")
+    if docker.is_dir():
+        return docker
+    return local
+
+
+MIGRATION_PATH = _get_plugin_source_dir() / "migrations" / "0021_external_source_auth_credentials_and_region.py"
 
 try:
     _spec = importlib.util.find_spec("netbox")

--- a/tests/test_migration_0021.py
+++ b/tests/test_migration_0021.py
@@ -21,46 +21,102 @@ MIGRATION_PATH = (
     / "0021_external_source_auth_credentials_and_region.py"
 )
 
-# ---------------------------------------------------------------------------
-# Guard: when running outside a NetBox container, stub out
-# netbox_ssl.models.external_source in sys.modules before the migration
-# module is imported. The migration does:
-#
-#   import netbox_ssl.models.external_source  # for validate_external_source_url
-#
-# Without the stub, importing the package triggers netbox_ssl/__init__.py
-# and the full Django model metaclass machinery, which requires a configured
-# Django settings environment.
-# ---------------------------------------------------------------------------
 try:
     _spec = importlib.util.find_spec("netbox")
     _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
 except (ValueError, ModuleNotFoundError):
     _NETBOX_AVAILABLE = False
 
-if not _NETBOX_AVAILABLE:
-    # Stub the external_source module with only what the migration references:
-    # the validate_external_source_url callable (used as a field validator).
-    def _stub_validate_external_source_url(value: str) -> None:  # noqa: D401
-        """Stub validator — no-op in unit test environment."""
 
-    _es_stub = MagicMock()
-    _es_stub.validate_external_source_url = _stub_validate_external_source_url
-
-    sys.modules.setdefault("netbox_ssl.models.external_source", _es_stub)
-
-    # Also ensure the package namespace resolves so attribute access
-    # `netbox_ssl.models.external_source` on the module object works.
-    _netbox_ssl_stub = sys.modules.get("netbox_ssl", MagicMock())
-    if not hasattr(_netbox_ssl_stub, "models"):
-        _netbox_ssl_stub.models = MagicMock()
-    _netbox_ssl_stub.models.external_source = _es_stub
-    sys.modules.setdefault("netbox_ssl", _netbox_ssl_stub)
-    sys.modules.setdefault("netbox_ssl.models", _netbox_ssl_stub.models)
+def _stub_validate_external_source_url(value: str) -> None:
+    """Stub validator — no-op in unit test environment."""
 
 
-def _load_migration():
-    """Load the migration module via importlib, bypassing Django's app registry."""
+@pytest.fixture
+def migration_module(monkeypatch):
+    """Load the migration module with fresh stubs (isolated per test).
+
+    This fixture ensures that sys.modules is clean for the migration exec
+    by force-replacing all relevant entries using monkeypatch.setitem().
+    Monkeypatch automatically restores values after the test, preventing
+    cross-file sys.modules contamination from earlier test runs.
+
+    Important: When other test modules (e.g. test_external_source) use
+    sys.modules.setdefault() to install MagicMocks for parent packages
+    like "django.db", those MagicMocks can interfere with attribute access
+    on submodules like "django.db.migrations". We must recreate the entire
+    parent hierarchy with real objects to avoid this pollution.
+    """
+    if not _NETBOX_AVAILABLE:
+        # Create real operation classes so migration operations have proper names
+        # Note: class names must be AlterField (not _AlterField) so type(op).__name__ works
+        class AlterField:
+            """Stub for migrations.AlterField."""
+
+            def __init__(self, **kwargs):
+                self.name = kwargs.get("name")
+
+        class AddField:
+            """Stub for migrations.AddField."""
+
+            def __init__(self, **kwargs):
+                self.name = kwargs.get("name")
+
+        class RunPython:
+            """Stub for migrations.RunPython."""
+
+            def __init__(self, func, *args, **kwargs):
+                self.code = func
+
+            @staticmethod
+            def noop(*args, **kwargs):
+                """Stub noop method."""
+                pass
+
+        class Migration:
+            """Stub Django Migration class."""
+
+            operations = []
+            dependencies = []
+
+        # Rebuild the django.db hierarchy to avoid MagicMock attribute pollution
+        _django_db = MagicMock()
+        _django_db_migrations = MagicMock()
+        _django_db_migrations.Migration = Migration
+        _django_db_migrations.AlterField = AlterField
+        _django_db_migrations.AddField = AddField
+        _django_db_migrations.RunPython = RunPython
+        _django_db.migrations = _django_db_migrations
+
+        monkeypatch.setitem(sys.modules, "django.db.migrations", _django_db_migrations)
+        monkeypatch.setitem(sys.modules, "django.db", _django_db)
+
+        # Create a fresh netbox.plugins.PluginConfig stub (required by netbox_ssl/__init__.py)
+        _netbox_plugins = MagicMock()
+
+        class _StubPluginConfig:
+            pass
+
+        _netbox_plugins.PluginConfig = _StubPluginConfig
+
+        # Force-install Django + NetBox stubs so netbox_ssl/__init__.py can import
+        monkeypatch.setitem(sys.modules, "netbox.plugins", _netbox_plugins)
+
+        # Create fresh external_source stub (required by the migration)
+        es_stub = MagicMock()
+        es_stub.validate_external_source_url = _stub_validate_external_source_url
+
+        monkeypatch.setitem(sys.modules, "netbox_ssl.models.external_source", es_stub)
+
+        # Ensure the package namespace resolves correctly for attribute access
+        netbox_ssl_stub = MagicMock()
+        models_stub = MagicMock()
+        models_stub.external_source = es_stub
+        netbox_ssl_stub.models = models_stub
+
+        monkeypatch.setitem(sys.modules, "netbox_ssl", netbox_ssl_stub)
+        monkeypatch.setitem(sys.modules, "netbox_ssl.models", models_stub)
+
     spec = importlib.util.spec_from_file_location("mig0021", MIGRATION_PATH)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -72,27 +128,21 @@ def test_migration_file_exists():
     assert MIGRATION_PATH.is_file(), f"Migration not found at {MIGRATION_PATH}"
 
 
-def test_migration_defines_expected_operations():
-    module = _load_migration()
-
-    operation_types = [type(op).__name__ for op in module.Migration.operations]
+def test_migration_defines_expected_operations(migration_module):
+    operation_types = [type(op).__name__ for op in migration_module.Migration.operations]
     # Two AddFields (auth_credentials, region), two AlterFields (auth_method, base_url), one RunPython (backfill).
     assert operation_types.count("AddField") == 2
     assert operation_types.count("AlterField") == 2
     assert operation_types.count("RunPython") == 1
 
 
-def test_migration_adds_auth_credentials_and_region():
-    module = _load_migration()
-
-    addfield_names = [op.name for op in module.Migration.operations if type(op).__name__ == "AddField"]
+def test_migration_adds_auth_credentials_and_region(migration_module):
+    addfield_names = [op.name for op in migration_module.Migration.operations if type(op).__name__ == "AddField"]
     assert set(addfield_names) == {"auth_credentials", "region"}
 
 
-def test_migration_depends_on_0020():
-    module = _load_migration()
-
+def test_migration_depends_on_0020(migration_module):
     assert (
         "netbox_ssl",
         "0020_compliancetrendsnapshot_netboxmodel_fields",
-    ) in module.Migration.dependencies
+    ) in migration_module.Migration.dependencies


### PR DESCRIPTION
## Summary

Implements Phase 1 of the multi-credential auth pattern spec (#99) — the infrastructure that unblocks AWS ACM (#100) and Azure Key Vault (#101) first-party adapters. No new adapters in this PR; only the storage, validation, and schema framework.

Spec: [docs/superpowers/specs/2026-04-21-multi-credential-auth-pattern-design.md](../blob/feature/99-multi-credential-auth/docs/superpowers/specs/2026-04-21-multi-credential-auth-pattern-design.md)

## What changes

- `ExternalSource.auth_credentials` JSONField — structured credential references.
- Four new `auth_method` values — `aws_explicit`, `aws_instance_role`, `azure_explicit`, `azure_managed_identity`.
- Per-adapter `credential_schema(auth_method)` classmethod with `CredentialField` metadata.
- `ExternalSourceSchemaValidator` — single source of truth for schema validation (form + serializer use it).
- `ExternalSourceForm` gains `auth_credentials` + `region` fields + schema-driven `clean()`.
- Migration 0021 — data-backfill from `auth_credentials_reference`; widens `auth_method` max_length to 30.
- Changelog snapshot — mutates `self._prechange_snapshot` in place to redact credential values while preserving key-level audit trail.
- GraphQL — `auth_credentials` excluded, `has_credentials` computed field added, `region` exposed.
- `auth_credentials_reference` deprecated (v2.0.0 removal target, tracked in ROADMAP §8.2).

## Backward compatibility

Zero operator action needed beyond `manage.py migrate`. Existing Lemur / Generic REST rows automatically get `auth_credentials = {"token": "env:..."}` from the backfill (migration 0021).

## Release target

v1.1.0 (infrastructure only). AWS ACM (#100) and Azure KV (#101) adapters land in follow-up PRs.

## Notable fixes discovered during integration smoke test

- **`auth_method` max_length bump** — the field was `max_length=20` but `azure_managed_identity` is 22 chars. Django system check raised `fields.E009`. Migration 0021 now includes an `AlterField` for `auth_method` that widens to 30.
- **`snapshot()` redaction contract fix** — initial implementation read from `super().snapshot()`'s return value, but `NetBoxModel.snapshot()` returns `None` and stores on `self._prechange_snapshot`. Rewritten to mutate `self._prechange_snapshot` in place. Verified in Docker: credential values no longer leak into changelog.
- **Test mock isolation** — migration smoke tests used `sys.modules.setdefault`, which silently no-oped when other test files had already populated `sys.modules`. Switched to `pytest` `monkeypatch` fixture for per-test isolation.

## Test plan

- [x] Ruff check + format pass on all 114 plugin files
- [x] `pytest tests/ -p no:django` — 907 passed, 142 skipped, 0 failed
- [x] Docker integration: migration applies idempotently (0021 runs clean on live NetBox 4.5); form validator smoke test passes (accepts Lemur+bearer, rejects Lemur+aws_explicit); snapshot redacts in `_prechange_snapshot`
- [ ] CI matrix: Integration v4.4 + v4.5 + Playwright E2E
- [ ] Bandit high/medium = 0 (run in CI)
- [ ] Gemini review