### PR TITLE
ci: serialize gh-pages docs deploys to fix release-time race (#110)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,18 @@ on:
 permissions:
   contents: write
 
+# Serialize gh-pages deploys (issue #110). On release, the dev->main merge and
+# the version-tag push fire within seconds; both trigger this workflow and both
+# `mike deploy --push` to the SAME gh-pages branch, so one is rejected
+# non-fast-forward (and it was the release-critical tag run that lost in v1.1.0).
+# A single fixed group (NOT keyed on github.ref — that would give each ref its
+# own group and defeat serialization) queues the runs. cancel-in-progress MUST
+# be false: each run writes a distinct mike slot/alias, so cancelling would drop
+# a needed versioned-docs or `latest` update.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy versioned docs

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -163,6 +163,16 @@ days. For urgent security issues, see [SECURITY.md](https://github.com/ctrl-alt-
 8. Push tag → triggers `publish.yml` (PyPI) and `docs.yml` (GH Pages)
 9. Close the milestone's issues with link to the release
 
+!!! note "Docs deploy ordering (gh-pages)"
+    The `dev → main` merge (step 6) and the tag push (step 8) both trigger
+    `docs.yml`, and both `mike deploy --push` to the same `gh-pages` branch. The
+    workflow declares a `concurrency: { group: gh-pages-deploy }` group so these
+    runs **serialize instead of racing** (a non-fast-forward push rejection
+    killed the release-critical tag deploy before this was added — issue #110).
+    As extra insurance, allow the `main`-push Docs Deploy to finish before
+    pushing the tag; if a deploy is ever rejected, re-run the failed run once the
+    competing run completes.
+
 See [versioning.md](versioning.md) for the semver policy.
 
 ## Questions?


### PR DESCRIPTION
## Summary

Fixes #110. On release, the `dev → main` merge and the version-tag push fire within seconds of each other. Both trigger `Docs Deploy`, and both `mike deploy --push` to the **same `gh-pages` branch** — so one is rejected non-fast-forward. In v1.1.0 the release-critical **tag** run (which creates the versioned `major.minor` slot and repoints `latest`) lost the race and had to be re-run manually.

## Fix

Add a **workflow-level** `concurrency` group to `.github/workflows/docs.yml`:

```yaml
concurrency:
  group: gh-pages-deploy
  cancel-in-progress: false
```

- **Fixed group name, not keyed on `github.ref`** — keying on the ref would give the main-push and tag-push runs separate groups and defeat serialization. A single shared group queues them.
- **`cancel-in-progress: false`** — each run writes a *distinct* mike slot/alias (main-push → `dev`; tag-push → `<major.minor>` + `latest`), so cancelling the older run would drop a needed docs update. Serialize (queue), never cancel.

Also documents the release-time ordering in `docs/development/contributing.md` as defence-in-depth (let the main-push deploy finish before pushing the tag; re-run a rejected deploy once the competing run completes).

## Acceptance criteria

- [x] `concurrency` group added to `docs.yml` (valid YAML verified)
- [x] Release-time ordering documented in `contributing.md`
- [ ] Next release validates real-world serialization (the only true end-to-end test — this race only manifests on a tag+main double-trigger)

## Notes

This is a CI-only change; it does not touch plugin code, the published package, or the schema. No migration. PyPI publish is a separate workflow/target and was never affected by this race.