### PR TITLE
ci: widen unit job to -m unit + order-independence canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,20 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pytest cryptography django requests boto3 'moto[acm]>=5.0,<6.0'
+          pip install pytest pytest-randomly cryptography django requests boto3 'moto[acm]>=5.0,<6.0'
 
       - name: Run unit tests
         run: |
-          python -m pytest tests/test_parser.py tests/test_models.py tests/test_events.py \
-                           tests/test_expiry_scan.py tests/test_aws_acm_adapter.py \
-                           -v -p no:django
+          # Run the whole unit-marked suite (not a hand-picked 5-file allowlist)
+          # so new unit tests cannot be silently excluded. Deterministic order.
+          python -m pytest tests/ -m unit -p no:django -p no:randomly
+
+      - name: Unit test order-independence canary
+        run: |
+          # pytest-randomly shuffles collection order to surface cross-file
+          # sys.modules contamination (#116) as an actionable failure, without
+          # flaking the deterministic gate above. The seed is printed for repro.
+          python -m pytest tests/ -m unit -p no:django -p randomly -q
 
   build-package:
     name: Build Package


### PR DESCRIPTION
## Summary

Follow-up that corrects a wrong call from v1.1.1. The fast `unit-tests` job ran a **hand-picked 5-file allowlist**, silently excluding ~50 other `unit`-marked test files (including new regression coverage) from the 3.10/3.11/3.12 host matrix — exactly the "fast lane gained nothing" gap.

This runs the **whole `-m unit` suite** (deterministic) plus a **`pytest-randomly` order-independence canary** that shuffles collection order to surface the `sys.modules` contamination pattern (#116) as an actionable signal rather than a silent latent risk.

### Why now
v1.1.1 deferred this on the basis of a reported "~813 collection errors." That figure was **wrong** — an artifact of a since-fixed bug in the new test files' env detection. The suite actually runs clean and order-independent:

```
pytest tests/ -m unit -p no:django  →  806 passed, 64 skipped, 0 errors
(stable across pytest-randomly seeds 1 / 42 / 12345)
```

So #116 is a *hygiene* issue (the mock-mutation pattern + the undocumented `-p no:django` foot-gun), not broken tests — #116 was updated to reflect this.

### Risk
CI-only, no runtime/package change. If a future test re-introduces order-dependence, the canary step (clearly labelled, prints its seed) goes red — which is the intent.
