### PR TITLE
fix: reconcile compliance/ExternalSource migration drift + add drift CI gate (#118)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,20 @@ jobs:
             /opt/netbox/netbox/manage.py spectacular --file /tmp/schema.yml --validate
           echo "OpenAPI schema generated and validated successfully."
 
+      - name: Check for migration drift (#118)
+        if: matrix.netbox_major == 'v4.6'
+        run: |
+          # `makemigrations --check` exits non-zero if the models have changes
+          # not captured in a migration. This is the gate that would have caught
+          # the v1.0.1 ComplianceTrendSnapshot 500 and the #118 compliance-tags
+          # drift before release. Pinned to v4.6 only: cross-version field churn
+          # (encoder/through-table internals differ per NetBox/Django) would make
+          # a multi-version gate flaky. NetBox's makemigrations override allows
+          # `--check` without DEVELOPER=True (it only blocks actual file writes).
+          docker compose exec -T netbox /opt/netbox/venv/bin/python \
+            /opt/netbox/netbox/manage.py makemigrations netbox_ssl --check
+          echo "No migration drift detected."
+
       - name: Regression gates must run (not skip) (#111/#112)
         run: |
           # Run the targeted regression tests in an isolated invocation and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Migration drift on the compliance models and ExternalSource** ([#118](https://github.com/ctrl-alt-automate/netbox-ssl/issues/118)):
+  `ComplianceCheck` and `CompliancePolicy` (both `NetBoxModel` subclasses) were
+  created without their `tags` field in the migration history, and several
+  `custom_field_data` / `tags` field definitions had drifted out of sync with
+  the models — the same class of issue as the v1.0.1 `ComplianceTrendSnapshot`
+  fix. Migration `0023` reconciles the state (adds `tags` to both compliance
+  models, aligns the `CustomFieldJSONEncoder`, drops a stale Certificate
+  constraint). All operations are additive / metadata-only and safe on existing
+  installs. A `makemigrations netbox_ssl --check` CI gate (pinned to NetBox 4.6)
+  now fails the build on any future drift.
+
+### Documentation
+
+- **Docs deploys no longer race on release** ([#110](https://github.com/ctrl-alt-automate/netbox-ssl/issues/110)):
+  the `Docs Deploy` workflow now serializes gh-pages pushes via a `concurrency`
+  group, so the release-critical tag-triggered deploy can no longer be rejected
+  by the concurrent `main`-push deploy.
+
 ## [1.1.1] - 2026-05-29
 
 **Patch release** — two bug fixes for issues reported on v1.1.0, plus a test &

--- a/netbox_ssl/migrations/0023_compliance_tags_and_field_reconciliation.py
+++ b/netbox_ssl/migrations/0023_compliance_tags_and_field_reconciliation.py
@@ -1,0 +1,90 @@
+"""
+Reconcile migration state with the model definitions (issue #118).
+
+Several NetBoxModel-provided fields and a stale constraint had drifted out of
+the migration history, so ``makemigrations netbox_ssl --check`` reported pending
+changes on a clean install (the same class of drift as the v1.0.1
+ComplianceTrendSnapshot fix, migration 0020):
+
+* ``tags`` was never migrated for ComplianceCheck / CompliancePolicy — both
+  inherit NetBoxModel (which provides ``tags`` via TaggableManager) but
+  migration 0005 created them without it.
+* ``custom_field_data`` on the compliance models and ExternalSource was frozen
+  without the ``CustomFieldJSONEncoder`` the model now uses.
+* ``tags`` on ExternalSource was frozen as a plain ManyToManyField (0013) but the
+  model inherits the NetBoxModel TaggableManager.
+* ``unique_external_source_id`` was added on Certificate in 0013 but later
+  removed from the model's Meta.constraints without a migration to drop it.
+
+All operations are additive / metadata-only and safe on existing installs (no
+NOT NULL backfill, no data migration). The ``extras`` dependency is anchored at
+``0001_initial`` — matching migrations 0015/0020 — so this applies cleanly
+across the supported NetBox 4.4–4.6 range rather than pinning a version-specific
+extras migration.
+
+The ExternalSource ``tags`` reconciliation is wrapped in
+``SeparateDatabaseAndState`` with NO database operation: Django refuses to ALTER
+between a plain M2M and a TaggableManager (``you cannot alter to or from M2M``),
+and no DB change is actually needed. The TaggableManager has always written to
+the shared ``extras_taggeditem`` table (via the NetBoxModel parent), so the old
+per-model ``netbox_ssl_externalsource_tags`` table created by 0013 has been dead
+since v0.8 (verified empty). We update only the migration *state* so the field
+matches the model; the dead table is left in place (harmless, and dropping it
+would be a non-additive schema change out of scope for this reconciliation).
+"""
+
+import taggit.managers
+import utilities.json
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("extras", "0001_initial"),
+        ("netbox_ssl", "0022_add_comments_fields"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="certificate",
+            name="unique_external_source_id",
+        ),
+        migrations.AddField(
+            model_name="compliancecheck",
+            name="tags",
+            field=taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag"),
+        ),
+        migrations.AddField(
+            model_name="compliancepolicy",
+            name="tags",
+            field=taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag"),
+        ),
+        migrations.AlterField(
+            model_name="compliancecheck",
+            name="custom_field_data",
+            field=models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder),
+        ),
+        migrations.AlterField(
+            model_name="compliancepolicy",
+            name="custom_field_data",
+            field=models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder),
+        ),
+        migrations.AlterField(
+            model_name="externalsource",
+            name="custom_field_data",
+            field=models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder),
+        ),
+        # State-only: align the field with the model's TaggableManager without a
+        # DB ALTER (Django cannot alter to/from M2M; no DB change is needed since
+        # tags already live in the shared extras_taggeditem table).
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="externalsource",
+                    name="tags",
+                    field=taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag"),
+                ),
+            ],
+            database_operations=[],
+        ),
+    ]

