### PR TITLE
ci: test & CI hardening to catch the #111/#112 bug classes before release (v1.1.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,9 @@ jobs:
       - name: Copy tests to container
         run: |
           docker cp tests/. $(docker compose ps -q netbox):/tmp/plugin_tests/
+          # Ship the plugin's pytest.ini so the in-container run uses the
+          # plugin's (strict) marker config, not NetBox's own.
+          docker cp pytest.ini $(docker compose ps -q netbox):/tmp/plugin_tests/pytest.ini
 
       - name: Create test data
         run: |
@@ -296,6 +299,30 @@ jobs:
       - name: Run Django system checks
         run: |
           docker compose exec -T netbox /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py check --tag netbox_ssl
+
+      - name: Validate OpenAPI schema (#111 regression gate)
+        run: |
+          # Regenerates the exact document served by /api/schema/ (Swagger UI).
+          # A serializer/filterset that drf-spectacular cannot introspect fails
+          # HERE instead of 500-ing in production — this is precisely how #111
+          # shipped undetected. Runs on every NetBox version in the matrix.
+          docker compose exec -T netbox /opt/netbox/venv/bin/python \
+            /opt/netbox/netbox/manage.py spectacular --file /tmp/schema.yml --validate
+          echo "OpenAPI schema generated and validated successfully."
+
+      - name: Regression gates must run (not skip) (#111/#112)
+        run: |
+          # Run the targeted regression tests in an isolated invocation and
+          # assert they actually executed. A silently-skipped @requires_netbox
+          # test is not a gate — a silent skip is how #111 stayed invisible.
+          NB=$(docker compose ps -q netbox)
+          docker compose exec -T netbox /opt/netbox/venv/bin/python -m pytest \
+            /tmp/plugin_tests/test_api_schema.py /tmp/plugin_tests/test_comments_field.py \
+            /tmp/plugin_tests/test_field_parity.py /tmp/plugin_tests/test_security_invariants.py \
+            -o addopts='' -p no:cacheprovider --junitxml=/tmp/reg.xml -q
+          docker cp "$NB":/tmp/reg.xml reg.xml
+          python3 -m pip install --quiet defusedxml 2>/dev/null || true
+          python3 scripts/assert_tests_ran.py reg.xml
 
       - name: Show logs on failure
         if: failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,42 @@ permissions:
   contents: write
 
 jobs:
+  verify-ci:
+    name: Require a passing CI run for this commit
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Require CI success before publishing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # A tag push publishes to PyPI. Without this gate a release ships even
+          # if CI is red — which is exactly how #111/#112 reached v1.1.0. Require
+          # the CI workflow for this commit to have concluded successfully.
+          sha="${GITHUB_SHA}"
+          echo "Requiring a successful 'CI' run for commit $sha before publishing."
+          for i in $(seq 1 30); do
+            status=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow CI --commit "$sha" --json status -q '.[0].status' 2>/dev/null || true)
+            concl=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow CI --commit "$sha" --json conclusion -q '.[0].conclusion' 2>/dev/null || true)
+            echo "attempt $i: status='${status}' conclusion='${concl}'"
+            if [ "$status" = "completed" ]; then
+              if [ "$concl" = "success" ]; then
+                echo "CI passed for $sha — proceeding to publish."
+                exit 0
+              fi
+              echo "::error::CI for $sha concluded '${concl}' (not success). Refusing to publish."
+              exit 1
+            fi
+            sleep 20
+          done
+          echo "::error::Timed out waiting for CI to complete for $sha. Re-run this workflow once CI is green."
+          exit 1
+
   publish:
     name: Build and publish to PyPI
+    needs: verify-ci
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,16 +72,6 @@ netbox_ssl = [
     "static/**/*",
 ]
 
