### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-17
+
+**Minor release** — External Source multi-credential auth, AWS ACM
+read-only adapter, and NetBox 4.6.x support. One additive migration
+(`0021`), one deprecation (`auth_credentials_reference`, removed in
+v2.0.0), no breaking changes.
+
 ### Added
 
 - **NetBox 4.6.x compatibility** ([#89](https://github.com/ctrl-alt-automate/netbox-ssl/issues/89)):

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "1.0.1"
+version = "1.1.0"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Release prep PR for **v1.1.0**. Version bump + CHANGELOG finalization only — all feature work is already merged to `dev` (PRs #105, #107, and the multi-credential auth work).

- `pyproject.toml` + `netbox_ssl/__init__.py`: 1.0.1 → 1.1.0
- `CHANGELOG.md`: `[Unreleased]` → `[1.1.0] - 2026-05-17`

## Release contents

| Feature | Issue | PR |
|---|---|---|
| NetBox 4.6.x support (Django 6.0) | #89 | #107 |
| Multi-credential auth pattern for External Sources | #99 | (on dev) |
| AWS ACM read-only adapter | #100 | #105 |

One additive migration (`0021`), one deprecation (`auth_credentials_reference`, removed in v2.0.0 per SemVer), no breaking changes → **minor** version bump.

## Verification

- NetBox 4.6 integration tests already green on #107 (Django 6.0 regression check passed)
- AWS ACM adapter: 56 unit tests, security review hardening applied (#105)
- `dev` CI green on both merge commits

## Test plan

- [ ] CI green on this PR (release branch)
- [ ] Admin-merge to `dev`
- [ ] Follow-up: `dev → main` PR, then tag `v1.1.0`