### PR TITLE
Release v1.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,9 @@ jobs:
       - name: Copy tests to container
         run: |
           docker cp tests/. $(docker compose ps -q netbox):/tmp/plugin_tests/
+          # Ship the plugin's pytest.ini so the in-container run uses the
+          # plugin's (strict) marker config, not NetBox's own.
+          docker cp pytest.ini $(docker compose ps -q netbox):/tmp/plugin_tests/pytest.ini
 
       - name: Create test data
         run: |
@@ -296,6 +299,30 @@ jobs:
       - name: Run Django system checks
         run: |
           docker compose exec -T netbox /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py check --tag netbox_ssl
+
+      - name: Validate OpenAPI schema (#111 regression gate)
+        run: |
+          # Regenerates the exact document served by /api/schema/ (Swagger UI).
+          # A serializer/filterset that drf-spectacular cannot introspect fails
+          # HERE instead of 500-ing in production — this is precisely how #111
+          # shipped undetected. Runs on every NetBox version in the matrix.
+          docker compose exec -T netbox /opt/netbox/venv/bin/python \
+            /opt/netbox/netbox/manage.py spectacular --file /tmp/schema.yml --validate
+          echo "OpenAPI schema generated and validated successfully."
+
+      - name: Regression gates must run (not skip) (#111/#112)
+        run: |
+          # Run the targeted regression tests in an isolated invocation and
+          # assert they actually executed. A silently-skipped @requires_netbox
+          # test is not a gate — a silent skip is how #111 stayed invisible.
+          NB=$(docker compose ps -q netbox)
+          docker compose exec -T netbox /opt/netbox/venv/bin/python -m pytest \
+            /tmp/plugin_tests/test_api_schema.py /tmp/plugin_tests/test_comments_field.py \
+            /tmp/plugin_tests/test_field_parity.py /tmp/plugin_tests/test_security_invariants.py \
+            -o addopts='' -p no:cacheprovider --junitxml=/tmp/reg.xml -q
+          docker cp "$NB":/tmp/reg.xml reg.xml
+          python3 -m pip install --quiet defusedxml 2>/dev/null || true
+          python3 scripts/assert_tests_ran.py reg.xml
 
       - name: Show logs on failure
         if: failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,42 @@ permissions:
   contents: write
 
 jobs:
+  verify-ci:
+    name: Require a passing CI run for this commit
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Require CI success before publishing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # A tag push publishes to PyPI. Without this gate a release ships even
+          # if CI is red — which is exactly how #111/#112 reached v1.1.0. Require
+          # the CI workflow for this commit to have concluded successfully.
+          sha="${GITHUB_SHA}"
+          echo "Requiring a successful 'CI' run for commit $sha before publishing."
+          for i in $(seq 1 30); do
+            status=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow CI --commit "$sha" --json status -q '.[0].status' 2>/dev/null || true)
+            concl=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow CI --commit "$sha" --json conclusion -q '.[0].conclusion' 2>/dev/null || true)
+            echo "attempt $i: status='${status}' conclusion='${concl}'"
+            if [ "$status" = "completed" ]; then
+              if [ "$concl" = "success" ]; then
+                echo "CI passed for $sha — proceeding to publish."
+                exit 0
+              fi
+              echo "::error::CI for $sha concluded '${concl}' (not success). Refusing to publish."
+              exit 1
+            fi
+            sleep 20
+          done
+          echo "::error::Timed out waiting for CI to complete for $sha. Re-run this workflow once CI is green."
+          exit 1
+
   publish:
     name: Build and publish to PyPI