-[tool.pytest.ini_options]
-markers = [
-    "unit: marks tests as unit tests (fast, no external dependencies)",
-    "api: marks tests as API integration tests (requires running NetBox)",
-    "browser: marks tests as browser tests (requires running NetBox and Playwright)",
-]
-testpaths = ["tests"]
-python_files = ["test_*.py"]
-python_functions = ["test_*"]
-
 [tool.ruff]
 line-length = 120
 target-version = "py310"

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,9 +4,10 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 testpaths = tests
-addopts = -v --tb=short
+addopts = -v --tb=short --strict-markers
 markers =
     unit: Unit tests (no database required)
     integration: Integration tests (database required)
+    api: API integration tests (requires running NetBox + token)
     browser: Browser tests (Playwright)
     slow: Slow running tests

--- a/scripts/assert_tests_ran.py
+++ b/scripts/assert_tests_ran.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Fail CI if a pytest JUnit XML shows zero tests, or any skipped/failed/errored.
+
+Used by the integration job to guarantee the #111/#112 regression gates
+actually EXECUTE. A ``@requires_netbox`` test that silently *skips* is not a
+gate — a silent skip is exactly how the #111 schema crash stayed invisible in
+CI. This turns "ran 0 / all skipped" into a hard failure.
+
+Usage: python scripts/assert_tests_ran.py <junit-xml-path>
+"""
+
+import sys
+
+# Prefer defusedxml (hardened against XXE / billion-laughs). The input here is
+# our own pytest-generated JUnit XML (trusted), but use the safe parser when
+# available and fall back to stdlib only if defusedxml is not installed.
+try:
+    from defusedxml import ElementTree as ET
+except ImportError:  # pragma: no cover - defusedxml may be absent locally
+    import xml.etree.ElementTree as ET
+
+
+def main(path: str) -> int:
+    root = ET.parse(path).getroot()
+    suites = root.findall("testsuite") or [root]
+    tests = sum(int(s.get("tests", 0)) for s in suites)
+    skipped = sum(int(s.get("skipped", 0)) for s in suites)
+    failures = sum(int(s.get("failures", 0)) for s in suites)
+    errors = sum(int(s.get("errors", 0)) for s in suites)
+
+    problems = []
+    if tests == 0:
+        problems.append("zero tests ran")
+    if skipped:
+        problems.append(f"{skipped} skipped (regression gates must run, not skip)")
+    if failures:
+        problems.append(f"{failures} failed")
+    if errors:
+        problems.append(f"{errors} errored")
+
+    if problems:
+        print("Regression gate check FAILED: " + "; ".join(problems), file=sys.stderr)
+        return 1
+    print(f"Regression gate check OK: {tests} tests ran; 0 skipped, 0 failed, 0 errored.")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: assert_tests_ran.py <junit-xml-path>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/tests/test_field_parity.py
+++ b/tests/test_field_parity.py
@@ -1,0 +1,99 @@
+"""
+Generic model<->form field-parity guard — generalizes issue #112.
+
+#112 shipped because the certificate edit form declared ``comments =
+CommentField()`` but the model (a ``NetBoxModel``, not ``PrimaryModel``) had no
+``comments`` column. Django ModelForms allow *declared* (class-attribute)
+fields that don't map to the model — they are simply dropped on save. So the
+field rendered, accepted input, and silently lost it.
+
+``test_comments_field.py`` covers the four models that had the bug by name.
+This test generalizes the guard: for EVERY plugin ``ModelForm``, every declared
+field must resolve to a real model field (or be an allow-listed virtual field).
+The next phantom field on any model is then caught automatically.
+
+Requires a real NetBox/Django environment; runs in the Docker integration job.
+"""
+
+import contextlib
+import inspect
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_root = Path(__file__).parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+import importlib.util
+
+try:
+    _spec = importlib.util.find_spec("netbox")
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
+
+if NETBOX_AVAILABLE:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
+
+    with contextlib.suppress(Exception):
+        django.setup()
+
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox not available - run these tests inside the Docker container",
+)
+
+# Declared form fields that legitimately do NOT map to a concrete model field.
+# Keep this list short and documented — every entry is a deliberate exception,
+# and the whole point of the test is that NEW unexplained entries are bugs.
+ALLOWED_NON_MODEL_FORM_FIELDS = {
+    "tags",  # NetBox TagField — virtual, persisted via the tagging framework, not a column
+    "_init_time",  # injected by NetBox's NetBoxModelForm (concurrency/timing); not a model field
+    "changelog_message",  # injected by NetBox's NetBoxModelForm (changelog note); not a model field
+    # CertificateAssignmentForm's GenericForeignKey target selectors. These are
+    # intentional virtual fields resolved to assigned_object_type/id in the
+    # form's clean()/save(); they deliberately have no own column.
+    "device",
+    "virtual_machine",
+    "service",
+}
+
+
+def _plugin_modelforms():
+    from django.forms import ModelForm
+
+    import netbox_ssl.forms as forms_mod
+
+    return [
+        cls
+        for _, cls in inspect.getmembers(forms_mod, inspect.isclass)
+        if issubclass(cls, ModelForm)
+        and (cls.__module__ or "").startswith("netbox_ssl")
+        and getattr(getattr(cls, "_meta", None), "model", None) is not None
+    ]
+
+
+@requires_netbox
+def test_every_modelform_declared_field_backs_onto_a_model_field():
+    """No plugin ModelForm may declare a field with no backing model column (#112)."""
+    forms = _plugin_modelforms()
+    assert forms, "no plugin ModelForms were discovered"
+
+    phantom = []
+    for form_cls in forms:
+        model = form_cls._meta.model
+        model_field_names = {f.name for f in model._meta.get_fields()}
+        for field_name, field in form_cls.declared_fields.items():
+            if field_name in model_field_names or field_name in ALLOWED_NON_MODEL_FORM_FIELDS:
+                continue
+            phantom.append(f"{form_cls.__name__}.{field_name} ({type(field).__name__})")
+
+    assert not phantom, (
+        "Form fields with no backing model column will be silently dropped on save (#112). "
+        "Add the field to the model (+ migration) or to ALLOWED_NON_MODEL_FORM_FIELDS with a "
+        "comment if it is a genuine virtual field. Offenders: " + "; ".join(phantom)
+    )

--- a/tests/test_security_invariants.py
+++ b/tests/test_security_invariants.py
@@ -1,0 +1,106 @@
+"""
+Regression tests for security invariants that previously had ZERO coverage.
+
+This plugin is the source of truth for TLS-certificate metadata, so a handful
+of security controls must never silently regress:
+
+1. CSV formula-injection sanitization (``CertificateExporter._sanitize_csv_value``)
+   — an exported CSV opened in a spreadsheet must not execute injected formulas.
+2. Custom (non-NetBox-generic) views must enforce authentication via
+   ``LoginRequiredMixin`` — a dropped mixin would expose a view to anonymous
+   users. (NetBox's own generic views carry their own object-permission
+   enforcement and are excluded.)
+
+Requires a real NetBox/Django environment; runs in the Docker integration job.
+"""
+
+import contextlib
+import importlib
+import importlib.util
+import inspect
+import os
+import pkgutil
+import sys
+from pathlib import Path
+
+import pytest
+
+_root = Path(__file__).parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+try:
+    _spec = importlib.util.find_spec("netbox")
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
+
+if NETBOX_AVAILABLE:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
+
+    with contextlib.suppress(Exception):
+        django.setup()
+
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox not available - run these tests inside the Docker container",
+)
+
+# Spreadsheet formula-trigger characters (mirrors CertificateExporter._FORMULA_CHARS).
+_FORMULA_CHARS = ["=", "+", "-", "@", "\t", "\r"]
+
+
+@requires_netbox
+@pytest.mark.parametrize("trigger", _FORMULA_CHARS)
+def test_csv_value_with_formula_char_is_neutralized(trigger):
+    """A value starting with a formula trigger must be prefixed with a quote."""
+    from netbox_ssl.utils.export import CertificateExporter
+
+    payload = f"{trigger}cmd|'/bin/calc'!A0"
+    sanitized = CertificateExporter._sanitize_csv_value(payload)
+    assert sanitized == "'" + payload, f"value starting with {trigger!r} was not neutralized: {sanitized!r}"
+
+
+@requires_netbox
+def test_csv_safe_values_are_unchanged():
+    """Non-formula values must pass through untouched."""
+    from netbox_ssl.utils.export import CertificateExporter
+
+    for safe in ["example.com", "CN=Test CA", "", "2048", "RSA"]:
+        assert CertificateExporter._sanitize_csv_value(safe) == safe
+
+
+@requires_netbox
+def test_custom_views_require_login():
+    """Every custom (non-NetBox-generic) view must include LoginRequiredMixin.
+
+    NetBox's generic Object*View classes enforce object permissions themselves;
+    our bespoke TemplateView/View subclasses (analytics, compliance report,
+    certificate map, import/renew flows) must not be reachable anonymously.
+    """
+    from django.contrib.auth.mixins import LoginRequiredMixin
+    from django.views.generic.base import View
+
+    import netbox_ssl.views as views_pkg
+
+    missing = []
+    seen = set()
+    for mod_info in pkgutil.iter_modules(views_pkg.__path__):
+        module = importlib.import_module(f"netbox_ssl.views.{mod_info.name}")
+        for name, cls in inspect.getmembers(module, inspect.isclass):
+            if cls in seen:
+                continue
+            seen.add(cls)
+            if not issubclass(cls, View):
+                continue
+            if not (cls.__module__ or "").startswith("netbox_ssl"):
+                continue
+            # NetBox generic views (ObjectView/ObjectEditView/...) carry their own
+            # ObjectPermissionRequiredMixin — they are not our responsibility.
+            if any("netbox.views.generic" in (base.__module__ or "") for base in cls.__mro__):
+                continue
+            if LoginRequiredMixin not in cls.__mro__:
+                missing.append(f"{cls.__module__}.{name}")
+
+    assert not missing, f"custom views missing LoginRequiredMixin (anonymous access risk): {missing}"


