### PR TITLE
fix: v1.1.1 bug fixes — OpenAPI schema 500 (#111) and comments not saved (#112)

### DIFF
--- a/netbox_ssl/api/serializers/certificate_authorities.py
+++ b/netbox_ssl/api/serializers/certificate_authorities.py
@@ -32,6 +32,7 @@ class CertificateAuthoritySerializer(NetBoxModelSerializer):
             "renewal_instructions",
             "is_approved",
             "certificate_count",
+            "comments",
             "tags",
             "custom_fields",
             "created",

--- a/netbox_ssl/api/serializers/certificates.py
+++ b/netbox_ssl/api/serializers/certificates.py
@@ -98,6 +98,7 @@ class CertificateSerializer(NetBoxModelSerializer):
             "external_source",
             "external_id",
             "source_removed",
+            "comments",
             "tags",
             "custom_fields",
             "created",

--- a/netbox_ssl/api/serializers/csr.py
+++ b/netbox_ssl/api/serializers/csr.py
@@ -46,6 +46,7 @@ class CertificateSigningRequestSerializer(NetBoxModelSerializer):
             "notes",
             "resulting_certificate",
             "tenant",
+            "comments",
             "tags",
             "custom_fields",
             "created",

--- a/netbox_ssl/api/serializers/external_sources.py
+++ b/netbox_ssl/api/serializers/external_sources.py
@@ -59,6 +59,7 @@ class ExternalSourceSerializer(NetBoxModelSerializer):
             "last_sync_message",
             "verify_ssl",
             "certificate_count",
+            "comments",
             "tags",
             "custom_fields",
             "created",

--- a/netbox_ssl/filtersets/compliance.py
+++ b/netbox_ssl/filtersets/compliance.py
@@ -20,10 +20,10 @@ class CompliancePolicyFilterSet(NetBoxModelFilterSet):
 
     name = django_filters.CharFilter(lookup_expr="icontains")
     policy_type = django_filters.MultipleChoiceFilter(
-        choices=CompliancePolicyTypeChoices.CHOICES,
+        choices=CompliancePolicyTypeChoices,
     )
     severity = django_filters.MultipleChoiceFilter(
-        choices=ComplianceSeverityChoices.CHOICES,
+        choices=ComplianceSeverityChoices,
     )
     enabled = django_filters.BooleanFilter()
     tenant_id = django_filters.NumberFilter()
@@ -65,11 +65,11 @@ class ComplianceCheckFilterSet(NetBoxModelFilterSet):
         lookup_expr="icontains",
     )
     result = django_filters.MultipleChoiceFilter(
-        choices=ComplianceResultChoices.CHOICES,
+        choices=ComplianceResultChoices,
     )
     severity = django_filters.MultipleChoiceFilter(
         field_name="policy__severity",
-        choices=ComplianceSeverityChoices.CHOICES,
+        choices=ComplianceSeverityChoices,
     )
     checked_after = django_filters.DateTimeFilter(
         field_name="checked_at",

--- a/netbox_ssl/migrations/0022_add_comments_fields.py
+++ b/netbox_ssl/migrations/0022_add_comments_fields.py
@@ -1,0 +1,35 @@
+"""Add the NetBox-standard ``comments`` field to CertificateAuthority and
+ExternalSource (issue #112).
+
+The edit forms for Certificate, CertificateAuthority, CertificateSigningRequest
+and ExternalSource all declared ``comments = CommentField()``, but the *models*
+never declared a matching field, so input was silently dropped on save.
+
+The Certificate (migration 0001) and CertificateSigningRequest (migration 0003)
+tables already carry a historical ``comments`` column — only the model field
+was missing, so re-declaring it on the model is enough for those two (no schema
+change). CertificateAuthority and ExternalSource have no such column, so it is
+added here. ``null=True`` matches the historical column definition and keeps the
+migration safe on existing installs (no NOT NULL backfill).
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_ssl", "0021_external_source_auth_credentials_and_region"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="certificateauthority",
+            name="comments",
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="externalsource",
+            name="comments",
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/netbox_ssl/models/certificate_authorities.py
+++ b/netbox_ssl/models/certificate_authorities.py
@@ -86,6 +86,10 @@ class CertificateAuthority(NetBoxModel):
         help_text="Whether this CA is approved for use in the organization",
     )
 
+    # Free-form comments (NetBox standard field; surfaced via CommentField in the form).
+    # null=True for consistency with the historical comments columns (0001/0003).
+    comments = models.TextField(blank=True, null=True)
+
     class Meta:
         ordering = ["name"]
         verbose_name = "Certificate Authority"

--- a/netbox_ssl/models/certificates.py
+++ b/netbox_ssl/models/certificates.py
@@ -223,6 +223,11 @@ class Certificate(NetBoxModel):
         help_text="Custom renewal instructions for this specific certificate. Overrides CA-level instructions.",
     )
 
+    # Free-form comments (NetBox standard field; surfaced via CommentField in the form).
+    # null=True matches the historical column from migration 0001 and avoids a
+    # risky NOT NULL alter on existing installs.
+    comments = models.TextField(blank=True, null=True)
+
     # Renewal tracking (Janus workflow)
     replaced_by = models.ForeignKey(
         "self",

--- a/netbox_ssl/models/csr.py
+++ b/netbox_ssl/models/csr.py
@@ -77,6 +77,11 @@ class CertificateSigningRequest(NetBoxModel):
         help_text="Requested Subject Alternative Names (DNS names, IPs, etc.)",
     )
 
+    # Free-form comments (NetBox standard field; surfaced via CommentField in the form).
+    # null=True matches the historical column from migration 0003 and avoids a
+    # risky NOT NULL alter on existing installs.
+    comments = models.TextField(blank=True, null=True)
+
     # Key information
     key_size = models.PositiveIntegerField(
         null=True,

--- a/netbox_ssl/models/external_source.py
+++ b/netbox_ssl/models/external_source.py
@@ -222,6 +222,10 @@ class ExternalSource(NetBoxModel):
         ),
     )
 
+    # Free-form comments (NetBox standard field; surfaced via CommentField in the form).
+    # null=True for consistency with the historical comments columns (0001/0003).
+    comments = models.TextField(blank=True, null=True)
+
     class Meta:
         ordering = ["name"]
         verbose_name = "External Source"

--- a/netbox_ssl/templates/netbox_ssl/certificate.html
+++ b/netbox_ssl/templates/netbox_ssl/certificate.html
@@ -119,6 +119,12 @@
   </div>
 </div>
 
+<div class="row mb-3">
+  <div class="col col-12">
+    {% include 'inc/panels/comments.html' %}
+  </div>
+</div>
+
 {% if object.is_acme %}
 <div class="row mb-3">
   <div class="col col-12">

--- a/netbox_ssl/templates/netbox_ssl/certificateauthority.html
+++ b/netbox_ssl/templates/netbox_ssl/certificateauthority.html
@@ -163,4 +163,9 @@
 </div>
 {% endif %}
 
+<div class="row mb-3">
+  <div class="col col-12">
+    {% include 'inc/panels/comments.html' %}
+  </div>
+</div>
 {% endblock content %}

--- a/netbox_ssl/templates/netbox_ssl/certificatesigningrequest.html
+++ b/netbox_ssl/templates/netbox_ssl/certificatesigningrequest.html
@@ -157,4 +157,9 @@
 </div>
 {% endif %}
 
+<div class="row mb-3">
+  <div class="col col-12">
+    {% include 'inc/panels/comments.html' %}
+  </div>
+</div>
 {% endblock content %}

--- a/netbox_ssl/templates/netbox_ssl/externalsource.html
+++ b/netbox_ssl/templates/netbox_ssl/externalsource.html
@@ -201,4 +201,9 @@
 </div>
 {% endif %}
 
+<div class="row mb-3">
+  <div class="col col-12">
+    {% include 'inc/panels/comments.html' %}
+  </div>
+</div>
 {% endblock content %}

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -1,0 +1,110 @@
+"""
+Regression tests for OpenAPI (drf-spectacular) schema generation — issue #111.
+
+NetBox 4.6's ``core/api/schema.py`` made ``/api/schema/`` (the REST API
+Swagger UI) crash with ``ValueError: too many values to unpack (expected 2,
+got 3)`` whenever a plugin FilterSet declared a ``MultipleChoiceFilter`` with a
+*raw* colored ChoiceSet list (``SomeChoiceSet.CHOICES`` — 3-tuples of
+``(value, label, color)``). drf-spectacular's ``_get_explicit_filter_choices``
+does ``[c for c, _ in filter_field.extra['choices']]`` and cannot unpack
+3-tuples, which aborts generation of the *entire* schema — so installing the
+plugin broke Swagger for the whole NetBox instance.
+
+Two guards:
+
+1. ``test_openapi_schema_generation_succeeds`` — builds the full schema exactly
+   like the ``/api/schema/`` endpoint; this reproduced #111 (it raised) and now
+   must succeed.
+2. ``test_plugin_filtersets_choices_are_spectacular_safe`` — a fast, targeted
+   guard asserting every plugin filter's choices are either *callable* (a
+   ChoiceSet class) or plain 2-tuples — never raw colored 3-tuples.
+
+These require a real NetBox/Django environment and run inside the Docker
+integration job; they skip elsewhere.
+"""
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Allow importing the plugin package directly.
+_project_root = Path(__file__).parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+_in_netbox_env = os.path.exists("/opt/netbox/netbox/netbox/settings.py") or "DJANGO_SETTINGS_MODULE" in os.environ
+
+if _in_netbox_env:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
+
+    with contextlib.suppress(RuntimeError):
+        django.setup()
+    NETBOX_AVAILABLE = True
+else:
+    NETBOX_AVAILABLE = False
+
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox not available - run these tests inside the Docker container",
+)
+
+
+@requires_netbox
+def test_openapi_schema_generation_succeeds():
+    """The full OpenAPI schema must generate without raising (regression #111).
+
+    Before the fix, ``SchemaGenerator.get_schema`` raised ``ValueError: too
+    many values to unpack (expected 2, got 3)`` while resolving the compliance
+    filterset's choice parameters, taking down ``/api/schema/`` entirely.
+    """
+    from drf_spectacular.generators import SchemaGenerator
+
+    generator = SchemaGenerator()
+    schema = generator.get_schema(request=None, public=True)
+
+    assert schema, "schema generation returned an empty document"
+    paths = schema.get("paths", {})
+    ssl_paths = [p for p in paths if "/plugins/ssl/" in p]
+    assert ssl_paths, "no netbox_ssl paths present in the generated OpenAPI schema"
+
+
+@requires_netbox
+def test_plugin_filtersets_choices_are_spectacular_safe():
+    """No plugin filter may expose raw colored (3-tuple) choices (#111).
+
+    drf-spectacular's ``_get_explicit_filter_choices`` skips *callable* choices
+    (a ChoiceSet class) but unpacks non-callable choices as 2-tuples. Passing
+    ``ChoiceSet.CHOICES`` (which include a colour) therefore crashes schema
+    generation. Always pass the ChoiceSet *class*, not ``.CHOICES``.
+    """
+    import inspect
+
+    import django_filters
+
+    from netbox_ssl import filtersets as ssl_filtersets
+
+    filterset_classes = [
+        obj
+        for _, obj in inspect.getmembers(ssl_filtersets, inspect.isclass)
+        if issubclass(obj, django_filters.FilterSet) and obj.__module__.startswith("netbox_ssl")
+    ]
+    assert filterset_classes, "no plugin FilterSet classes were discovered"
+
+    offenders = []
+    for fs_class in filterset_classes:
+        for field_name, filter_field in fs_class.base_filters.items():
+            choices = getattr(filter_field, "extra", {}).get("choices")
+            if choices is None or callable(choices):
+                continue
+            for entry in choices:
+                if not (isinstance(entry, (list, tuple)) and len(entry) == 2):
+                    offenders.append(f"{fs_class.__name__}.{field_name} -> {entry!r}")
+
+    assert not offenders, (
+        "Filter choices must be a callable ChoiceSet class or 2-tuples so "
+        "drf-spectacular can build the schema; offending filters: " + "; ".join(offenders)
+    )

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -35,17 +35,20 @@ _project_root = Path(__file__).parent.parent
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-_in_netbox_env = os.path.exists("/opt/netbox/netbox/netbox/settings.py") or "DJANGO_SETTINGS_MODULE" in os.environ
+import importlib.util
 
-if _in_netbox_env:
+try:
+    _spec = importlib.util.find_spec("netbox")
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
+
+if NETBOX_AVAILABLE:
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
     import django
 
-    with contextlib.suppress(RuntimeError):
+    with contextlib.suppress(Exception):
         django.setup()
-    NETBOX_AVAILABLE = True
-else:
-    NETBOX_AVAILABLE = False
 
 requires_netbox = pytest.mark.skipif(
     not NETBOX_AVAILABLE,

--- a/tests/test_bulk_import.py
+++ b/tests/test_bulk_import.py
@@ -390,6 +390,13 @@ def django_api_available():
         if not settings.configured:
             return False
 
+        # These tests hit the API + DB in-process and need pytest-django for
+        # proper test-database isolation. Without it they mutate the live DB
+        # and previously only skipped by accident (sys.modules contamination).
+        # Require pytest-django so they skip *deterministically* until it is
+        # adopted (tracked follow-up) instead of erroring in the suite.
+        import pytest_django  # noqa: F401
+
         # Try to import REST framework test client
         from django.contrib.auth import get_user_model  # noqa: F401
         from rest_framework.test import APIClient  # noqa: F401

--- a/tests/test_bulk_operations.py
+++ b/tests/test_bulk_operations.py
@@ -1,341 +1,132 @@
 """
-Unit tests for bulk operations serializers.
+Tests for the bulk-operations serializers (BulkStatusUpdateSerializer,
+BulkAssignSerializer).
 
-Tests the BulkStatusUpdateSerializer and BulkAssignSerializer field
-definitions and class structure without requiring a running NetBox instance
-or djangorestframework installed.
+NOTE (test-hardening, v1.1.1): this file previously exec'd the serializer
+source with hand-built *fake* DRF field classes and asserted on those fakes via
+class-attribute access (``Serializer.field.kwargs``). That only ever exercised
+the fakes — never the shipped serializers — and only "passed" in CI because an
+unrelated ``sys.modules`` mock contamination forced the fake code path. It
+therefore caught zero real bugs (false confidence).
+
+It now tests the **real** DRF serializers via the real field API
+(``serializer().fields``), so it actually validates the code that ships. This
+requires a real NetBox/DRF environment and runs in the Docker integration job;
+it skips elsewhere.
 """
 
-import importlib.util
+import contextlib
+import os
+import sys
 from pathlib import Path
-
-
-def _get_plugin_source_dir():
-    """Find the netbox_ssl source directory (local or Docker CI)."""
-    local = Path(__file__).resolve().parent.parent / "netbox_ssl"
-    if local.is_dir():
-        return local
-    docker = Path("/opt/netbox/netbox/netbox_ssl")
-    if docker.is_dir():
-        return docker
-    return local
-
-
-from types import ModuleType
-from unittest.mock import MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Mock Django/NetBox/DRF before importing plugin code
-# ---------------------------------------------------------------------------
+_root = Path(__file__).parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+import importlib.util
+
 try:
     _spec = importlib.util.find_spec("netbox")
-    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
-    if _NETBOX_AVAILABLE:
-        # Verify Django settings are actually configured (not just importable)
-        from django.conf import settings
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
 
-        _ = settings.USE_I18N  # noqa: F841
-except (ValueError, ModuleNotFoundError, Exception):
-    _NETBOX_AVAILABLE = False
+if NETBOX_AVAILABLE:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
 
+    with contextlib.suppress(Exception):
+        django.setup()
 
-def _load_serializer_classes() -> tuple:
-    """Load the bulk serializer classes from certificates.py.
-
-    In a non-NetBox environment (no DRF, no Django), we exec the module
-    source with injected fake base classes so the serializer class
-    definitions can be inspected without the full import chain.
-    """
-    if _NETBOX_AVAILABLE:
-        from netbox_ssl.api.serializers.certificates import (
-            BulkAssignSerializer,
-            BulkStatusUpdateSerializer,
-        )
-
-        return BulkStatusUpdateSerializer, BulkAssignSerializer
-
-    # --- Fake DRF field classes ---
-
-    class _FakeSerializer:
-        """Minimal Serializer stand-in for class definition."""
-
-        def __init_subclass__(cls, **kwargs):
-            super().__init_subclass__(**kwargs)
-
-    class _FakeField:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-    class _FakeListField(_FakeField):
-        pass
-
-    class _FakeChoiceField(_FakeField):
-        pass
-
-    class _FakeCharField(_FakeField):
-        pass
-
-    class _FakeIntegerField(_FakeField):
-        pass
-
-    class _FakeBooleanField(_FakeField):
-        pass
-
-    class _FakeHyperlinkedIdentityField(_FakeField):
-        pass
-
-    class _FakeSerializerMethodField(_FakeField):
-        pass
-
-    class _FakePrimaryKeyRelatedField(_FakeField):
-        pass
-
-    class _FakeValidationError(Exception):
-        pass
-
-    class _FakeNetBoxModelSerializer(_FakeSerializer):
-        class Meta:
-            pass
-
-        def __init__(self, *args, **kwargs):
-            pass
-
-    class _FakeStatusChoices:
-        STATUS_ACTIVE = "active"
-        STATUS_EXPIRED = "expired"
-        STATUS_REPLACED = "replaced"
-        STATUS_REVOKED = "revoked"
-        STATUS_PENDING = "pending"
-
-    # Build a fake serializers module for the `from rest_framework import serializers` line
-    rf_serializers_mod = ModuleType("rest_framework.serializers")
-    rf_serializers_mod.Serializer = _FakeSerializer
-    rf_serializers_mod.ListField = _FakeListField
-    rf_serializers_mod.ChoiceField = _FakeChoiceField
-    rf_serializers_mod.CharField = _FakeCharField
-    rf_serializers_mod.IntegerField = _FakeIntegerField
-    rf_serializers_mod.BooleanField = _FakeBooleanField
-    rf_serializers_mod.HyperlinkedIdentityField = _FakeHyperlinkedIdentityField
-    rf_serializers_mod.SerializerMethodField = _FakeSerializerMethodField
-    rf_serializers_mod.PrimaryKeyRelatedField = _FakePrimaryKeyRelatedField
-    rf_serializers_mod.ValidationError = _FakeValidationError
-
-    # Prepare namespace with all imports pre-resolved
-    namespace: dict = {
-        "__name__": "netbox_ssl.api.serializers.certificates",
-        "__package__": "netbox_ssl.api.serializers",
-        "NetBoxModelSerializer": _FakeNetBoxModelSerializer,
-        "serializers": rf_serializers_mod,
-        "TenantSerializer": type("TenantSerializer", (_FakeNetBoxModelSerializer,), {}),
-        "Tenant": MagicMock(),
-        "Certificate": MagicMock(),
-        "CertificateStatusChoices": _FakeStatusChoices,
-        "CertificateParseError": Exception,
-        "CertificateParser": MagicMock(),
-        "detect_issuing_ca": MagicMock(),
-        "CertificateAuthoritySerializer": type("CertificateAuthoritySerializer", (_FakeNetBoxModelSerializer,), {}),
-        "ExternalSourceSerializer": type("ExternalSourceSerializer", (_FakeNetBoxModelSerializer,), {}),
-    }
-
-    # Read the source and strip import lines so our injected names are used
-    source_path = _get_plugin_source_dir() / "api" / "serializers" / "certificates.py"
-    if not source_path.exists():
-        # Docker CI: tests at /tmp/plugin_tests/, plugin at /opt/netbox/netbox/netbox_ssl/
-        source_path = Path("/opt/netbox/netbox/netbox_ssl/api/serializers/certificates.py")
-    source = source_path.read_text()
-
-    lines = source.split("\n")
-    filtered: list[str] = []
-    in_import = False
-    for line in lines:
-        stripped = line.strip()
-        # Detect start of import block
-        if stripped.startswith("from ") or stripped.startswith("import "):
-            in_import = True
-            # Single-line import
-            if "(" not in stripped or ")" in stripped:
-                in_import = False
-            continue
-        # Inside multi-line import
-        if in_import:
-            if ")" in stripped:
-                in_import = False
-            continue
-        filtered.append(line)
-
-    clean_source = "\n".join(filtered)
-    exec(compile(clean_source, str(source_path), "exec"), namespace)  # noqa: S102
-
-    return namespace["BulkStatusUpdateSerializer"], namespace["BulkAssignSerializer"]
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox/DRF not available - run these tests inside the Docker container",
+)
 
 
-BulkStatusUpdateSerializer, BulkAssignSerializer = _load_serializer_classes()
+def _fields(serializer_cls):
+    """Return the bound DRF fields (name -> Field) for a serializer class."""
+    return serializer_cls().fields
 
 
-# ---------------------------------------------------------------------------
-# Tests: BulkStatusUpdateSerializer
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
+@requires_netbox
 class TestBulkStatusUpdateSerializer:
-    """Tests for BulkStatusUpdateSerializer field definitions."""
+    """Field-level checks against the real BulkStatusUpdateSerializer."""
 
-    def test_has_ids_field(self) -> None:
-        """Serializer defines an 'ids' field."""
-        assert hasattr(BulkStatusUpdateSerializer, "ids")
+    def _fields(self):
+        from netbox_ssl.api.serializers import BulkStatusUpdateSerializer
 
-    def test_ids_field_is_list_field(self) -> None:
-        """The 'ids' field is a ListField."""
-        field = BulkStatusUpdateSerializer.ids
-        assert "ListField" in type(field).__name__
+        return _fields(BulkStatusUpdateSerializer)
 
-    def test_ids_field_has_child_integer(self) -> None:
-        """The 'ids' ListField child is an IntegerField."""
-        field = BulkStatusUpdateSerializer.ids
-        child = field.kwargs.get("child")
-        assert child is not None
-        assert "IntegerField" in type(child).__name__
+    def test_has_ids_and_status_fields(self):
+        from rest_framework import serializers
 
-    def test_ids_field_disallows_empty(self) -> None:
-        """The 'ids' field does not allow empty lists."""
-        field = BulkStatusUpdateSerializer.ids
-        assert field.kwargs.get("allow_empty") is False
+        fields = self._fields()
+        assert "ids" in fields
+        assert "status" in fields
+        assert isinstance(fields["ids"], serializers.ListField)
+        assert isinstance(fields["status"], serializers.ChoiceField)
 
-    def test_has_status_field(self) -> None:
-        """Serializer defines a 'status' field."""
-        assert hasattr(BulkStatusUpdateSerializer, "status")
+    def test_ids_is_integer_list_disallowing_empty(self):
+        from rest_framework import serializers
 
-    def test_status_field_is_choice_field(self) -> None:
-        """The 'status' field is a ChoiceField."""
-        field = BulkStatusUpdateSerializer.status
-        assert "ChoiceField" in type(field).__name__
+        ids = self._fields()["ids"]
+        assert isinstance(ids.child, serializers.IntegerField)
+        assert ids.allow_empty is False
+        assert ids.help_text
 
-    def test_status_field_has_choices(self) -> None:
-        """The 'status' ChoiceField has choices configured."""
-        field = BulkStatusUpdateSerializer.status
-        assert "choices" in field.kwargs
+    def test_status_choices_match_certificate_status_choices(self):
+        from netbox_ssl.models import CertificateStatusChoices
 
-    def test_status_field_choices_reference_status_choices(self) -> None:
-        """The 'status' ChoiceField references CertificateStatusChoices."""
-        field = BulkStatusUpdateSerializer.status
-        choices = field.kwargs["choices"]
-        # Should reference our fake status choices class
-        assert hasattr(choices, "STATUS_ACTIVE")
-
-    def test_ids_field_has_help_text(self) -> None:
-        """The 'ids' field has help_text."""
-        field = BulkStatusUpdateSerializer.ids
-        assert field.kwargs.get("help_text")
-
-    def test_status_field_has_help_text(self) -> None:
-        """The 'status' field has help_text."""
-        field = BulkStatusUpdateSerializer.status
-        assert field.kwargs.get("help_text")
-
-    def test_class_has_both_required_fields(self) -> None:
-        """BulkStatusUpdateSerializer has both 'ids' and 'status' fields."""
-        assert hasattr(BulkStatusUpdateSerializer, "ids")
-        assert hasattr(BulkStatusUpdateSerializer, "status")
+        status = self._fields()["status"]
+        expected = {c[0] for c in CertificateStatusChoices.CHOICES}
+        assert set(status.choices.keys()) == expected
+        assert status.help_text
 
 
-# ---------------------------------------------------------------------------
-# Tests: BulkAssignSerializer
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
+@requires_netbox
 class TestBulkAssignSerializer:
-    """Tests for BulkAssignSerializer field definitions."""
+    """Field-level checks against the real BulkAssignSerializer."""
 
-    def test_has_certificate_ids_field(self) -> None:
-        """Serializer defines a 'certificate_ids' field."""
-        assert hasattr(BulkAssignSerializer, "certificate_ids")
+    def _fields(self):
+        from netbox_ssl.api.serializers import BulkAssignSerializer
 
-    def test_certificate_ids_is_list_field(self) -> None:
-        """The 'certificate_ids' field is a ListField."""
-        field = BulkAssignSerializer.certificate_ids
-        assert "ListField" in type(field).__name__
+        return _fields(BulkAssignSerializer)
 
-    def test_certificate_ids_has_child_integer(self) -> None:
-        """The 'certificate_ids' ListField child is an IntegerField."""
-        field = BulkAssignSerializer.certificate_ids
-        child = field.kwargs.get("child")
-        assert child is not None
-        assert "IntegerField" in type(child).__name__
+    def test_has_all_four_expected_fields(self):
+        fields = self._fields()
+        assert set(fields) >= {"certificate_ids", "assigned_object_type", "assigned_object_id", "is_primary"}
 
-    def test_certificate_ids_disallows_empty(self) -> None:
-        """The 'certificate_ids' field does not allow empty lists."""
-        field = BulkAssignSerializer.certificate_ids
-        assert field.kwargs.get("allow_empty") is False
+    def test_certificate_ids_is_integer_list_disallowing_empty(self):
+        from rest_framework import serializers
 
-    def test_has_assigned_object_type_field(self) -> None:
-        """Serializer defines an 'assigned_object_type' field."""
-        assert hasattr(BulkAssignSerializer, "assigned_object_type")
+        cert_ids = self._fields()["certificate_ids"]
+        assert isinstance(cert_ids, serializers.ListField)
+        assert isinstance(cert_ids.child, serializers.IntegerField)
+        assert cert_ids.allow_empty is False
+        assert cert_ids.help_text
 
-    def test_assigned_object_type_is_char_field(self) -> None:
-        """The 'assigned_object_type' field is a CharField."""
-        field = BulkAssignSerializer.assigned_object_type
-        assert "CharField" in type(field).__name__
+    def test_assigned_object_type_is_char_field(self):
+        from rest_framework import serializers
 
-    def test_has_assigned_object_id_field(self) -> None:
-        """Serializer defines an 'assigned_object_id' field."""
-        assert hasattr(BulkAssignSerializer, "assigned_object_id")
+        field = self._fields()["assigned_object_type"]
+        assert isinstance(field, serializers.CharField)
+        assert "content type" in (field.help_text or "").lower()
 
-    def test_assigned_object_id_is_integer_field(self) -> None:
-        """The 'assigned_object_id' field is an IntegerField."""
-        field = BulkAssignSerializer.assigned_object_id
-        assert "IntegerField" in type(field).__name__
+    def test_assigned_object_id_is_integer_field(self):
+        from rest_framework import serializers
 
-    def test_has_is_primary_field(self) -> None:
-        """Serializer defines an 'is_primary' field."""
-        assert hasattr(BulkAssignSerializer, "is_primary")
+        field = self._fields()["assigned_object_id"]
+        assert isinstance(field, serializers.IntegerField)
+        assert field.help_text
 
-    def test_is_primary_is_boolean_field(self) -> None:
-        """The 'is_primary' field is a BooleanField."""
-        field = BulkAssignSerializer.is_primary
-        assert "BooleanField" in type(field).__name__
+    def test_is_primary_is_boolean_defaulting_true(self):
+        from rest_framework import serializers
 
-    def test_is_primary_defaults_to_true(self) -> None:
-        """The 'is_primary' field defaults to True."""
-        field = BulkAssignSerializer.is_primary
-        assert field.kwargs.get("default") is True
-
-    def test_certificate_ids_has_help_text(self) -> None:
-        """The 'certificate_ids' field has help_text."""
-        field = BulkAssignSerializer.certificate_ids
-        assert field.kwargs.get("help_text")
-
-    def test_assigned_object_type_has_help_text(self) -> None:
-        """The 'assigned_object_type' field has help_text."""
-        field = BulkAssignSerializer.assigned_object_type
-        assert field.kwargs.get("help_text")
-
-    def test_assigned_object_id_has_help_text(self) -> None:
-        """The 'assigned_object_id' field has help_text."""
-        field = BulkAssignSerializer.assigned_object_id
-        assert field.kwargs.get("help_text")
-
-    def test_is_primary_has_help_text(self) -> None:
-        """The 'is_primary' field has help_text."""
-        field = BulkAssignSerializer.is_primary
-        assert field.kwargs.get("help_text")
-
-    def test_has_all_four_expected_fields(self) -> None:
-        """BulkAssignSerializer has all four expected fields."""
-        expected_fields = [
-            "certificate_ids",
-            "assigned_object_type",
-            "assigned_object_id",
-            "is_primary",
-        ]
-        for field_name in expected_fields:
-            assert hasattr(BulkAssignSerializer, field_name), f"Missing field: {field_name}"
-
-    def test_assigned_object_type_help_text_mentions_content_types(self) -> None:
-        """The help_text for assigned_object_type mentions supported types."""
-        field = BulkAssignSerializer.assigned_object_type
-        help_text = field.kwargs.get("help_text", "")
-        assert "dcim.device" in help_text or "content type" in help_text.lower()
+        field = self._fields()["is_primary"]
+        assert isinstance(field, serializers.BooleanField)
+        assert field.default is True
+        assert field.help_text

--- a/tests/test_comments_field.py
+++ b/tests/test_comments_field.py
@@ -25,17 +25,20 @@ _project_root = Path(__file__).parent.parent
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-_in_netbox_env = os.path.exists("/opt/netbox/netbox/netbox/settings.py") or "DJANGO_SETTINGS_MODULE" in os.environ
+import importlib.util
 
-if _in_netbox_env:
+try:
+    _spec = importlib.util.find_spec("netbox")
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
+
+if NETBOX_AVAILABLE:
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
     import django
 
-    with contextlib.suppress(RuntimeError):
+    with contextlib.suppress(Exception):
         django.setup()
-    NETBOX_AVAILABLE = True
-else:
-    NETBOX_AVAILABLE = False
 
 requires_netbox = pytest.mark.skipif(
     not NETBOX_AVAILABLE,

--- a/tests/test_comments_field.py
+++ b/tests/test_comments_field.py
@@ -1,0 +1,91 @@
+"""
+Regression tests for the ``comments`` field — issue #112.
+
+The edit forms for Certificate, CertificateAuthority, CertificateSigningRequest
+and ExternalSource declared ``comments = CommentField()`` and listed
+``"comments"`` in their fieldsets, but the models inherit ``NetBoxModel`` —
+which (unlike ``PrimaryModel``) does NOT provide a ``comments`` column. So the
+field rendered and accepted input, but the value was silently discarded on
+save ("comments are not retained after save").
+
+These tests assert the field now exists on every affected model, that each
+form's ``comments`` maps onto a real model field (so it persists), and that the
+API serializers expose it. They require a real NetBox/Django environment and
+run inside the Docker integration job; they skip elsewhere.
+"""
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_project_root = Path(__file__).parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+_in_netbox_env = os.path.exists("/opt/netbox/netbox/netbox/settings.py") or "DJANGO_SETTINGS_MODULE" in os.environ
+
+if _in_netbox_env:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
+
+    with contextlib.suppress(RuntimeError):
+        django.setup()
+    NETBOX_AVAILABLE = True
+else:
+    NETBOX_AVAILABLE = False
+
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox not available - run these tests inside the Docker container",
+)
+
+# Model import path, form class name, serializer class name for each affected model.
+_AFFECTED = [
+    ("Certificate", "CertificateForm", "CertificateSerializer"),
+    ("CertificateAuthority", "CertificateAuthorityForm", "CertificateAuthoritySerializer"),
+    ("CertificateSigningRequest", "CertificateSigningRequestForm", "CertificateSigningRequestSerializer"),
+    ("ExternalSource", "ExternalSourceForm", "ExternalSourceSerializer"),
+]
+
+
+@requires_netbox
+@pytest.mark.parametrize("model_name", [m for m, _, _ in _AFFECTED])
+def test_model_has_comments_field(model_name):
+    """Every affected model must define a real ``comments`` column (#112)."""
+    import netbox_ssl.models as models_mod
+
+    model = getattr(models_mod, model_name)
+    field_names = {f.name for f in model._meta.get_fields()}
+    assert "comments" in field_names, f"{model_name} is missing a 'comments' model field (#112)"
+
+
+@requires_netbox
+@pytest.mark.parametrize("model_name,form_name", [(m, f) for m, f, _ in _AFFECTED])
+def test_form_comments_maps_to_model(model_name, form_name):
+    """The form's ``comments`` field must map onto a model field so it persists.
+
+    This is the exact #112 failure mode: ``comments`` was present in the form
+    but absent from the model, so it never saved.
+    """
+    import netbox_ssl.forms as forms_mod
+
+    form_cls = getattr(forms_mod, form_name)
+    form = form_cls()
+    assert "comments" in form.fields, f"{form_name} does not expose a comments field"
+    model_field_names = {f.name for f in form._meta.model._meta.get_fields()}
+    assert "comments" in model_field_names, (
+        f"{form_name}.comments has no backing model field — it will not persist (#112)"
+    )
+
+
+@requires_netbox
+@pytest.mark.parametrize("serializer_name", [s for _, _, s in _AFFECTED])
+def test_serializer_exposes_comments(serializer_name):
+    """The REST API serializers must expose ``comments`` for read/write parity."""
+    import netbox_ssl.api.serializers as serializers_mod
+
+    serializer_cls = getattr(serializers_mod, serializer_name)
+    assert "comments" in serializer_cls().fields, f"{serializer_name} does not expose 'comments'"


### PR DESCRIPTION
## Summary

Two release-blocking bugs reported on v1.1.0, both detectable without any certificate data (they trigger purely from loading the plugin).

### #111 — `/api/schema/` returns 500 (Swagger UI broken on NetBox 4.6)
The compliance FilterSets passed the raw colored ChoiceSet list (`SomeChoiceSet.CHOICES` — 3-tuples of `(value, label, color)`) to `MultipleChoiceFilter`. drf-spectacular's `_get_explicit_filter_choices` does `[c for c, _ in choices]`, which can't unpack 3-tuples, so on NetBox 4.6 it raised `ValueError: too many values to unpack` and aborted generation of the **entire** OpenAPI schema. Every other filterset passed the ChoiceSet **class** (callable → spectacular skips it); only compliance used `.CHOICES`. Fix: pass the class.

### #112 — Comments are not retained after save
The edit forms declared `comments = CommentField()`, but the models inherit `NetBoxModel`, which (unlike `PrimaryModel`) has no `comments` column — a phantom field whose input was silently dropped on save. Fix: declare `comments` on Certificate/CA/CSR/ExternalSource (migration `0022` adds the column for CA + ExternalSource; Certificate/CSR already had a leftover column from 0001/0003), expose it in the REST serializers, and render a Comments panel on the detail pages.

## Test plan

- ✅ New regression tests `tests/test_api_schema.py` (full OpenAPI schema generation + filter-choice safety guard) and `tests/test_comments_field.py` (model/form/serializer field parity) — **14 tests pass** on NetBox 4.6.0.
- ✅ `manage.py spectacular --validate` → **0 errors** on NetBox 4.6.0.
- ✅ Migration `0022` applies cleanly; `makemigrations netbox_ssl --check` is clean for the `comments` field.
- ✅ `ruff check` + `ruff format --check` clean.

CI/test hardening to catch this class of bug earlier ships in a follow-up PR (stacked on this one).

Closes #111
Closes #112