--- a/tests/test_migration_0023.py
+++ b/tests/test_migration_0023.py
@@ -1,0 +1,146 @@
+"""Smoke test that migration 0023 exists and declares the expected operations.
+
+Migration 0023 reconciles drifted NetBoxModel fields / a stale constraint with
+the model definitions (issue #118). Full apply/rollback/zero-drift behavior is
+verified in the Docker integration suite (real NetBox DB) and by the
+``makemigrations --check`` CI gate; this host-runnable test just locks the
+operation structure so an accidental edit is caught in the fast unit lane.
+"""
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _get_plugin_source_dir():
+    """Find the netbox_ssl source directory (local or Docker CI)."""
+    local = Path(__file__).resolve().parent.parent / "netbox_ssl"
+    if local.is_dir():
+        return local
+    docker = Path("/opt/netbox/netbox/netbox_ssl")
+    if docker.is_dir():
+        return docker
+    return local
+
+
+MIGRATION_PATH = _get_plugin_source_dir() / "migrations" / "0023_compliance_tags_and_field_reconciliation.py"
+
+try:
+    _spec = importlib.util.find_spec("netbox")
+    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    _NETBOX_AVAILABLE = False
+
+
+@pytest.fixture
+def migration_module(monkeypatch):
+    """Load the migration module with fresh stubs (isolated per test).
+
+    Mirrors test_migration_0021's approach: rebuild the django.db / taggit /
+    utilities hierarchy with real stub classes so operation type names resolve
+    and sys.modules pollution from other test files cannot interfere.
+    """
+    if not _NETBOX_AVAILABLE:
+
+        class _Op:
+            def __init__(self, **kwargs):
+                self.model_name = kwargs.get("model_name")
+                self.name = kwargs.get("name")
+
+        class AddField(_Op):
+            pass
+
+        class AlterField(_Op):
+            pass
+
+        class RemoveConstraint(_Op):
+            pass
+
+        class SeparateDatabaseAndState:
+            def __init__(self, state_operations=None, database_operations=None, **kwargs):
+                self.state_operations = state_operations or []
+                self.database_operations = database_operations or []
+
+        class Migration:
+            operations = []
+            dependencies = []
+
+        _migrations = MagicMock()
+        _migrations.Migration = Migration
+        _migrations.AddField = AddField
+        _migrations.AlterField = AlterField
+        _migrations.RemoveConstraint = RemoveConstraint
+        _migrations.SeparateDatabaseAndState = SeparateDatabaseAndState
+
+        _models = MagicMock()
+        _django_db = MagicMock()
+        _django_db.migrations = _migrations
+        _django_db.models = _models
+
+        monkeypatch.setitem(sys.modules, "django.db", _django_db)
+        monkeypatch.setitem(sys.modules, "django.db.migrations", _migrations)
+        monkeypatch.setitem(sys.modules, "django.db.models", _models)
+
+        _taggit = MagicMock()
+        _taggit_managers = MagicMock()
+        _taggit.managers = _taggit_managers
+        monkeypatch.setitem(sys.modules, "taggit", _taggit)
+        monkeypatch.setitem(sys.modules, "taggit.managers", _taggit_managers)
+
+        _utilities = MagicMock()
+        _utilities_json = MagicMock()
+        _utilities.json = _utilities_json
+        monkeypatch.setitem(sys.modules, "utilities", _utilities)
+        monkeypatch.setitem(sys.modules, "utilities.json", _utilities_json)
+
+    spec = importlib.util.spec_from_file_location("mig0023", MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_migration_file_exists():
+    assert MIGRATION_PATH.is_file(), f"Migration not found at {MIGRATION_PATH}"
+
+
+def test_migration_depends_on_0022(migration_module):
+    deps = migration_module.Migration.dependencies
+    assert ("netbox_ssl", "0022_add_comments_fields") in deps
+    # extras anchored at 0001_initial for cross-version (4.4-4.6) safety.
+    assert ("extras", "0001_initial") in deps
+
+
+def test_adds_tags_to_both_compliance_models(migration_module):
+    add_targets = {
+        (op.model_name, op.name) for op in migration_module.Migration.operations if type(op).__name__ == "AddField"
+    }
+    assert ("compliancecheck", "tags") in add_targets
+    assert ("compliancepolicy", "tags") in add_targets
+
+
+def test_removes_stale_unique_external_source_id_constraint(migration_module):
+    removed = {
+        (op.model_name, op.name)
+        for op in migration_module.Migration.operations
+        if type(op).__name__ == "RemoveConstraint"
+    }
+    assert ("certificate", "unique_external_source_id") in removed
+
+
+def test_externalsource_tags_reconciliation_is_state_only(migration_module):
+    """The M2M->TaggableManager alter must be state-only (no DB op).
+
+    Django cannot ALTER to/from M2M; a DB op here would crash on migrate.
+    """
+    sds = [op for op in migration_module.Migration.operations if type(op).__name__ == "SeparateDatabaseAndState"]
+    assert len(sds) == 1, "externalsource.tags reconciliation must use SeparateDatabaseAndState"
+    assert sds[0].database_operations == [], "must carry NO database operation"
+    state_targets = {(op.model_name, op.name) for op in sds[0].state_operations}
+    assert ("externalsource", "tags") in state_targets


### PR DESCRIPTION
## Summary

Fixes #118. On a clean NetBox 4.6 install, `makemigrations netbox_ssl --check` reported pending changes — the same class of drift as the v1.0.1 `ComplianceTrendSnapshot` fix (a `NetBoxModel` field never captured in migrations, which caused a production 500).

## Root cause (verified in a real v4.6 container, not theorized)

`makemigrations netbox_ssl --check` produced **7** operations, not the 2 the issue anticipated:

```
- Remove constraint unique_external_source_id from certificate
+ Add field tags to compliancecheck
+ Add field tags to compliancepolicy
~ Alter field custom_field_data on compliancecheck
~ Alter field custom_field_data on compliancepolicy
~ Alter field custom_field_data on externalsource
~ Alter field tags on externalsource
```

- `ComplianceCheck` / `CompliancePolicy` inherit `NetBoxModel` (→ `tags` via `TaggableManager`) but migration `0005` created them without it.
- `custom_field_data` on the compliance models + ExternalSource was frozen without the `CustomFieldJSONEncoder` the models now use.
- `unique_external_source_id` was added on Certificate in `0013` but later removed from the model's `Meta.constraints` with no migration to drop it (verified: the model now only declares `unique_serial_issuer`).
- ExternalSource `tags` was frozen as a plain `ManyToManyField` in `0013` but the model inherits the `NetBoxModel` `TaggableManager`.

## How `0023` was produced

**Generated by NetBox's own `makemigrations`** (via `DEVELOPER=True` in a v4.6 container — NetBox blocks file-writing `makemigrations` otherwise), *not* hand-written, so the operation set is canonical. Two deliberate adjustments:

1. **`extras` dependency anchored at `0001_initial`** (matching `0015`/`0020`) instead of the version-specific `0138_…` Django-6 generated, so it applies cleanly across NetBox 4.4–4.6.
2. **ExternalSource `tags` reconciliation wrapped in `SeparateDatabaseAndState` with an empty `database_operations`.** Django refuses to `ALTER` to/from an M2M (`you cannot alter to or from M2M fields`) — and no DB change is needed: the `TaggableManager` has always written to the shared `extras_taggeditem` table via the `NetBoxModel` parent, so the per-model `netbox_ssl_externalsource_tags` table created by `0013` has been **dead since v0.8 (verified: 0 rows)**. Only the migration *state* is aligned; the dead table is left in place (dropping it is a non-additive change, out of scope).

## Verification (real NetBox v4.6.0 container)

- `migrate netbox_ssl` → `Applying 0023… OK`
- Rollback `0023 → 0022 → 0023` → clean, no errors
- `makemigrations netbox_ssl --check` → **`No changes detected`, exit 0** (zero drift)
- All three models expose `tags` as `TaggableManager` via `extras_taggeditem`; ORM queries compile
- Host unit suite: **811 passed** (806 + 5 new smoke tests), no regressions

## CI gate

Adds a **`makemigrations netbox_ssl --check`** step to the integration job, **pinned to `matrix.netbox_major == 'v4.6'`** (cross-version field-internal churn — encoder/through-table — would make a multi-version gate flaky). This is the gate that would have caught the v1.0.1 500 and this drift before release. NetBox's `makemigrations` override permits `--check` without `DEVELOPER=True` (it only blocks actual file writes), so the gate runs in the stock image.

Also includes a host-runnable smoke test (`tests/test_migration_0023.py`) locking the operation structure, including the state-only externalsource.tags reconciliation.

## Notes

- Also lands the CHANGELOG entry for #110 (docs gh-pages race, merged in #124 without a CHANGELOG note).
- Migration `0023` is additive / metadata-only — safe on existing installs, no data migration, no NOT NULL backfill.