### PR DESCRIPTION
## Summary

v1.1.1 **test & CI hardening** so the bug *classes* behind #111 (OpenAPI schema crash) and #112 (model/form field drift) are caught before release. Stacked on #114 (the bug fixes themselves).

### Added gates
- **OpenAPI schema gate (#111 class):** `manage.py spectacular --validate` runs on every NetBox version (4.4/4.5/4.6). A serializer/filterset drf-spectacular can't introspect now fails CI instead of 500-ing `/api/schema/` in production.
- **Non-skippable regression gate:** the #111/#112 regression tests run in an isolated step and `scripts/assert_tests_ran.py` fails the build if any were *skipped* — a silently-skipped `@requires_netbox` test is exactly how #111 stayed invisible.
- **Publish gate:** `publish.yml` now requires a green CI run for the tagged commit before releasing to PyPI. Previously a tag push published regardless of CI status — the systemic gap that let #111/#112 ship.
- **Generalized hardening tests:** `tests/test_field_parity.py` (catches *any* phantom form field, generalizing #112) and `tests/test_security_invariants.py` (CSV formula-injection sanitization + custom views enforce `LoginRequiredMixin` — both previously had zero coverage).
- **pytest config:** one strict `pytest.ini` (registers all markers incl. the previously-unregistered `integration`, adds `--strict-markers`); removes the dead `[tool.pytest.ini_options]` block from `pyproject.toml`.

### Deferred (tracked follow-up)
Widening the host unit job to `-m unit` is **not** in this PR: the existing ~40 mock-based test files contaminate each other's `sys.modules` at collection time (813 errors when run together host-side). That needs a dedicated test-isolation refactor (guard the mocks / adopt `pytest-django` / per-file process isolation) — out of scope for a patch.

### Verification (NetBox 4.6.0, in-container)
- Full suite: **967 passed, 149 skipped, 0 failed**.
- `spectacular --validate`: exit 0. Regression gate (4 files): 23 passed, 0 skipped.
- `ruff check` + `ruff format --check`: clean.

> Base is `fix/v1.1.1-bugfixes` (stacked on #114) so this diff shows only the hardening. Merge #114 first; GitHub will retarget this to `dev`.
