### PR TITLE
test: fix Python 3.10 mock patch resolution in test_checks (#116)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pytest cryptography django requests boto3 'moto[acm]>=5.0,<6.0'
+          pip install pytest pytest-randomly cryptography django requests boto3 \
+                      'moto[acm]>=5.0,<6.0' jsonpath-ng pyyaml
 
       - name: Run unit tests
         run: |
-          python -m pytest tests/test_parser.py tests/test_models.py tests/test_events.py \
-                           tests/test_expiry_scan.py tests/test_aws_acm_adapter.py \
-                           -v -p no:django
+          # Run the ENTIRE unit suite (not a hand-picked allowlist), so every
+          # host-runnable test is exercised on all three Python versions. The
+          # 5-file allowlist previously hid the test_checks Python-3.10 failure
+          # (issue #116). pytest-randomly shuffles collection order each run so
+          # any future order-dependence fails CI instead of shipping silently.
+          # -p no:django is required: pytest.ini sets DJANGO_SETTINGS_MODULE
+          # (for the in-container integration run), which is absent here.
+          python -m pytest tests/ -m unit -p no:django
 
   build-package:
     name: Build Package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ aws = [
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "pytest-randomly>=3.15",
     "ruff>=0.4.0",
     "bandit>=1.7.0",
     "playwright>=1.40",

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -94,6 +94,19 @@ if not _NETBOX_AVAILABLE:
 
     sys.modules.setdefault("netbox_ssl.models", MagicMock())
 
+    # issue #116: bind each mocked submodule onto its parent package so that
+    # unittest.mock.patch() target resolution works on Python 3.10. On 3.10
+    # mock._dot_lookup walks getattr(parent, child) rather than consulting
+    # sys.modules, so patch("django.db.connection") and
+    # patch("netbox_ssl.models.Certificate") resolved to a different object than
+    # the code imported — or raised AttributeError, because the real netbox_ssl
+    # package has no bound `models` attribute. Python 3.11+ consults sys.modules
+    # and was unaffected (which is why this only failed on 3.10).
+    sys.modules["django"].db = sys.modules["django.db"]
+    import netbox_ssl
+
+    netbox_ssl.models = sys.modules["netbox_ssl.models"]
+
     Info = _Info
     Warning = _Warning
 else:


### PR DESCRIPTION
## Summary

Fixes #116. `test_checks.py` failed on **Python 3.10 only** — both in isolation and in the full suite — and the bug was masked in CI because the `unit-tests` job ran a hand-picked 5-file allowlist that excluded `test_checks.py`.

## Root cause (corrected diagnosis)

#116 was originally framed as `sys.modules` *contamination* (collection-order dependent). That is **not** what this is — `test_checks.py` fails on 3.10 even when run completely isolated:

```
thing = <module 'netbox_ssl' from '.../netbox_ssl/__init__.py'>, comp = 'models'
    def _dot_lookup(thing, comp, import_path):
        try: return getattr(thing, comp)
        except AttributeError:
            __import__(import_path)
>           return getattr(thing, comp)
E   AttributeError: module 'netbox_ssl' has no attribute 'models'
/usr/local/lib/python3.10/unittest/mock.py:1251
```

`unittest.mock.patch()` target resolution differs across Python versions. On **3.10**, `mock._dot_lookup` walks `getattr(parent, child)` instead of consulting `sys.modules`. So `patch("django.db.connection")` and `patch("netbox_ssl.models.Certificate")` resolved to a *different object* than the code imported — or raised `AttributeError`, because the real `netbox_ssl` package has no bound `models` attribute (the mock lives only in `sys.modules`). **Python 3.11+ rewrote `_dot_lookup` to consult `sys.modules`**, which is exactly why the failure was 3.10-exclusive.

## Fix

1. **`tests/test_checks.py`** — bind each mocked submodule onto its parent package so `getattr`-based resolution finds the same object on every version:
   - `sys.modules["django"].db = sys.modules["django.db"]`
   - `netbox_ssl.models = sys.modules["netbox_ssl.models"]`
   The existing stub approach (which never imports the real `django.core.checks`) is kept — it is immune to the translation/db-models force-mocks other test files install, so switching to real Django was rejected.

2. **`.github/workflows/ci.yml`** — widen the `unit-tests` job from the 5-file allowlist to the entire `-m unit` suite and add **`pytest-randomly`**, so every host-runnable test runs on 3.10/3.11/3.12 and any future order-dependence fails CI instead of shipping silently. This re-does the reverted #122, now that the underlying failure is actually fixed. The allowlist is precisely what hid this bug.

3. **`pyproject.toml`** — add `pytest-randomly` to the `dev` extra so local runs match CI.

## Verification

Full `-m unit` suite in clean `python:3.X-slim` containers (django + moto[acm] + deps), deterministic **and** under `pytest-randomly`:

| Python | `test_checks` isolated | full `-m unit` (det) | full `-m unit` (randomly 1337) |
|--------|------------------------|----------------------|-------------------------------|
| 3.10   | ✅ 7 passed            | ✅ 806 passed         | ✅ 806 passed                  |
| 3.11   | ✅ 7 passed            | ✅ 806 passed         | ✅ 806 passed                  |
| 3.12   | ✅ 7 passed            | ✅ 806 passed         | ✅ 806 passed                  |

Before the fix: 3.10 = 7 failed isolated, 17 failed in full suite under randomization.