+    needs: verify-ci
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-29
+
+**Patch release** — two bug fixes for issues reported on v1.1.0, plus a test &
+CI hardening pass to catch this class of bug before release. One additive
+migration (`0022`), no breaking changes.
+
+### Fixed
+
+- **`/api/schema/` (Swagger UI) returned HTTP 500 on NetBox 4.6** ([#111](https://github.com/ctrl-alt-automate/netbox-ssl/issues/111)):
+  the compliance FilterSets passed a raw colored `ChoiceSet.CHOICES` list
+  (3-tuples of `value, label, color`) to `MultipleChoiceFilter`. drf-spectacular
+  cannot unpack 3-tuple choices, which aborted generation of the **entire**
+  OpenAPI schema for any install with the plugin enabled — even with zero
+  certificates. Now passes the ChoiceSet class, consistent with every other
+  filterset.
+- **Certificate comments were not retained after save** ([#112](https://github.com/ctrl-alt-automate/netbox-ssl/issues/112)):
+  the edit forms exposed a `comments` field but the models (which inherit
+  `NetBoxModel`, not `PrimaryModel`) had no `comments` column, so input was
+  silently discarded. Added a real `comments` field to `Certificate`,
+  `CertificateAuthority`, `CertificateSigningRequest` and `ExternalSource`
+  (migration `0022`, additive), exposed it in the REST API, and rendered a
+  Comments panel on the detail pages.
+
+### Changed
+
+- **Test & CI hardening** to catch the #111/#112 bug classes before release: an
+  OpenAPI schema-generation gate (`spectacular --validate`) on every supported
+  NetBox version; a non-skippable regression gate; `publish.yml` now requires a
+  passing CI run for the tagged commit before releasing to PyPI; a single
+  strict pytest configuration; and new generalized tests for form↔model field
+  parity and security invariants (CSV-injection sanitization, view
+  authentication). Several pre-existing serializer tests were rewritten to
+  exercise the real DRF serializers instead of hand-built fakes. Follow-ups
+  tracked in [#116](https://github.com/ctrl-alt-automate/netbox-ssl/issues/116)–[#119](https://github.com/ctrl-alt-automate/netbox-ssl/issues/119).
+
 ## [1.1.0] - 2026-05-17
 
 **Minor release** — External Source multi-credential auth, AWS ACM
@@ -577,7 +612,9 @@ Initial release of NetBox SSL Plugin.
 - NetBox 4.4.0 - 4.5.x
 - Python 3.10+
 
-[Unreleased]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v1.0.1...v1.1.0
 [0.7.0]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/ctrl-alt-automate/netbox-ssl/compare/v0.5.0...v0.5.1

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/netbox_ssl/api/serializers/certificate_authorities.py
+++ b/netbox_ssl/api/serializers/certificate_authorities.py
@@ -32,6 +32,7 @@ class CertificateAuthoritySerializer(NetBoxModelSerializer):
             "renewal_instructions",
             "is_approved",
             "certificate_count",
+            "comments",
             "tags",
             "custom_fields",
             "created",

--- a/netbox_ssl/api/serializers/certificates.py
+++ b/netbox_ssl/api/serializers/certificates.py
@@ -98,6 +98,7 @@ class CertificateSerializer(NetBoxModelSerializer):
             "external_source",
             "external_id",
             "source_removed",
+            "comments",
             "tags",
             "custom_fields",
             "created",

--- a/netbox_ssl/api/serializers/csr.py
+++ b/netbox_ssl/api/serializers/csr.py
@@ -46,6 +46,7 @@ class CertificateSigningRequestSerializer(NetBoxModelSerializer):
             "notes",
             "resulting_certificate",
             "tenant",
+            "comments",
             "tags",
             "custom_fields",
             "created",

--- a/netbox_ssl/api/serializers/external_sources.py
+++ b/netbox_ssl/api/serializers/external_sources.py
@@ -59,6 +59,7 @@ class ExternalSourceSerializer(NetBoxModelSerializer):
             "last_sync_message",
             "verify_ssl",
             "certificate_count",
+            "comments",
             "tags",
             "custom_fields",
             "created",

--- a/netbox_ssl/filtersets/compliance.py
+++ b/netbox_ssl/filtersets/compliance.py
@@ -20,10 +20,10 @@ class CompliancePolicyFilterSet(NetBoxModelFilterSet):
 
     name = django_filters.CharFilter(lookup_expr="icontains")
     policy_type = django_filters.MultipleChoiceFilter(
-        choices=CompliancePolicyTypeChoices.CHOICES,
+        choices=CompliancePolicyTypeChoices,
     )
     severity = django_filters.MultipleChoiceFilter(
-        choices=ComplianceSeverityChoices.CHOICES,
+        choices=ComplianceSeverityChoices,
     )
     enabled = django_filters.BooleanFilter()
     tenant_id = django_filters.NumberFilter()
@@ -65,11 +65,11 @@ class ComplianceCheckFilterSet(NetBoxModelFilterSet):
         lookup_expr="icontains",
     )
     result = django_filters.MultipleChoiceFilter(
-        choices=ComplianceResultChoices.CHOICES,
+        choices=ComplianceResultChoices,
     )
     severity = django_filters.MultipleChoiceFilter(
         field_name="policy__severity",
-        choices=ComplianceSeverityChoices.CHOICES,
+        choices=ComplianceSeverityChoices,
     )
     checked_after = django_filters.DateTimeFilter(
         field_name="checked_at",

--- a/netbox_ssl/migrations/0022_add_comments_fields.py
+++ b/netbox_ssl/migrations/0022_add_comments_fields.py
@@ -1,0 +1,35 @@
+"""Add the NetBox-standard ``comments`` field to CertificateAuthority and
+ExternalSource (issue #112).
+
+The edit forms for Certificate, CertificateAuthority, CertificateSigningRequest
+and ExternalSource all declared ``comments = CommentField()``, but the *models*
+never declared a matching field, so input was silently dropped on save.
+
+The Certificate (migration 0001) and CertificateSigningRequest (migration 0003)
+tables already carry a historical ``comments`` column — only the model field
+was missing, so re-declaring it on the model is enough for those two (no schema
+change). CertificateAuthority and ExternalSource have no such column, so it is
+added here. ``null=True`` matches the historical column definition and keeps the
+migration safe on existing installs (no NOT NULL backfill).
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_ssl", "0021_external_source_auth_credentials_and_region"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="certificateauthority",
+            name="comments",
+            field=models.TextField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="externalsource",
+            name="comments",
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/netbox_ssl/models/certificate_authorities.py
+++ b/netbox_ssl/models/certificate_authorities.py
@@ -86,6 +86,10 @@ class CertificateAuthority(NetBoxModel):
         help_text="Whether this CA is approved for use in the organization",
     )
 
+    # Free-form comments (NetBox standard field; surfaced via CommentField in the form).
+    # null=True for consistency with the historical comments columns (0001/0003).
+    comments = models.TextField(blank=True, null=True)
+
     class Meta:
         ordering = ["name"]
         verbose_name = "Certificate Authority"

--- a/netbox_ssl/models/certificates.py
+++ b/netbox_ssl/models/certificates.py
@@ -223,6 +223,11 @@ class Certificate(NetBoxModel):
         help_text="Custom renewal instructions for this specific certificate. Overrides CA-level instructions.",
     )
 
+    # Free-form comments (NetBox standard field; surfaced via CommentField in the form).
+    # null=True matches the historical column from migration 0001 and avoids a
+    # risky NOT NULL alter on existing installs.
+    comments = models.TextField(blank=True, null=True)
+
     # Renewal tracking (Janus workflow)
     replaced_by = models.ForeignKey(
         "self",

--- a/netbox_ssl/models/csr.py
+++ b/netbox_ssl/models/csr.py
@@ -77,6 +77,11 @@ class CertificateSigningRequest(NetBoxModel):
         help_text="Requested Subject Alternative Names (DNS names, IPs, etc.)",
     )
 
+    # Free-form comments (NetBox standard field; surfaced via CommentField in the form).
+    # null=True matches the historical column from migration 0003 and avoids a
+    # risky NOT NULL alter on existing installs.
+    comments = models.TextField(blank=True, null=True)
+
     # Key information
     key_size = models.PositiveIntegerField(
         null=True,

--- a/netbox_ssl/models/external_source.py
+++ b/netbox_ssl/models/external_source.py
@@ -222,6 +222,10 @@ class ExternalSource(NetBoxModel):
         ),
     )
 
+    # Free-form comments (NetBox standard field; surfaced via CommentField in the form).
+    # null=True for consistency with the historical comments columns (0001/0003).
+    comments = models.TextField(blank=True, null=True)
+
     class Meta:
         ordering = ["name"]
         verbose_name = "External Source"

--- a/netbox_ssl/templates/netbox_ssl/certificate.html
+++ b/netbox_ssl/templates/netbox_ssl/certificate.html
@@ -119,6 +119,12 @@
   </div>
 </div>
 
+<div class="row mb-3">
+  <div class="col col-12">
+    {% include 'inc/panels/comments.html' %}
+  </div>
+</div>
+
 {% if object.is_acme %}
 <div class="row mb-3">
   <div class="col col-12">

--- a/netbox_ssl/templates/netbox_ssl/certificateauthority.html
+++ b/netbox_ssl/templates/netbox_ssl/certificateauthority.html
@@ -163,4 +163,9 @@
 </div>
 {% endif %}
 
+<div class="row mb-3">
+  <div class="col col-12">
+    {% include 'inc/panels/comments.html' %}
+  </div>
+</div>
 {% endblock content %}

--- a/netbox_ssl/templates/netbox_ssl/certificatesigningrequest.html
+++ b/netbox_ssl/templates/netbox_ssl/certificatesigningrequest.html
@@ -157,4 +157,9 @@
 </div>
 {% endif %}
 
+<div class="row mb-3">
+  <div class="col col-12">
+    {% include 'inc/panels/comments.html' %}
+  </div>
+</div>
 {% endblock content %}

--- a/netbox_ssl/templates/netbox_ssl/externalsource.html
+++ b/netbox_ssl/templates/netbox_ssl/externalsource.html
@@ -201,4 +201,9 @@
 </div>
 {% endif %}
 
+<div class="row mb-3">
+  <div class="col col-12">
+    {% include 'inc/panels/comments.html' %}
+  </div>
+</div>
 {% endblock content %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,16 +72,6 @@ netbox_ssl = [
     "static/**/*",
 ]
 
-[tool.pytest.ini_options]
-markers = [
-    "unit: marks tests as unit tests (fast, no external dependencies)",
-    "api: marks tests as API integration tests (requires running NetBox)",
-    "browser: marks tests as browser tests (requires running NetBox and Playwright)",
-]
-testpaths = ["tests"]
-python_files = ["test_*.py"]
-python_functions = ["test_*"]
-
 [tool.ruff]
 line-length = 120
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "1.1.0"
+version = "1.1.1"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,9 +4,10 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 testpaths = tests
-addopts = -v --tb=short
+addopts = -v --tb=short --strict-markers
 markers =
     unit: Unit tests (no database required)
     integration: Integration tests (database required)
+    api: API integration tests (requires running NetBox + token)
     browser: Browser tests (Playwright)
     slow: Slow running tests

--- a/scripts/assert_tests_ran.py
+++ b/scripts/assert_tests_ran.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Fail CI if a pytest JUnit XML shows zero tests, or any skipped/failed/errored.
+
+Used by the integration job to guarantee the #111/#112 regression gates
+actually EXECUTE. A ``@requires_netbox`` test that silently *skips* is not a
+gate — a silent skip is exactly how the #111 schema crash stayed invisible in
+CI. This turns "ran 0 / all skipped" into a hard failure.
+
+Usage: python scripts/assert_tests_ran.py <junit-xml-path>
+"""
+
+import sys
+
+# Prefer defusedxml (hardened against XXE / billion-laughs). The input here is
+# our own pytest-generated JUnit XML (trusted), but use the safe parser when
+# available and fall back to stdlib only if defusedxml is not installed.
+try:
+    from defusedxml import ElementTree as ET
+except ImportError:  # pragma: no cover - defusedxml may be absent locally
+    import xml.etree.ElementTree as ET
+
+
+def main(path: str) -> int:
+    root = ET.parse(path).getroot()
+    suites = root.findall("testsuite") or [root]
+    tests = sum(int(s.get("tests", 0)) for s in suites)
+    skipped = sum(int(s.get("skipped", 0)) for s in suites)
+    failures = sum(int(s.get("failures", 0)) for s in suites)
+    errors = sum(int(s.get("errors", 0)) for s in suites)
+
+    problems = []
+    if tests == 0:
+        problems.append("zero tests ran")
+    if skipped:
+        problems.append(f"{skipped} skipped (regression gates must run, not skip)")
+    if failures:
+        problems.append(f"{failures} failed")
+    if errors:
+        problems.append(f"{errors} errored")
+
+    if problems:
+        print("Regression gate check FAILED: " + "; ".join(problems), file=sys.stderr)
+        return 1
+    print(f"Regression gate check OK: {tests} tests ran; 0 skipped, 0 failed, 0 errored.")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: assert_tests_ran.py <junit-xml-path>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -1,0 +1,110 @@
+"""
+Regression tests for OpenAPI (drf-spectacular) schema generation — issue #111.
+
+NetBox 4.6's ``core/api/schema.py`` made ``/api/schema/`` (the REST API
+Swagger UI) crash with ``ValueError: too many values to unpack (expected 2,
+got 3)`` whenever a plugin FilterSet declared a ``MultipleChoiceFilter`` with a
+*raw* colored ChoiceSet list (``SomeChoiceSet.CHOICES`` — 3-tuples of
+``(value, label, color)``). drf-spectacular's ``_get_explicit_filter_choices``
+does ``[c for c, _ in filter_field.extra['choices']]`` and cannot unpack
+3-tuples, which aborts generation of the *entire* schema — so installing the
+plugin broke Swagger for the whole NetBox instance.
+
+Two guards:
+
+1. ``test_openapi_schema_generation_succeeds`` — builds the full schema exactly
+   like the ``/api/schema/`` endpoint; this reproduced #111 (it raised) and now
+   must succeed.
+2. ``test_plugin_filtersets_choices_are_spectacular_safe`` — a fast, targeted
+   guard asserting every plugin filter's choices are either *callable* (a
+   ChoiceSet class) or plain 2-tuples — never raw colored 3-tuples.
+
+These require a real NetBox/Django environment and run inside the Docker
+integration job; they skip elsewhere.
+"""
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Allow importing the plugin package directly.
+_project_root = Path(__file__).parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+_in_netbox_env = os.path.exists("/opt/netbox/netbox/netbox/settings.py") or "DJANGO_SETTINGS_MODULE" in os.environ
+
+if _in_netbox_env:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
+
+    with contextlib.suppress(RuntimeError):
+        django.setup()
+    NETBOX_AVAILABLE = True
+else:
+    NETBOX_AVAILABLE = False
+
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox not available - run these tests inside the Docker container",
+)
+
+
+@requires_netbox
+def test_openapi_schema_generation_succeeds():
+    """The full OpenAPI schema must generate without raising (regression #111).
+
+    Before the fix, ``SchemaGenerator.get_schema`` raised ``ValueError: too
+    many values to unpack (expected 2, got 3)`` while resolving the compliance
+    filterset's choice parameters, taking down ``/api/schema/`` entirely.
+    """
+    from drf_spectacular.generators import SchemaGenerator
+
+    generator = SchemaGenerator()
+    schema = generator.get_schema(request=None, public=True)
+
+    assert schema, "schema generation returned an empty document"
+    paths = schema.get("paths", {})
+    ssl_paths = [p for p in paths if "/plugins/ssl/" in p]
+    assert ssl_paths, "no netbox_ssl paths present in the generated OpenAPI schema"
+
+
+@requires_netbox
+def test_plugin_filtersets_choices_are_spectacular_safe():
+    """No plugin filter may expose raw colored (3-tuple) choices (#111).
+
+    drf-spectacular's ``_get_explicit_filter_choices`` skips *callable* choices
+    (a ChoiceSet class) but unpacks non-callable choices as 2-tuples. Passing
+    ``ChoiceSet.CHOICES`` (which include a colour) therefore crashes schema
+    generation. Always pass the ChoiceSet *class*, not ``.CHOICES``.
+    """
+    import inspect
+
+    import django_filters
+
+    from netbox_ssl import filtersets as ssl_filtersets
+
+    filterset_classes = [
+        obj
+        for _, obj in inspect.getmembers(ssl_filtersets, inspect.isclass)
+        if issubclass(obj, django_filters.FilterSet) and obj.__module__.startswith("netbox_ssl")
+    ]
+    assert filterset_classes, "no plugin FilterSet classes were discovered"
+
+    offenders = []
+    for fs_class in filterset_classes:
+        for field_name, filter_field in fs_class.base_filters.items():
+            choices = getattr(filter_field, "extra", {}).get("choices")
+            if choices is None or callable(choices):
+                continue
+            for entry in choices:
+                if not (isinstance(entry, (list, tuple)) and len(entry) == 2):
+                    offenders.append(f"{fs_class.__name__}.{field_name} -> {entry!r}")
+
+    assert not offenders, (
+        "Filter choices must be a callable ChoiceSet class or 2-tuples so "
+        "drf-spectacular can build the schema; offending filters: " + "; ".join(offenders)
+    )

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -35,17 +35,20 @@ _project_root = Path(__file__).parent.parent
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-_in_netbox_env = os.path.exists("/opt/netbox/netbox/netbox/settings.py") or "DJANGO_SETTINGS_MODULE" in os.environ
+import importlib.util
 
-if _in_netbox_env:
+try:
+    _spec = importlib.util.find_spec("netbox")
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
+
+if NETBOX_AVAILABLE:
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
     import django
 
-    with contextlib.suppress(RuntimeError):
+    with contextlib.suppress(Exception):
         django.setup()
-    NETBOX_AVAILABLE = True
-else:
-    NETBOX_AVAILABLE = False
 
 requires_netbox = pytest.mark.skipif(
     not NETBOX_AVAILABLE,

--- a/tests/test_bulk_import.py
+++ b/tests/test_bulk_import.py
@@ -390,6 +390,13 @@ def django_api_available():
         if not settings.configured:
             return False
 
+        # These tests hit the API + DB in-process and need pytest-django for
+        # proper test-database isolation. Without it they mutate the live DB
+        # and previously only skipped by accident (sys.modules contamination).
+        # Require pytest-django so they skip *deterministically* until it is
+        # adopted (tracked follow-up) instead of erroring in the suite.
+        import pytest_django  # noqa: F401
+
         # Try to import REST framework test client
         from django.contrib.auth import get_user_model  # noqa: F401
         from rest_framework.test import APIClient  # noqa: F401

--- a/tests/test_bulk_operations.py
+++ b/tests/test_bulk_operations.py
@@ -1,341 +1,132 @@
 """
-Unit tests for bulk operations serializers.
+Tests for the bulk-operations serializers (BulkStatusUpdateSerializer,
+BulkAssignSerializer).
 
-Tests the BulkStatusUpdateSerializer and BulkAssignSerializer field
-definitions and class structure without requiring a running NetBox instance
-or djangorestframework installed.
+NOTE (test-hardening, v1.1.1): this file previously exec'd the serializer
+source with hand-built *fake* DRF field classes and asserted on those fakes via
+class-attribute access (``Serializer.field.kwargs``). That only ever exercised
+the fakes — never the shipped serializers — and only "passed" in CI because an
+unrelated ``sys.modules`` mock contamination forced the fake code path. It
+therefore caught zero real bugs (false confidence).
+
+It now tests the **real** DRF serializers via the real field API
+(``serializer().fields``), so it actually validates the code that ships. This
+requires a real NetBox/DRF environment and runs in the Docker integration job;
+it skips elsewhere.
 """
 
-import importlib.util
+import contextlib
+import os
+import sys
 from pathlib import Path
-
-
-def _get_plugin_source_dir():
-    """Find the netbox_ssl source directory (local or Docker CI)."""
-    local = Path(__file__).resolve().parent.parent / "netbox_ssl"
-    if local.is_dir():
-        return local
-    docker = Path("/opt/netbox/netbox/netbox_ssl")
-    if docker.is_dir():
-        return docker
-    return local
-
-
-from types import ModuleType
-from unittest.mock import MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Mock Django/NetBox/DRF before importing plugin code
-# ---------------------------------------------------------------------------
+_root = Path(__file__).parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+import importlib.util
+
 try:
     _spec = importlib.util.find_spec("netbox")
-    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
-    if _NETBOX_AVAILABLE:
-        # Verify Django settings are actually configured (not just importable)
-        from django.conf import settings
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
 
-        _ = settings.USE_I18N  # noqa: F841
-except (ValueError, ModuleNotFoundError, Exception):
-    _NETBOX_AVAILABLE = False
+if NETBOX_AVAILABLE:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
 
+    with contextlib.suppress(Exception):
+        django.setup()
 
-def _load_serializer_classes() -> tuple:
-    """Load the bulk serializer classes from certificates.py.
-
-    In a non-NetBox environment (no DRF, no Django), we exec the module
-    source with injected fake base classes so the serializer class
-    definitions can be inspected without the full import chain.
-    """
-    if _NETBOX_AVAILABLE:
-        from netbox_ssl.api.serializers.certificates import (
-            BulkAssignSerializer,
-            BulkStatusUpdateSerializer,
-        )
-
-        return BulkStatusUpdateSerializer, BulkAssignSerializer
-
-    # --- Fake DRF field classes ---
-
-    class _FakeSerializer:
-        """Minimal Serializer stand-in for class definition."""
-
-        def __init_subclass__(cls, **kwargs):
-            super().__init_subclass__(**kwargs)
-
-    class _FakeField:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-    class _FakeListField(_FakeField):
-        pass
-
-    class _FakeChoiceField(_FakeField):
-        pass
-
-    class _FakeCharField(_FakeField):
-        pass
-
-    class _FakeIntegerField(_FakeField):
-        pass
-
-    class _FakeBooleanField(_FakeField):
-        pass
-
-    class _FakeHyperlinkedIdentityField(_FakeField):
-        pass
-
-    class _FakeSerializerMethodField(_FakeField):
-        pass
-
-    class _FakePrimaryKeyRelatedField(_FakeField):
-        pass
-
-    class _FakeValidationError(Exception):
-        pass
-
-    class _FakeNetBoxModelSerializer(_FakeSerializer):
-        class Meta:
-            pass
-
-        def __init__(self, *args, **kwargs):
-            pass
-
-    class _FakeStatusChoices:
-        STATUS_ACTIVE = "active"
-        STATUS_EXPIRED = "expired"
-        STATUS_REPLACED = "replaced"
-        STATUS_REVOKED = "revoked"
-        STATUS_PENDING = "pending"
-
-    # Build a fake serializers module for the `from rest_framework import serializers` line
-    rf_serializers_mod = ModuleType("rest_framework.serializers")
-    rf_serializers_mod.Serializer = _FakeSerializer
-    rf_serializers_mod.ListField = _FakeListField
-    rf_serializers_mod.ChoiceField = _FakeChoiceField
-    rf_serializers_mod.CharField = _FakeCharField
-    rf_serializers_mod.IntegerField = _FakeIntegerField
-    rf_serializers_mod.BooleanField = _FakeBooleanField
-    rf_serializers_mod.HyperlinkedIdentityField = _FakeHyperlinkedIdentityField
-    rf_serializers_mod.SerializerMethodField = _FakeSerializerMethodField
-    rf_serializers_mod.PrimaryKeyRelatedField = _FakePrimaryKeyRelatedField
-    rf_serializers_mod.ValidationError = _FakeValidationError
-
-    # Prepare namespace with all imports pre-resolved
-    namespace: dict = {
-        "__name__": "netbox_ssl.api.serializers.certificates",
-        "__package__": "netbox_ssl.api.serializers",
-        "NetBoxModelSerializer": _FakeNetBoxModelSerializer,
-        "serializers": rf_serializers_mod,
-        "TenantSerializer": type("TenantSerializer", (_FakeNetBoxModelSerializer,), {}),
-        "Tenant": MagicMock(),
-        "Certificate": MagicMock(),
-        "CertificateStatusChoices": _FakeStatusChoices,
-        "CertificateParseError": Exception,
-        "CertificateParser": MagicMock(),
-        "detect_issuing_ca": MagicMock(),
-        "CertificateAuthoritySerializer": type("CertificateAuthoritySerializer", (_FakeNetBoxModelSerializer,), {}),
-        "ExternalSourceSerializer": type("ExternalSourceSerializer", (_FakeNetBoxModelSerializer,), {}),
-    }
-
-    # Read the source and strip import lines so our injected names are used
-    source_path = _get_plugin_source_dir() / "api" / "serializers" / "certificates.py"
-    if not source_path.exists():
-        # Docker CI: tests at /tmp/plugin_tests/, plugin at /opt/netbox/netbox/netbox_ssl/
-        source_path = Path("/opt/netbox/netbox/netbox_ssl/api/serializers/certificates.py")
-    source = source_path.read_text()
-
-    lines = source.split("\n")
-    filtered: list[str] = []
-    in_import = False
-    for line in lines:
-        stripped = line.strip()
-        # Detect start of import block
-        if stripped.startswith("from ") or stripped.startswith("import "):
-            in_import = True
-            # Single-line import
-            if "(" not in stripped or ")" in stripped:
-                in_import = False
-            continue
-        # Inside multi-line import
-        if in_import:
-            if ")" in stripped:
-                in_import = False
-            continue
-        filtered.append(line)
-
-    clean_source = "\n".join(filtered)
-    exec(compile(clean_source, str(source_path), "exec"), namespace)  # noqa: S102
-
-    return namespace["BulkStatusUpdateSerializer"], namespace["BulkAssignSerializer"]
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox/DRF not available - run these tests inside the Docker container",
+)
 
 
-BulkStatusUpdateSerializer, BulkAssignSerializer = _load_serializer_classes()
+def _fields(serializer_cls):
+    """Return the bound DRF fields (name -> Field) for a serializer class."""
+    return serializer_cls().fields
 
 
-# ---------------------------------------------------------------------------
-# Tests: BulkStatusUpdateSerializer
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
+@requires_netbox
 class TestBulkStatusUpdateSerializer:
-    """Tests for BulkStatusUpdateSerializer field definitions."""
+    """Field-level checks against the real BulkStatusUpdateSerializer."""
 
-    def test_has_ids_field(self) -> None:
-        """Serializer defines an 'ids' field."""
-        assert hasattr(BulkStatusUpdateSerializer, "ids")
+    def _fields(self):
+        from netbox_ssl.api.serializers import BulkStatusUpdateSerializer
 
-    def test_ids_field_is_list_field(self) -> None:
-        """The 'ids' field is a ListField."""
-        field = BulkStatusUpdateSerializer.ids
-        assert "ListField" in type(field).__name__
+        return _fields(BulkStatusUpdateSerializer)
 
-    def test_ids_field_has_child_integer(self) -> None:
-        """The 'ids' ListField child is an IntegerField."""
-        field = BulkStatusUpdateSerializer.ids
-        child = field.kwargs.get("child")
-        assert child is not None
-        assert "IntegerField" in type(child).__name__
+    def test_has_ids_and_status_fields(self):
+        from rest_framework import serializers
 
-    def test_ids_field_disallows_empty(self) -> None:
-        """The 'ids' field does not allow empty lists."""
-        field = BulkStatusUpdateSerializer.ids
-        assert field.kwargs.get("allow_empty") is False
+        fields = self._fields()
+        assert "ids" in fields
+        assert "status" in fields
+        assert isinstance(fields["ids"], serializers.ListField)
+        assert isinstance(fields["status"], serializers.ChoiceField)
 
-    def test_has_status_field(self) -> None:
-        """Serializer defines a 'status' field."""
-        assert hasattr(BulkStatusUpdateSerializer, "status")
+    def test_ids_is_integer_list_disallowing_empty(self):
+        from rest_framework import serializers
 
-    def test_status_field_is_choice_field(self) -> None:
-        """The 'status' field is a ChoiceField."""
-        field = BulkStatusUpdateSerializer.status
-        assert "ChoiceField" in type(field).__name__
+        ids = self._fields()["ids"]
+        assert isinstance(ids.child, serializers.IntegerField)
+        assert ids.allow_empty is False
+        assert ids.help_text
 
-    def test_status_field_has_choices(self) -> None:
-        """The 'status' ChoiceField has choices configured."""
-        field = BulkStatusUpdateSerializer.status
-        assert "choices" in field.kwargs
+    def test_status_choices_match_certificate_status_choices(self):
+        from netbox_ssl.models import CertificateStatusChoices
 
-    def test_status_field_choices_reference_status_choices(self) -> None:
-        """The 'status' ChoiceField references CertificateStatusChoices."""
-        field = BulkStatusUpdateSerializer.status
-        choices = field.kwargs["choices"]
-        # Should reference our fake status choices class
-        assert hasattr(choices, "STATUS_ACTIVE")
-
-    def test_ids_field_has_help_text(self) -> None:
-        """The 'ids' field has help_text."""
-        field = BulkStatusUpdateSerializer.ids
-        assert field.kwargs.get("help_text")
-
-    def test_status_field_has_help_text(self) -> None:
-        """The 'status' field has help_text."""
-        field = BulkStatusUpdateSerializer.status
-        assert field.kwargs.get("help_text")
-
-    def test_class_has_both_required_fields(self) -> None:
-        """BulkStatusUpdateSerializer has both 'ids' and 'status' fields."""
-        assert hasattr(BulkStatusUpdateSerializer, "ids")
-        assert hasattr(BulkStatusUpdateSerializer, "status")
+        status = self._fields()["status"]
+        expected = {c[0] for c in CertificateStatusChoices.CHOICES}
+        assert set(status.choices.keys()) == expected
+        assert status.help_text
 
 
-# ---------------------------------------------------------------------------
-# Tests: BulkAssignSerializer
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
+@requires_netbox
 class TestBulkAssignSerializer:
-    """Tests for BulkAssignSerializer field definitions."""
+    """Field-level checks against the real BulkAssignSerializer."""
 
-    def test_has_certificate_ids_field(self) -> None:
-        """Serializer defines a 'certificate_ids' field."""
-        assert hasattr(BulkAssignSerializer, "certificate_ids")
+    def _fields(self):
+        from netbox_ssl.api.serializers import BulkAssignSerializer
 
-    def test_certificate_ids_is_list_field(self) -> None:
-        """The 'certificate_ids' field is a ListField."""
-        field = BulkAssignSerializer.certificate_ids
-        assert "ListField" in type(field).__name__
+        return _fields(BulkAssignSerializer)
 
-    def test_certificate_ids_has_child_integer(self) -> None:
-        """The 'certificate_ids' ListField child is an IntegerField."""
-        field = BulkAssignSerializer.certificate_ids
-        child = field.kwargs.get("child")
-        assert child is not None
-        assert "IntegerField" in type(child).__name__
+    def test_has_all_four_expected_fields(self):
+        fields = self._fields()
+        assert set(fields) >= {"certificate_ids", "assigned_object_type", "assigned_object_id", "is_primary"}
 
-    def test_certificate_ids_disallows_empty(self) -> None:
-        """The 'certificate_ids' field does not allow empty lists."""
-        field = BulkAssignSerializer.certificate_ids
-        assert field.kwargs.get("allow_empty") is False
+    def test_certificate_ids_is_integer_list_disallowing_empty(self):
+        from rest_framework import serializers
 
-    def test_has_assigned_object_type_field(self) -> None:
-        """Serializer defines an 'assigned_object_type' field."""
-        assert hasattr(BulkAssignSerializer, "assigned_object_type")
+        cert_ids = self._fields()["certificate_ids"]
+        assert isinstance(cert_ids, serializers.ListField)
+        assert isinstance(cert_ids.child, serializers.IntegerField)
+        assert cert_ids.allow_empty is False
+        assert cert_ids.help_text
 
-    def test_assigned_object_type_is_char_field(self) -> None:
-        """The 'assigned_object_type' field is a CharField."""
-        field = BulkAssignSerializer.assigned_object_type
-        assert "CharField" in type(field).__name__
+    def test_assigned_object_type_is_char_field(self):
+        from rest_framework import serializers
 
-    def test_has_assigned_object_id_field(self) -> None:
-        """Serializer defines an 'assigned_object_id' field."""
-        assert hasattr(BulkAssignSerializer, "assigned_object_id")
+        field = self._fields()["assigned_object_type"]
+        assert isinstance(field, serializers.CharField)
+        assert "content type" in (field.help_text or "").lower()
 
-    def test_assigned_object_id_is_integer_field(self) -> None:
-        """The 'assigned_object_id' field is an IntegerField."""
-        field = BulkAssignSerializer.assigned_object_id
-        assert "IntegerField" in type(field).__name__
+    def test_assigned_object_id_is_integer_field(self):
+        from rest_framework import serializers
 
-    def test_has_is_primary_field(self) -> None:
-        """Serializer defines an 'is_primary' field."""
-        assert hasattr(BulkAssignSerializer, "is_primary")
+        field = self._fields()["assigned_object_id"]
+        assert isinstance(field, serializers.IntegerField)
+        assert field.help_text
 
-    def test_is_primary_is_boolean_field(self) -> None:
-        """The 'is_primary' field is a BooleanField."""
-        field = BulkAssignSerializer.is_primary
-        assert "BooleanField" in type(field).__name__
+    def test_is_primary_is_boolean_defaulting_true(self):
+        from rest_framework import serializers
 
-    def test_is_primary_defaults_to_true(self) -> None:
-        """The 'is_primary' field defaults to True."""
-        field = BulkAssignSerializer.is_primary
-        assert field.kwargs.get("default") is True
-
-    def test_certificate_ids_has_help_text(self) -> None:
-        """The 'certificate_ids' field has help_text."""
-        field = BulkAssignSerializer.certificate_ids
-        assert field.kwargs.get("help_text")
-
-    def test_assigned_object_type_has_help_text(self) -> None:
-        """The 'assigned_object_type' field has help_text."""
-        field = BulkAssignSerializer.assigned_object_type
-        assert field.kwargs.get("help_text")
-
-    def test_assigned_object_id_has_help_text(self) -> None:
-        """The 'assigned_object_id' field has help_text."""
-        field = BulkAssignSerializer.assigned_object_id
-        assert field.kwargs.get("help_text")
-
-    def test_is_primary_has_help_text(self) -> None:
-        """The 'is_primary' field has help_text."""
-        field = BulkAssignSerializer.is_primary
-        assert field.kwargs.get("help_text")
-
-    def test_has_all_four_expected_fields(self) -> None:
-        """BulkAssignSerializer has all four expected fields."""
-        expected_fields = [
-            "certificate_ids",
-            "assigned_object_type",
-            "assigned_object_id",
-            "is_primary",
-        ]
-        for field_name in expected_fields:
-            assert hasattr(BulkAssignSerializer, field_name), f"Missing field: {field_name}"
-
-    def test_assigned_object_type_help_text_mentions_content_types(self) -> None:
-        """The help_text for assigned_object_type mentions supported types."""
-        field = BulkAssignSerializer.assigned_object_type
-        help_text = field.kwargs.get("help_text", "")
-        assert "dcim.device" in help_text or "content type" in help_text.lower()
+        field = self._fields()["is_primary"]
+        assert isinstance(field, serializers.BooleanField)
+        assert field.default is True
+        assert field.help_text

--- a/tests/test_comments_field.py
+++ b/tests/test_comments_field.py
@@ -25,17 +25,20 @@ _project_root = Path(__file__).parent.parent
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-_in_netbox_env = os.path.exists("/opt/netbox/netbox/netbox/settings.py") or "DJANGO_SETTINGS_MODULE" in os.environ
+import importlib.util
 
-if _in_netbox_env:
+try:
+    _spec = importlib.util.find_spec("netbox")
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
+
+if NETBOX_AVAILABLE:
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
     import django
 
-    with contextlib.suppress(RuntimeError):
+    with contextlib.suppress(Exception):
         django.setup()
-    NETBOX_AVAILABLE = True
-else:
-    NETBOX_AVAILABLE = False
 
 requires_netbox = pytest.mark.skipif(
     not NETBOX_AVAILABLE,

--- a/tests/test_comments_field.py
+++ b/tests/test_comments_field.py
@@ -1,0 +1,91 @@
+"""
+Regression tests for the ``comments`` field — issue #112.
+
+The edit forms for Certificate, CertificateAuthority, CertificateSigningRequest
+and ExternalSource declared ``comments = CommentField()`` and listed
+``"comments"`` in their fieldsets, but the models inherit ``NetBoxModel`` —
+which (unlike ``PrimaryModel``) does NOT provide a ``comments`` column. So the
+field rendered and accepted input, but the value was silently discarded on
+save ("comments are not retained after save").
+
+These tests assert the field now exists on every affected model, that each
+form's ``comments`` maps onto a real model field (so it persists), and that the
+API serializers expose it. They require a real NetBox/Django environment and
+run inside the Docker integration job; they skip elsewhere.
+"""
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_project_root = Path(__file__).parent.parent
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+_in_netbox_env = os.path.exists("/opt/netbox/netbox/netbox/settings.py") or "DJANGO_SETTINGS_MODULE" in os.environ
+
+if _in_netbox_env:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
+
+    with contextlib.suppress(RuntimeError):
+        django.setup()
+    NETBOX_AVAILABLE = True
+else:
+    NETBOX_AVAILABLE = False
+
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox not available - run these tests inside the Docker container",
+)
+
+# Model import path, form class name, serializer class name for each affected model.
+_AFFECTED = [
+    ("Certificate", "CertificateForm", "CertificateSerializer"),
+    ("CertificateAuthority", "CertificateAuthorityForm", "CertificateAuthoritySerializer"),
+    ("CertificateSigningRequest", "CertificateSigningRequestForm", "CertificateSigningRequestSerializer"),
+    ("ExternalSource", "ExternalSourceForm", "ExternalSourceSerializer"),
+]
+
+
+@requires_netbox
+@pytest.mark.parametrize("model_name", [m for m, _, _ in _AFFECTED])
+def test_model_has_comments_field(model_name):
+    """Every affected model must define a real ``comments`` column (#112)."""
+    import netbox_ssl.models as models_mod
+
+    model = getattr(models_mod, model_name)
+    field_names = {f.name for f in model._meta.get_fields()}
+    assert "comments" in field_names, f"{model_name} is missing a 'comments' model field (#112)"
+
+
+@requires_netbox
+@pytest.mark.parametrize("model_name,form_name", [(m, f) for m, f, _ in _AFFECTED])
+def test_form_comments_maps_to_model(model_name, form_name):
+    """The form's ``comments`` field must map onto a model field so it persists.
+
+    This is the exact #112 failure mode: ``comments`` was present in the form
+    but absent from the model, so it never saved.
+    """
+    import netbox_ssl.forms as forms_mod
+
+    form_cls = getattr(forms_mod, form_name)
+    form = form_cls()
+    assert "comments" in form.fields, f"{form_name} does not expose a comments field"
+    model_field_names = {f.name for f in form._meta.model._meta.get_fields()}
+    assert "comments" in model_field_names, (
+        f"{form_name}.comments has no backing model field — it will not persist (#112)"
+    )
+
+
+@requires_netbox
+@pytest.mark.parametrize("serializer_name", [s for _, _, s in _AFFECTED])
+def test_serializer_exposes_comments(serializer_name):
+    """The REST API serializers must expose ``comments`` for read/write parity."""
+    import netbox_ssl.api.serializers as serializers_mod
+
+    serializer_cls = getattr(serializers_mod, serializer_name)
+    assert "comments" in serializer_cls().fields, f"{serializer_name} does not expose 'comments'"

--- a/tests/test_field_parity.py
+++ b/tests/test_field_parity.py
@@ -1,0 +1,99 @@
+"""
+Generic model<->form field-parity guard — generalizes issue #112.
+
+#112 shipped because the certificate edit form declared ``comments =
+CommentField()`` but the model (a ``NetBoxModel``, not ``PrimaryModel``) had no
+``comments`` column. Django ModelForms allow *declared* (class-attribute)
+fields that don't map to the model — they are simply dropped on save. So the
+field rendered, accepted input, and silently lost it.
+
+``test_comments_field.py`` covers the four models that had the bug by name.
+This test generalizes the guard: for EVERY plugin ``ModelForm``, every declared
+field must resolve to a real model field (or be an allow-listed virtual field).
+The next phantom field on any model is then caught automatically.
+
+Requires a real NetBox/Django environment; runs in the Docker integration job.
+"""
+
+import contextlib
+import inspect
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_root = Path(__file__).parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+import importlib.util
+
+try:
+    _spec = importlib.util.find_spec("netbox")
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
+
+if NETBOX_AVAILABLE:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
+
+    with contextlib.suppress(Exception):
+        django.setup()
+
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox not available - run these tests inside the Docker container",
+)
+
+# Declared form fields that legitimately do NOT map to a concrete model field.
+# Keep this list short and documented — every entry is a deliberate exception,
+# and the whole point of the test is that NEW unexplained entries are bugs.
+ALLOWED_NON_MODEL_FORM_FIELDS = {
+    "tags",  # NetBox TagField — virtual, persisted via the tagging framework, not a column
+    "_init_time",  # injected by NetBox's NetBoxModelForm (concurrency/timing); not a model field
+    "changelog_message",  # injected by NetBox's NetBoxModelForm (changelog note); not a model field
+    # CertificateAssignmentForm's GenericForeignKey target selectors. These are
+    # intentional virtual fields resolved to assigned_object_type/id in the
+    # form's clean()/save(); they deliberately have no own column.
+    "device",
+    "virtual_machine",
+    "service",
+}
+
+
+def _plugin_modelforms():
+    from django.forms import ModelForm
+
+    import netbox_ssl.forms as forms_mod
+
+    return [
+        cls
+        for _, cls in inspect.getmembers(forms_mod, inspect.isclass)
+        if issubclass(cls, ModelForm)
+        and (cls.__module__ or "").startswith("netbox_ssl")
+        and getattr(getattr(cls, "_meta", None), "model", None) is not None
+    ]
+
+
+@requires_netbox
+def test_every_modelform_declared_field_backs_onto_a_model_field():
+    """No plugin ModelForm may declare a field with no backing model column (#112)."""
+    forms = _plugin_modelforms()
+    assert forms, "no plugin ModelForms were discovered"
+
+    phantom = []
+    for form_cls in forms:
+        model = form_cls._meta.model
+        model_field_names = {f.name for f in model._meta.get_fields()}
+        for field_name, field in form_cls.declared_fields.items():
+            if field_name in model_field_names or field_name in ALLOWED_NON_MODEL_FORM_FIELDS:
+                continue
+            phantom.append(f"{form_cls.__name__}.{field_name} ({type(field).__name__})")
+
+    assert not phantom, (
+        "Form fields with no backing model column will be silently dropped on save (#112). "
+        "Add the field to the model (+ migration) or to ALLOWED_NON_MODEL_FORM_FIELDS with a "
+        "comment if it is a genuine virtual field. Offenders: " + "; ".join(phantom)
+    )

--- a/tests/test_security_invariants.py
+++ b/tests/test_security_invariants.py
@@ -1,0 +1,106 @@
+"""
+Regression tests for security invariants that previously had ZERO coverage.
+
+This plugin is the source of truth for TLS-certificate metadata, so a handful
+of security controls must never silently regress:
+
+1. CSV formula-injection sanitization (``CertificateExporter._sanitize_csv_value``)
+   — an exported CSV opened in a spreadsheet must not execute injected formulas.
+2. Custom (non-NetBox-generic) views must enforce authentication via
+   ``LoginRequiredMixin`` — a dropped mixin would expose a view to anonymous
+   users. (NetBox's own generic views carry their own object-permission
+   enforcement and are excluded.)
+
+Requires a real NetBox/Django environment; runs in the Docker integration job.
+"""
+
+import contextlib
+import importlib
+import importlib.util
+import inspect
+import os
+import pkgutil
+import sys
+from pathlib import Path
+
+import pytest
+
+_root = Path(__file__).parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+try:
+    _spec = importlib.util.find_spec("netbox")
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
+
+if NETBOX_AVAILABLE:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
+
+    with contextlib.suppress(Exception):
+        django.setup()
+
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox not available - run these tests inside the Docker container",
+)
+
+# Spreadsheet formula-trigger characters (mirrors CertificateExporter._FORMULA_CHARS).
+_FORMULA_CHARS = ["=", "+", "-", "@", "\t", "\r"]
+
+
+@requires_netbox
+@pytest.mark.parametrize("trigger", _FORMULA_CHARS)
+def test_csv_value_with_formula_char_is_neutralized(trigger):
+    """A value starting with a formula trigger must be prefixed with a quote."""
+    from netbox_ssl.utils.export import CertificateExporter
+
+    payload = f"{trigger}cmd|'/bin/calc'!A0"
+    sanitized = CertificateExporter._sanitize_csv_value(payload)
+    assert sanitized == "'" + payload, f"value starting with {trigger!r} was not neutralized: {sanitized!r}"
+
+
+@requires_netbox
+def test_csv_safe_values_are_unchanged():
+    """Non-formula values must pass through untouched."""
+    from netbox_ssl.utils.export import CertificateExporter
+
+    for safe in ["example.com", "CN=Test CA", "", "2048", "RSA"]:
+        assert CertificateExporter._sanitize_csv_value(safe) == safe
+
+
+@requires_netbox
+def test_custom_views_require_login():
+    """Every custom (non-NetBox-generic) view must include LoginRequiredMixin.
+
+    NetBox's generic Object*View classes enforce object permissions themselves;
+    our bespoke TemplateView/View subclasses (analytics, compliance report,
+    certificate map, import/renew flows) must not be reachable anonymously.
+    """
+    from django.contrib.auth.mixins import LoginRequiredMixin
+    from django.views.generic.base import View
+
+    import netbox_ssl.views as views_pkg
+
+    missing = []
+    seen = set()
+    for mod_info in pkgutil.iter_modules(views_pkg.__path__):
+        module = importlib.import_module(f"netbox_ssl.views.{mod_info.name}")
+        for name, cls in inspect.getmembers(module, inspect.isclass):
+            if cls in seen:
+                continue
+            seen.add(cls)
+            if not issubclass(cls, View):
+                continue
+            if not (cls.__module__ or "").startswith("netbox_ssl"):
+                continue
+            # NetBox generic views (ObjectView/ObjectEditView/...) carry their own
+            # ObjectPermissionRequiredMixin — they are not our responsibility.
+            if any("netbox.views.generic" in (base.__module__ or "") for base in cls.__mro__):
+                continue
+            if LoginRequiredMixin not in cls.__mro__:
+                missing.append(f"{cls.__module__}.{name}")
+
+    assert not missing, f"custom views missing LoginRequiredMixin (anonymous access risk): {missing}"


### PR DESCRIPTION
v1.1.1 — patch release. Fixes #111 (Swagger /api/schema/ 500 on NetBox 4.6) and #112 (comments not retained), plus the test & CI hardening pass (#114, #115) and the version bump + CHANGELOG (#120). Additive migration 0022, no breaking changes. CI green on v4.4/4.5/4.6.