### PR TITLE
feat: show public certificate PEM on the detail page (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Public certificate PEM on the detail page** ([#113](https://github.com/ctrl-alt-automate/netbox-ssl/issues/113)):
+  the stored public PEM is now shown in a collapsible "Certificate PEM" card on
+  the certificate detail page, with copy-to-clipboard and download controls,
+  visible to any user with **view** permission (previously the PEM was only
+  reachable from the edit form, forcing operators to be granted edit rights).
+  The field holds the public certificate only — private keys are rejected at
+  import — so this exposes nothing beyond the metadata already shown. Aligned
+  with the plugin's passive-administration model: no new active capability.
+
 ## [1.1.1] - 2026-05-29
 
 **Patch release** — two bug fixes for issues reported on v1.1.0, plus a test &

--- a/netbox_ssl/templates/netbox_ssl/certificate.html
+++ b/netbox_ssl/templates/netbox_ssl/certificate.html
@@ -125,6 +125,77 @@
   </div>
 </div>
 
+{# Public certificate PEM — visible to any user with view permission (issue #113). #}
+{# pem_content holds the public certificate only; private keys are rejected at import. #}
+{% if object.pem_content %}
+<div class="row mb-3">
+  <div class="col col-12">
+    <div class="card">
+      <h5 class="card-header d-flex justify-content-between align-items-center">
+        <button class="btn btn-link p-0 text-decoration-none" type="button"
+                data-bs-toggle="collapse" data-bs-target="#pem-collapse"
+                aria-expanded="false" aria-controls="pem-collapse">
+          <i class="mdi mdi-certificate"></i> Certificate PEM
+        </button>
+        <span>
+          <button type="button" class="btn btn-sm btn-secondary" id="pem-copy-btn">
+            <i class="mdi mdi-content-copy"></i> Copy
+          </button>
+          <button type="button" class="btn btn-sm btn-primary" id="pem-download-btn">
+            <i class="mdi mdi-download"></i> Download
+          </button>
+        </span>
+      </h5>
+      <div class="collapse" id="pem-collapse">
+        <div class="card-body">
+          <pre id="pem-content" class="mb-0" style="max-height: 24rem; overflow-y: auto;">{{ object.pem_content }}</pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script type="text/javascript">
+  (function () {
+    // The public PEM as a JS string (escapejs keeps newlines/quotes intact).
+    const pem = "{{ object.pem_content|escapejs }}";
+    const filename = "{{ object.common_name|escapejs|default:'certificate' }}.pem";
+
+    const copyBtn = document.getElementById("pem-copy-btn");
+    if (copyBtn) {
+      copyBtn.addEventListener("click", function () {
+        const done = function () {
+          const original = copyBtn.innerHTML;
+          copyBtn.innerHTML = '<i class="mdi mdi-check"></i> Copied';
+          setTimeout(function () { copyBtn.innerHTML = original; }, 2000);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(pem).then(done).catch(function () {
+            window.prompt("Copy the certificate PEM:", pem);
+          });
+        } else {
+          window.prompt("Copy the certificate PEM:", pem);
+        }
+      });
+    }
+
+    const dlBtn = document.getElementById("pem-download-btn");
+    if (dlBtn) {
+      dlBtn.addEventListener("click", function () {
+        const blob = new Blob([pem], { type: "application/x-pem-file" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      });
+    }
+  })();
+</script>
+{% endif %}
+
 {% if object.is_acme %}
 <div class="row mb-3">
   <div class="col col-12">

--- a/tests/test_pem_display.py
+++ b/tests/test_pem_display.py
@@ -1,0 +1,110 @@
+"""Render tests for the public-PEM section on the certificate detail page (#113).
+
+The public certificate PEM (``Certificate.pem_content``) is shown on the detail
+page to any user with VIEW permission, in a collapsible card with copy/download
+controls. These tests render the real detail view in the NetBox container and
+assert the section appears when a PEM is present and is absent otherwise.
+
+Requires a real NetBox environment (DB + templates); skipped on the host unit
+lane via the find_spec guard.
+"""
+
+import contextlib
+import importlib.util
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+try:
+    _spec = importlib.util.find_spec("netbox")
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
+
+if NETBOX_AVAILABLE:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
+
+    with contextlib.suppress(Exception):
+        django.setup()
+
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox not available - run these tests inside the Docker container",
+)
+
+pytestmark = pytest.mark.integration
+
+SAMPLE_PEM = "-----BEGIN CERTIFICATE-----\nMIIBpemDisplayRenderTestContent\n-----END CERTIFICATE-----"
+
+
+def _superuser():
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+    user, _ = User.objects.get_or_create(
+        username="test_pem_display_user",
+        defaults={"is_superuser": True},
+    )
+    if not user.is_superuser:
+        user.is_superuser = True
+        user.save()
+    return user
+
+
+def _make_certificate(**overrides):
+    from netbox_ssl.models import Certificate
+
+    fields = {
+        "common_name": "pem-display-test.example.com",
+        "serial_number": "PEMDISPLAYTEST",
+        "issuer": "Test CA",
+        "valid_from": datetime(2025, 1, 1, tzinfo=timezone.utc),
+        "valid_to": datetime(2027, 1, 1, tzinfo=timezone.utc),
+        "status": "active",
+        "pem_content": SAMPLE_PEM,
+    }
+    fields.update(overrides)
+    return Certificate.objects.create(**fields)
+
+
+@requires_netbox
+def test_pem_section_rendered_when_pem_present():
+    """A certificate with pem_content shows the PEM card + copy/download controls."""
+    from django.test import Client
+
+    cert = _make_certificate()
+    try:
+        client = Client()
+        client.force_login(_superuser())
+        resp = client.get(cert.get_absolute_url())
+        assert resp.status_code == 200
+        html = resp.content.decode()
+        assert "Certificate PEM" in html
+        assert 'id="pem-content"' in html
+        assert "pem-copy-btn" in html
+        assert "pem-download-btn" in html
+        # The actual PEM body is rendered inside the <pre> block.
+        assert "MIIBpemDisplayRenderTestContent" in html
+    finally:
+        cert.delete()
+
+
+@requires_netbox
+def test_pem_section_absent_when_no_pem():
+    """A certificate without pem_content does NOT render the PEM card."""
+    from django.test import Client
+
+    cert = _make_certificate(serial_number="PEMDISPLAYNONE", pem_content="")
+    try:
+        client = Client()
+        client.force_login(_superuser())
+        resp = client.get(cert.get_absolute_url())
+        assert resp.status_code == 200
+        html = resp.content.decode()
+        # The section is guarded by {% if object.pem_content %}.
+        assert 'id="pem-content"' not in html
+        assert "pem-copy-btn" not in html
+    finally:
+        cert.delete()


### PR DESCRIPTION
## Summary

Implements #113 (community request). Operators with **view-only** access could see parsed certificate metadata but not the actual public PEM — it was only reachable from the edit form, forcing admins to grant broader edit permissions just so someone could retrieve a certificate for deployment/troubleshooting.

This adds a collapsible **"Certificate PEM"** card to the certificate detail page with copy-to-clipboard and download controls, visible to any user with normal **view** permission.

## Implementation

- **`netbox_ssl/templates/netbox_ssl/certificate.html`** — a new collapsible card (placed after the comments panel, before the ACME/renewal sections), rendered only when `{% if object.pem_content %}`. Read-only `<pre>` with `max-height` + scroll; "Copy" uses the Clipboard API (with a `window.prompt` fallback) and "Download" builds a client-side `Blob` (no server round-trip, no CORS). The PEM is passed to JS via `|escapejs` (preserves newlines/quotes) and rendered HTML-escaped in the `<pre>`.
- **No view/serializer change needed.** `CertificateView` is a `generic.ObjectView` (applies `.restrict(user, "view")`) and does **not** defer `pem_content` — only the *list* view defers it (`certificates.py:62`). So view permission is the gate, and the field is already in context.

## Security

`Certificate.pem_content` stores the **public certificate only** ("Certificate in PEM format (public certificate only)", `certificates.py:292`); private keys are rejected at import by the parser. Exposing it to view-perm users reveals nothing beyond the issuer/fingerprint/SAN/validity metadata already shown on the page. Tenant boundaries are still enforced by NetBox's `.restrict()`.

## Tests

`tests/test_pem_display.py` (Docker integration lane, `@requires_netbox`, marked `integration`):
- `test_pem_section_rendered_when_pem_present` — renders the detail view, asserts the PEM card, `<pre>`, copy/download buttons, and the PEM body are present.
- `test_pem_section_absent_when_no_pem` — asserts the section is **not** rendered when `pem_content` is empty.

Verified in a real **NetBox v4.6.0** container: both pass (HTTP 200, section present/absent as expected). Host unit lane unaffected — the tests are marked `integration` (deselected under `-m unit`) and skip cleanly via the `find_spec` guard (`2 skipped`, no errors). Full host `-m unit`: **811 passed**.

## Notes

Minor / community enhancement, no migration, no breaking change. Aligned with the plugin's passive-administration model — inventory/retrieval only, no new active capability.