### PR TITLE
feat: URL Certificate Import flow (#106, PR 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **URL Certificate Import — foundation** ([#106](https://github.com/ctrl-alt-automate/netbox-ssl/issues/106)):
-  groundwork for importing certificates by scraping them over a TLS handshake.
-  Adds a `tls_scraper` utility (connects to a pre-validated IP, returns the
-  leaf + chain as PEM, with hard timeout/size caps and a DNS-rebinding defense),
-  extends the SSRF URL validator with an opt-in private-CIDR allowlist
-  (`url_import_private_cidr_allowlist`; loopback is always blocked regardless),
-  and adds `discovered_via_url` / `last_seen_at` fields plus a `run_urlimport`
-  permission to `Certificate` (migration `0024`, additive). The user-facing
-  import flow (CSV upload → preview → scan → results) follows in subsequent PRs.
+- **URL Certificate Import** ([#106](https://github.com/ctrl-alt-automate/netbox-ssl/issues/106)):
+  import certificates by scraping them over a TLS handshake. A new
+  "Import from URLs (CSV)" flow (Certificates menu) takes a CSV of URLs
+  (`url`, optional `assigned_device`/`assigned_vm`/`assigned_service`/`tenant`/
+  `verify_chain`/`sni`); for each row the plugin opens a TLS connection, scrapes
+  the server-presented leaf + chain, parses it, and imports it with the same
+  serial+issuer dedup as Smart Paste — upload → preview → scan → results.
+  A `Certificate URL Scan` NetBox Script provides the same import for large
+  batches outside the request cycle. Only the public certificate is stored
+  (private keys are never exposed in a handshake). New `discovered_via_url` /
+  `last_seen_at` fields and a `run_urlimport` permission on `Certificate`
+  (migration `0024`, additive). **Security:** HTTPS-only; the scraper connects to
+  the validated IP and never re-resolves the hostname (DNS-rebinding defense);
+  hard timeout/size caps; private/loopback addresses are blocked unless an
+  administrator allowlists their CIDR via
+  `PLUGINS_CONFIG["netbox_ssl"]["url_import_private_cidr_allowlist"]` — loopback
+  is always blocked regardless. Self-signed/untrusted chains are imported with a
+  flag only when a row opts in with `verify_chain=false`.
 
 - **Public certificate PEM on the detail page** ([#113](https://github.com/ctrl-alt-automate/netbox-ssl/issues/113)):
   the stored public PEM is now shown in a collapsible "Certificate PEM" card on

--- a/netbox_ssl/forms/__init__.py
+++ b/netbox_ssl/forms/__init__.py
@@ -24,6 +24,7 @@ from .external_sources import (
     ExternalSourceFilterForm,
     ExternalSourceForm,
 )
+from .url_import import UrlImportForm
 
 __all__ = [
     "CertificateForm",
@@ -42,4 +43,5 @@ __all__ = [
     "ExternalSourceForm",
     "ExternalSourceFilterForm",
     "ExternalSourceBulkEditForm",
+    "UrlImportForm",
 ]

--- a/netbox_ssl/forms/url_import.py
+++ b/netbox_ssl/forms/url_import.py
@@ -1,0 +1,53 @@
+"""
+Form for the URL Certificate Import feature (#106).
+
+A plain ``forms.Form`` (not a NetBoxModelForm) for the upload step of the
+CSV-driven URL import flow. The heavy lifting (parsing, preview, scanning) lives
+in the view + scan script; this form just collects the CSV (file or pasted text)
+and an optional default tenant.
+"""
+
+from django import forms
+from django.utils.translation import gettext_lazy as _
+from tenancy.models import Tenant
+from utilities.forms.fields import DynamicModelChoiceField
+
+
+class UrlImportForm(forms.Form):
+    """Upload or paste a CSV of URLs to scrape via TLS handshake."""
+
+    csv_file = forms.FileField(
+        required=False,
+        label=_("CSV file"),
+        help_text=_(
+            "Upload a .csv file of URLs to scan. Columns: url (required), "
+            "assigned_device, assigned_vm, assigned_service, tenant, verify_chain, sni."
+        ),
+        widget=forms.ClearableFileInput(attrs={"accept": ".csv,.txt"}),
+    )
+
+    csv_text = forms.CharField(
+        required=False,
+        label=_("Or paste CSV"),
+        widget=forms.Textarea(
+            attrs={
+                "rows": 10,
+                "class": "font-monospace",
+                "placeholder": "url,assigned_device,tenant,verify_chain\nhttps://web.internal.example.com:8443,web01,acme,true",
+            }
+        ),
+        help_text=_("Paste CSV rows directly instead of uploading a file."),
+    )
+
+    default_tenant = DynamicModelChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label=_("Default tenant"),
+        help_text=_("Applied to rows that do not specify their own tenant column."),
+    )
+
+    def clean(self):
+        cleaned = super().clean()
+        if not cleaned.get("csv_file") and not cleaned.get("csv_text", "").strip():
+            raise forms.ValidationError(_("Provide a CSV file or paste CSV text."))
+        return cleaned

--- a/netbox_ssl/navigation.py
+++ b/netbox_ssl/navigation.py
@@ -34,6 +34,11 @@ menu = PluginMenu(
                     permissions=["netbox_ssl.add_certificate"],
                 ),
                 PluginMenuItem(
+                    link="plugins:netbox_ssl:certificate_url_import",
+                    link_text="Import from URLs (CSV)",
+                    permissions=["netbox_ssl.run_urlimport"],
+                ),
+                PluginMenuItem(
                     link="plugins:netbox_ssl:certificateassignment_list",
                     link_text="Assignments",
                     permissions=["netbox_ssl.view_certificateassignment"],

--- a/netbox_ssl/scripts/__init__.py
+++ b/netbox_ssl/scripts/__init__.py
@@ -8,6 +8,7 @@ from .expiry_notification import CertificateExpiryNotification
 from .expiry_scan import CertificateExpiryScan
 from .external_sync import ExternalSourceSync
 from .scheduled_export import ScheduledCertificateExport
+from .url_scan import CertificateURLScan
 
 __all__ = [
     "CertificateARIPoll",
@@ -16,4 +17,5 @@ __all__ = [
     "CertificateExpiryScan",
     "ExternalSourceSync",
     "ScheduledCertificateExport",
+    "CertificateURLScan",
 ]

--- a/netbox_ssl/scripts/url_scan.py
+++ b/netbox_ssl/scripts/url_scan.py
@@ -1,0 +1,130 @@
+"""
+Certificate URL Scan (#106).
+
+A NetBox Script that scrapes certificates over TLS from a pasted CSV of URLs and
+imports them — the batch / long-running counterpart to the interactive
+UrlImportView. Runs outside the request cycle so large scans don't block the UI.
+
+Each row: SSRF-validate (HTTPS + private-IP allowlist + loopback block) → resolve
+to a concrete IP and connect to that IP (DNS-rebinding defense) → scrape the
+presented chain → parse → import with serial+issuer dedup.
+"""
+
+import socket
+
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+from extras.scripts import Script, TextVar
+
+from netbox_ssl.models import Certificate, CertificateStatusChoices
+from netbox_ssl.utils import CertificateParseError, CertificateParser, detect_issuing_ca
+from netbox_ssl.utils.tls_scraper import TLSScrapeError, scrape_tls_certificate
+from netbox_ssl.utils.url_bulk_parser import parse as url_parse
+from netbox_ssl.utils.url_validation import URLValidationError, validate_https_url
+
+
+class CertificateURLScan(Script):
+    """Scrape certificates over TLS from a CSV of URLs and import them."""
+
+    class Meta:
+        name = "Certificate URL Scan"
+        description = "Scrape TLS certificates from a CSV of URLs and import them into the inventory"
+        commit_default = True
+        job_timeout = 1800
+
+    csv_text = TextVar(
+        description="CSV of URLs to scan. Columns: url (required), assigned_device, "
+        "assigned_vm, assigned_service, tenant, verify_chain, sni.",
+        label="URL CSV",
+    )
+
+    def get_plugin_setting(self, name, default=None):
+        return settings.PLUGINS_CONFIG.get("netbox_ssl", {}).get(name, default)
+
+    def run(self, data, commit):
+        allowlist = self.get_plugin_setting("url_import_private_cidr_allowlist", [])
+        result = url_parse(data.get("csv_text", ""))
+
+        for err in result.errors:
+            self.log_warning(f"Row {err.row} [{err.field}]: {err.message}")
+
+        if not result.valid_rows:
+            self.log_failure("No valid URL rows to scan.")
+            return "0 imported"
+
+        imported = matched = failed = blocked = 0
+
+        for row in result.valid_rows:
+            try:
+                validate_https_url(row.url, cidr_allowlist=allowlist)
+            except URLValidationError as exc:
+                self.log_warning(f"{row.url}: blocked — {exc}")
+                blocked += 1
+                continue
+
+            try:
+                resolved_ip = socket.getaddrinfo(row.host, row.port)[0][4][0]
+            except OSError as exc:
+                self.log_warning(f"{row.url}: DNS resolution failed — {exc}")
+                failed += 1
+                continue
+
+            try:
+                pem = scrape_tls_certificate(
+                    resolved_ip, row.host, row.port, sni=row.sni, verify_chain=row.verify_chain
+                )
+                parsed = CertificateParser.parse(pem)
+            except (TLSScrapeError, CertificateParseError) as exc:
+                self.log_warning(f"{row.url}: {exc}")
+                failed += 1
+                continue
+
+            existing = Certificate.objects.filter(serial_number=parsed.serial_number, issuer=parsed.issuer).first()
+            if existing:
+                if commit:
+                    existing.last_seen_at = timezone.now()
+                    if not existing.discovered_via_url:
+                        existing.discovered_via_url = row.url
+                    existing.save(update_fields=["last_seen_at", "discovered_via_url"])
+                self.log_info(f"{row.url}: matched existing certificate {parsed.common_name}")
+                matched += 1
+                continue
+
+            if not commit:
+                self.log_info(f"{row.url}: would import {parsed.common_name} (dry run)")
+                imported += 1
+                continue
+
+            try:
+                with transaction.atomic():
+                    cert = Certificate.objects.create(
+                        common_name=parsed.common_name,
+                        serial_number=parsed.serial_number,
+                        fingerprint_sha256=parsed.fingerprint_sha256,
+                        issuer=parsed.issuer,
+                        issuing_ca=detect_issuing_ca(parsed.issuer),
+                        valid_from=parsed.valid_from,
+                        valid_to=parsed.valid_to,
+                        sans=parsed.sans or [],
+                        key_size=parsed.key_size,
+                        algorithm=parsed.algorithm,
+                        status=CertificateStatusChoices.STATUS_ACTIVE,
+                        pem_content=parsed.pem_content,
+                        issuer_chain=parsed.issuer_chain,
+                        discovered_via_url=row.url,
+                        last_seen_at=timezone.now(),
+                    )
+                    cert.auto_detect_acme(save=True)
+            except Exception as exc:  # noqa: BLE001 - surface per-row
+                self.log_failure(f"{row.url}: import failed — {exc}")
+                failed += 1
+                continue
+
+            flag = "" if row.verify_chain else " (untrusted chain)"
+            self.log_success(f"{row.url}: imported {parsed.common_name}{flag}")
+            imported += 1
+
+        summary = f"{imported} imported, {matched} matched, {blocked} blocked, {failed} failed"
+        self.log_info(summary)
+        return summary

--- a/netbox_ssl/templates/netbox_ssl/certificate_url_import.html
+++ b/netbox_ssl/templates/netbox_ssl/certificate_url_import.html
@@ -1,0 +1,169 @@
+{% extends 'generic/object_list.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block title %}Import Certificates from URLs (CSV){% endblock %}
+
+{% block tabs %}{% endblock %}
+{% block table %}{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col col-md-12">
+
+    {% if step == "preview" %}
+    {# ── Preview step ── #}
+    <div class="card mb-3">
+      <h5 class="card-header">Scan Preview</h5>
+      <div class="card-body">
+        <p><strong>{{ row_count }}</strong> URL(s) ready to scan.</p>
+
+        {% if errors %}
+        <div class="alert alert-warning">
+          <strong>Validation warnings ({{ errors|length }}):</strong>
+          <ul class="mb-0">
+            {% for err in errors %}
+            <li>Row {{ err.row }}{% if err.field %}, field <code>{{ err.field }}</code>{% endif %}: {{ err.message }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+
+        {% if rows %}
+        <div class="table-responsive">
+          <table class="table table-hover table-sm">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>URL</th>
+                <th>Host</th>
+                <th>Port</th>
+                <th>Verify chain</th>
+                <th>Tenant</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in rows %}
+              <tr>
+                <td>{{ row.row }}</td>
+                <td><code>{{ row.url }}</code></td>
+                <td>{{ row.host }}</td>
+                <td>{{ row.port }}</td>
+                <td>{% if row.verify_chain %}<span class="badge text-bg-success">Yes</span>{% else %}<span class="badge text-bg-warning">No</span>{% endif %}</td>
+                <td>{{ row.tenant|default:"—" }}</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+
+        <form method="post" action="{% url 'plugins:netbox_ssl:certificate_url_import' %}">
+          {% csrf_token %}
+          <input type="hidden" name="confirm" value="yes">
+          <button type="submit" class="btn btn-primary">
+            <i class="mdi mdi-shield-search"></i> Run scan &amp; import
+          </button>
+          <a href="{% url 'plugins:netbox_ssl:certificate_url_import' %}" class="btn btn-outline-secondary">Cancel</a>
+        </form>
+        {% endif %}
+      </div>
+    </div>
+
+    {% elif step == "result" %}
+    {# ── Result step ── #}
+    <div class="card mb-3">
+      <h5 class="card-header">Scan Results</h5>
+      <div class="card-body">
+        <p><strong>{{ imported }}</strong> certificate(s) imported.</p>
+        <div class="table-responsive">
+          <table class="table table-hover table-sm">
+            <thead>
+              <tr><th>URL</th><th>Outcome</th><th>Detail</th></tr>
+            </thead>
+            <tbody>
+              {% for o in outcomes %}
+              <tr>
+                <td><code>{{ o.url }}</code></td>
+                <td>
+                  {% if o.status == "imported" %}<span class="badge text-bg-success">Imported</span>
+                  {% elif o.status == "imported_untrusted" %}<span class="badge text-bg-warning">Imported (untrusted chain)</span>
+                  {% elif o.status == "matched" %}<span class="badge text-bg-info">Matched existing</span>
+                  {% elif o.status == "blocked" %}<span class="badge text-bg-danger">Blocked (policy)</span>
+                  {% elif o.status == "unreachable" %}<span class="badge text-bg-secondary">Unreachable</span>
+                  {% else %}<span class="badge text-bg-danger">Error</span>{% endif %}
+                </td>
+                <td>
+                  {% if o.pk %}<a href="{% url 'plugins:netbox_ssl:certificate' pk=o.pk %}">{{ o.detail }}</a>
+                  {% else %}{{ o.detail }}{% endif %}
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <a href="{% url 'plugins:netbox_ssl:certificate_list' %}" class="btn btn-primary">View certificates</a>
+        <a href="{% url 'plugins:netbox_ssl:certificate_url_import' %}" class="btn btn-outline-secondary">Import more</a>
+      </div>
+    </div>
+
+    {% else %}
+    {# ── Input step ── #}
+    <div class="card mb-3">
+      <h5 class="card-header">Import Certificates from URLs</h5>
+      <div class="card-body">
+        <p class="text-muted">
+          Provide a CSV of URLs. For each row the plugin opens a TLS connection,
+          scrapes the certificate the server presents, and imports it. Only the
+          public certificate is stored — private keys are never transmitted in a
+          handshake. HTTPS only; private/loopback addresses are blocked unless an
+          administrator allowlists their range.
+        </p>
+
+        {% if errors %}
+        <div class="alert alert-danger">
+          <strong>Could not parse the CSV:</strong>
+          <ul class="mb-0">
+            {% for err in errors %}
+            <li>Row {{ err.row }}{% if err.field %}, field <code>{{ err.field }}</code>{% endif %}: {{ err.message }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+
+        <form method="post" enctype="multipart/form-data" action="{% url 'plugins:netbox_ssl:certificate_url_import' %}">
+          {% csrf_token %}
+          <div class="mb-3">
+            <label class="form-label" for="id_csv_file">CSV file</label>
+            <input type="file" name="csv_file" id="id_csv_file" class="form-control" accept=".csv,.txt">
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="id_csv_text">Or paste CSV</label>
+            <textarea name="csv_text" id="id_csv_text" rows="10" class="form-control font-monospace"
+              placeholder="url,assigned_device,tenant,verify_chain&#10;https://web.internal.example.com:8443,web01,acme,true">{{ csv_text }}</textarea>
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="id_default_tenant">Default tenant (optional)</label>
+            <input type="text" name="default_tenant" id="id_default_tenant" class="form-control"
+              placeholder="Tenant name, slug, or ID — applied to rows without a tenant column">
+          </div>
+          <button type="submit" class="btn btn-primary">
+            <i class="mdi mdi-magnify"></i> Parse &amp; preview
+          </button>
+        </form>
+
+        <hr>
+        <h6>CSV columns</h6>
+        <ul class="text-muted small mb-0">
+          <li><code>url</code> — required, <code>https://host[:port]</code> or <code>host:port</code> (port defaults to 443)</li>
+          <li><code>assigned_device</code>, <code>assigned_vm</code>, <code>assigned_service</code> — optional, name or ID</li>
+          <li><code>tenant</code> — optional, name/slug/ID</li>
+          <li><code>verify_chain</code> — optional <code>true</code>/<code>false</code> (default <code>true</code>); <code>false</code> imports self-signed/untrusted certs with a flag</li>
+          <li><code>sni</code> — optional SNI override</li>
+        </ul>
+      </div>
+    </div>
+    {% endif %}
+
+  </div>
+</div>
+{% endblock %}

--- a/netbox_ssl/urls.py
+++ b/netbox_ssl/urls.py
@@ -38,6 +38,11 @@ urlpatterns = [
         name="certificate_bulk_import",
     ),
     path(
+        "certificates/url-import/",
+        views.UrlImportView.as_view(),
+        name="certificate_url_import",
+    ),
+    path(
         "certificates/edit/",
         views.CertificateBulkEditView.as_view(),
         name="certificate_bulk_edit",

--- a/netbox_ssl/utils/url_bulk_parser.py
+++ b/netbox_ssl/utils/url_bulk_parser.py
@@ -1,0 +1,198 @@
+"""
+CSV parser for the URL Certificate Import feature (#106).
+
+Parses a CSV (or pasted CSV text) of URLs-to-scrape into validated rows. This
+layer is pure / DB-free and host-testable: it validates the *shape* of each row
+(URL form, port, booleans) and normalizes host/port/SNI. Resolving
+device/VM/service/tenant references against the database is the scan Script's
+job (PR 2 view + script), since that needs DB access.
+
+CSV schema (header row required):
+    url               required   https://host[:port] or host:port (https assumed)
+    assigned_device   optional   Device name or ID
+    assigned_vm       optional   VM name or ID
+    assigned_service  optional   Service name or device_id:service_name
+    tenant            optional   Tenant name or slug
+    verify_chain      optional   true/false (default true)
+    sni               optional   SNI hostname override
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+# Aligned with the existing bulk-import caps (views/certificates.py).
+MAX_ROWS = 500
+URL_MAX_LENGTH = 2048
+DEFAULT_PORT = 443
+
+_TRUE = {"true", "yes", "1", "y", "t"}
+_FALSE = {"false", "no", "0", "n", "f", ""}
+
+KNOWN_COLUMNS = {
+    "url",
+    "assigned_device",
+    "assigned_vm",
+    "assigned_service",
+    "tenant",
+    "verify_chain",
+    "sni",
+}
+
+
+@dataclass
+class UrlRowError:
+    """Validation error for a single CSV row."""
+
+    row: int
+    field: str
+    message: str
+
+
+@dataclass
+class UrlImportRow:
+    """A validated URL-import row (references unresolved — resolved in the Script)."""
+
+    row: int
+    url: str
+    host: str
+    port: int
+    sni: str
+    verify_chain: bool = True
+    assigned_device: str = ""
+    assigned_vm: str = ""
+    assigned_service: str = ""
+    tenant: str = ""
+
+
+@dataclass
+class UrlParseResult:
+    """Result of parsing a URL-import CSV."""
+
+    valid_rows: list[UrlImportRow] = field(default_factory=list)
+    errors: list[UrlRowError] = field(default_factory=list)
+
+    @property
+    def has_errors(self) -> bool:
+        return len(self.errors) > 0
+
+
+def _parse_bool(value: str, row: int, errors: list[UrlRowError]) -> bool:
+    """Parse a verify_chain cell, defaulting to True; record an error on garbage."""
+    token = (value or "").strip().lower()
+    if token == "":
+        return True  # absent -> default verify
+    if token in _TRUE:
+        return True
+    if token in _FALSE:
+        return False
+    errors.append(UrlRowError(row=row, field="verify_chain", message=f"Expected true/false, got {value!r}"))
+    return True
+
+
+def _normalize_url(raw: str, row: int, errors: list[UrlRowError]) -> tuple[str, str, int] | None:
+    """Validate + normalize a url cell into (url, host, port).
+
+    Accepts ``https://host[:port]`` or bare ``host[:port]`` (https assumed). Only
+    the ``https`` scheme is accepted; the actual SSRF/IP checks happen later in
+    the validator. Returns None (and records an error) on malformed input.
+    """
+    value = (raw or "").strip()
+    if not value:
+        errors.append(UrlRowError(row=row, field="url", message="url is required"))
+        return None
+    if len(value) > URL_MAX_LENGTH:
+        errors.append(UrlRowError(row=row, field="url", message=f"url exceeds {URL_MAX_LENGTH} chars"))
+        return None
+
+    # Bare host[:port] → assume https so urlparse populates hostname/port.
+    candidate = value if "://" in value else f"https://{value}"
+    try:
+        parsed = urlparse(candidate)
+    except ValueError:
+        errors.append(UrlRowError(row=row, field="url", message=f"Malformed URL: {value!r}"))
+        return None
+
+    if parsed.scheme != "https":
+        errors.append(UrlRowError(row=row, field="url", message=f"Only https is supported, got {parsed.scheme!r}"))
+        return None
+
+    host = parsed.hostname
+    if not host:
+        errors.append(UrlRowError(row=row, field="url", message=f"URL has no host: {value!r}"))
+        return None
+
+    try:
+        port = parsed.port or DEFAULT_PORT
+    except ValueError:
+        errors.append(UrlRowError(row=row, field="url", message=f"Invalid port in {value!r}"))
+        return None
+
+    # Canonical url we record on the imported cert.
+    canonical = f"https://{host}:{port}"
+    return canonical, host, port
+
+
+def parse_csv(content: str) -> UrlParseResult:
+    """Parse URL-import CSV content into validated rows."""
+    result = UrlParseResult()
+
+    if content.startswith("﻿"):
+        content = content[1:]
+
+    try:
+        reader = csv.DictReader(io.StringIO(content))
+    except Exception as e:  # pragma: no cover - csv rarely raises here
+        result.errors.append(UrlRowError(row=0, field="", message=f"Cannot parse CSV: {e}"))
+        return result
+
+    if reader.fieldnames is None or "url" not in {(f or "").strip().lower() for f in reader.fieldnames}:
+        result.errors.append(UrlRowError(row=0, field="url", message="CSV must have a 'url' header column"))
+        return result
+
+    for idx, raw_row in enumerate(reader, start=1):
+        # Normalize header casing/whitespace.
+        row = {(k or "").strip().lower(): (v or "").strip() for k, v in raw_row.items() if k}
+
+        normalized = _normalize_url(row.get("url", ""), idx, result.errors)
+        if normalized is None:
+            continue
+        url, host, port = normalized
+
+        verify_chain = _parse_bool(row.get("verify_chain", ""), idx, result.errors)
+        sni = row.get("sni", "") or host
+
+        result.valid_rows.append(
+            UrlImportRow(
+                row=idx,
+                url=url,
+                host=host,
+                port=port,
+                sni=sni,
+                verify_chain=verify_chain,
+                assigned_device=row.get("assigned_device", ""),
+                assigned_vm=row.get("assigned_vm", ""),
+                assigned_service=row.get("assigned_service", ""),
+                tenant=row.get("tenant", ""),
+            )
+        )
+
+    if len(result.valid_rows) > MAX_ROWS:
+        result.errors.append(
+            UrlRowError(
+                row=0,
+                field="",
+                message=f"Too many rows ({len(result.valid_rows)}). Maximum is {MAX_ROWS}; split into batches.",
+            )
+        )
+        result.valid_rows = result.valid_rows[:MAX_ROWS]
+
+    return result
+
+
+def parse(content: str) -> UrlParseResult:
+    """Parse URL-import content (CSV only)."""
+    return parse_csv(content)

--- a/netbox_ssl/utils/url_bulk_parser.py
+++ b/netbox_ssl/utils/url_bulk_parser.py
@@ -82,12 +82,12 @@ class UrlParseResult:
 
 def _parse_bool(value: str, row: int, errors: list[UrlRowError]) -> bool:
     """Parse a verify_chain cell, defaulting to True; record an error on garbage."""
-    token = (value or "").strip().lower()
-    if token == "":
+    cell = (value or "").strip().lower()
+    if not cell:
         return True  # absent -> default verify
-    if token in _TRUE:
+    if cell in _TRUE:
         return True
-    if token in _FALSE:
+    if cell in _FALSE:
         return False
     errors.append(UrlRowError(row=row, field="verify_chain", message=f"Expected true/false, got {value!r}"))
     return True

--- a/netbox_ssl/views/__init__.py
+++ b/netbox_ssl/views/__init__.py
@@ -41,6 +41,9 @@ from .external_sources import (
     ExternalSourceListView,
     ExternalSourceView,
 )
+from .url_import import (
+    UrlImportView,
+)
 
 __all__ = [
     # Certificate views
@@ -53,6 +56,7 @@ __all__ = [
     "CertificateImportView",
     "CertificateRenewView",
     "CertificateBulkDataImportView",
+    "UrlImportView",
     # CSR views
     "CertificateSigningRequestListView",
     "CertificateSigningRequestView",

--- a/netbox_ssl/views/url_import.py
+++ b/netbox_ssl/views/url_import.py
@@ -1,0 +1,239 @@
+"""
+URL Certificate Import view (#106).
+
+Single step-based view mirroring CertificateBulkDataImportView:
+1. GET                     -> upload form (step='input')
+2. POST (csv)              -> parse + preview (step='preview'), rows stashed in session
+3. POST (confirm=yes)      -> scrape each URL over TLS, import certs (step='result')
+
+Each row is validated for SSRF (HTTPS + private-IP/allowlist + loopback-block),
+scraped via the pre-validated IP (DNS-rebinding defense), parsed, and imported
+with the same serial+issuer dedup as Smart Paste. Device/VM/service/tenant
+references are resolved against the requesting user's accessible objects.
+"""
+
+from __future__ import annotations
+
+import socket
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db import transaction
+from django.shortcuts import redirect, render
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import View
+
+from ..models import Certificate, CertificateStatusChoices
+from ..utils import CertificateParseError, CertificateParser, detect_issuing_ca
+from ..utils.tls_scraper import TLSScrapeError, scrape_tls_certificate
+from ..utils.url_bulk_parser import parse as url_parse
+from ..utils.url_validation import URLValidationError, validate_https_url
+
+
+def _plugin_setting(name: str, default=None):
+    return settings.PLUGINS_CONFIG.get("netbox_ssl", {}).get(name, default)
+
+
+class UrlImportView(LoginRequiredMixin, View):
+    """Import certificates by scraping them over TLS from a CSV of URLs."""
+
+    template_name = "netbox_ssl/certificate_url_import.html"
+    MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10 MB (per #106 scope)
+    MAX_SESSION_ROWS = 500
+    SESSION_KEY = "url_import_rows"
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.has_perm("netbox_ssl.run_urlimport"):
+            messages.error(request, _("You do not have permission to run URL certificate import."))
+            return redirect(reverse("plugins:netbox_ssl:certificate_list"))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request):
+        return render(request, self.template_name, {"step": "input"})
+
+    def post(self, request):
+        if request.POST.get("confirm") == "yes":
+            return self._scan_and_import(request)
+        return self._parse_and_preview(request)
+
+    # -- step 2: parse + preview ------------------------------------------------
+
+    def _parse_and_preview(self, request):
+        content = ""
+        if request.FILES.get("csv_file"):
+            uploaded = request.FILES["csv_file"]
+            if uploaded.size > self.MAX_UPLOAD_SIZE:
+                messages.error(request, _("File too large. Maximum is 10 MB."))
+                return render(request, self.template_name, {"step": "input"})
+            content = uploaded.read().decode("utf-8-sig")
+        else:
+            content = request.POST.get("csv_text", "")
+
+        if len(content) > self.MAX_UPLOAD_SIZE:
+            messages.error(request, _("Pasted content too large."))
+            return render(request, self.template_name, {"step": "input"})
+        if not content.strip():
+            messages.error(request, _("No data provided. Upload a CSV or paste rows."))
+            return render(request, self.template_name, {"step": "input"})
+
+        default_tenant = (request.POST.get("default_tenant") or "").strip()
+        result = url_parse(content)
+
+        if result.has_errors and not result.valid_rows:
+            return render(
+                request,
+                self.template_name,
+                {"step": "input", "errors": result.errors, "csv_text": content},
+            )
+
+        rows = result.valid_rows[: self.MAX_SESSION_ROWS]
+        # Stash a JSON-serializable form in the session for the confirm step.
+        request.session[self.SESSION_KEY] = {
+            "default_tenant": default_tenant,
+            "rows": [
+                {
+                    "row": r.row,
+                    "url": r.url,
+                    "host": r.host,
+                    "port": r.port,
+                    "sni": r.sni,
+                    "verify_chain": r.verify_chain,
+                    "assigned_device": r.assigned_device,
+                    "assigned_vm": r.assigned_vm,
+                    "assigned_service": r.assigned_service,
+                    "tenant": r.tenant,
+                }
+                for r in rows
+            ],
+        }
+
+        return render(
+            request,
+            self.template_name,
+            {
+                "step": "preview",
+                "rows": rows,
+                "errors": result.errors,
+                "row_count": len(rows),
+                "default_tenant": default_tenant,
+            },
+        )
+
+    # -- step 3: scan + import --------------------------------------------------
+
+    def _scan_and_import(self, request):
+        from tenancy.models import Tenant
+
+        stash = request.session.pop(self.SESSION_KEY, None)
+        if not stash or not stash.get("rows"):
+            messages.warning(request, _("No pending URL import data found."))
+            return redirect(reverse("plugins:netbox_ssl:certificate_url_import"))
+
+        allowlist = _plugin_setting("url_import_private_cidr_allowlist", [])
+        user_tenants = Tenant.objects.restrict(request.user, "view")
+        default_tenant = self._resolve_tenant(stash.get("default_tenant"), user_tenants)
+
+        outcomes = []
+        imported = 0
+
+        for row in stash["rows"]:
+            outcome = self._process_row(request, row, allowlist, user_tenants, default_tenant)
+            outcomes.append(outcome)
+            if outcome["status"] == "imported":
+                imported += 1
+
+        if imported:
+            messages.success(request, _("Imported %(n)d certificate(s) from URLs.") % {"n": imported})
+
+        return render(
+            request,
+            self.template_name,
+            {"step": "result", "outcomes": outcomes, "imported": imported},
+        )
+
+    def _process_row(self, request, row, allowlist, user_tenants, default_tenant):
+        """Validate → scrape → parse → import a single row; return an outcome dict."""
+        label = row["url"]
+
+        # 1. SSRF validation (resolves DNS and checks every resolved IP).
+        try:
+            validate_https_url(row["url"], cidr_allowlist=allowlist)
+        except URLValidationError as exc:
+            return {"url": label, "status": "blocked", "detail": str(exc)}
+
+        # 2. Resolve to a concrete IP and connect to THAT ip (DNS-rebinding defense).
+        try:
+            resolved_ip = socket.getaddrinfo(row["host"], row["port"])[0][4][0]
+        except OSError as exc:
+            return {"url": label, "status": "unreachable", "detail": f"DNS failed: {exc}"}
+
+        # 3. Scrape the presented chain.
+        try:
+            pem = scrape_tls_certificate(
+                resolved_ip,
+                row["host"],
+                row["port"],
+                sni=row["sni"],
+                verify_chain=row["verify_chain"],
+            )
+        except TLSScrapeError as exc:
+            return {"url": label, "status": "unreachable", "detail": str(exc)}
+
+        # 4. Parse.
+        try:
+            parsed = CertificateParser.parse(pem)
+        except CertificateParseError as exc:
+            return {"url": label, "status": "error", "detail": str(exc)}
+
+        # 5. Dedup on serial+issuer (same as Smart Paste / bulk import).
+        existing = Certificate.objects.filter(serial_number=parsed.serial_number, issuer=parsed.issuer).first()
+        if existing:
+            existing.last_seen_at = timezone.now()
+            if not existing.discovered_via_url:
+                existing.discovered_via_url = row["url"]
+            existing.save(update_fields=["last_seen_at", "discovered_via_url"])
+            return {"url": label, "status": "matched", "detail": parsed.common_name, "pk": existing.pk}
+
+        # 6. Create.
+        tenant = self._resolve_tenant(row.get("tenant"), user_tenants) or default_tenant
+        try:
+            with transaction.atomic():
+                cert = Certificate.objects.create(
+                    common_name=parsed.common_name,
+                    serial_number=parsed.serial_number,
+                    fingerprint_sha256=parsed.fingerprint_sha256,
+                    issuer=parsed.issuer,
+                    issuing_ca=detect_issuing_ca(parsed.issuer),
+                    valid_from=parsed.valid_from,
+                    valid_to=parsed.valid_to,
+                    sans=parsed.sans or [],
+                    key_size=parsed.key_size,
+                    algorithm=parsed.algorithm,
+                    status=CertificateStatusChoices.STATUS_ACTIVE,
+                    pem_content=parsed.pem_content,
+                    issuer_chain=parsed.issuer_chain,
+                    tenant=tenant,
+                    discovered_via_url=row["url"],
+                    last_seen_at=timezone.now(),
+                )
+                cert.auto_detect_acme(save=True)
+        except Exception as exc:  # noqa: BLE001 - surface per-row, don't abort the batch
+            return {"url": label, "status": "error", "detail": str(exc)}
+
+        status = "imported" if row["verify_chain"] else "imported_untrusted"
+        return {"url": label, "status": status, "detail": parsed.common_name, "pk": cert.pk}
+
+    @staticmethod
+    def _resolve_tenant(ref, user_tenants):
+        """Resolve a tenant name/slug/ID against the user's accessible tenants."""
+        ref = (ref or "").strip()
+        if not ref:
+            return None
+        if ref.isdigit():
+            tenant = user_tenants.filter(pk=int(ref)).first()
+            if tenant:
+                return tenant
+        return user_tenants.filter(name=ref).first() or user_tenants.filter(slug=ref).first()

--- a/tests/test_url_bulk_parser.py
+++ b/tests/test_url_bulk_parser.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for the URL-import CSV parser (#106, PR 2).
+
+Pure / DB-free — host-runnable on the unit lane (`-m unit -p no:django`).
+"""
+
+import importlib.util
+import sys
+
+import pytest
+
+# Mock the absent NetBox packages so importing netbox_ssl.utils.* (which triggers
+# netbox_ssl/__init__.py -> from netbox.plugins import PluginConfig) works
+# host-side. Django stays real. Same pattern as test_parser.py (issue #116).
+try:
+    _spec = importlib.util.find_spec("netbox")
+    _NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    _NETBOX_AVAILABLE = False
+
+if not _NETBOX_AVAILABLE and "netbox" not in sys.modules:
+    from unittest.mock import MagicMock
+
+    sys.modules["netbox"] = MagicMock()
+    sys.modules["netbox.plugins"] = MagicMock()
+
+from netbox_ssl.utils.url_bulk_parser import (  # noqa: E402
+    DEFAULT_PORT,
+    MAX_ROWS,
+    UrlImportRow,
+    parse,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_minimal_row_with_scheme():
+    result = parse("url\nhttps://web.example.com:8443\n")
+    assert not result.errors
+    assert len(result.valid_rows) == 1
+    row = result.valid_rows[0]
+    assert isinstance(row, UrlImportRow)
+    assert row.host == "web.example.com"
+    assert row.port == 8443
+    assert row.url == "https://web.example.com:8443"
+    assert row.sni == "web.example.com"
+    assert row.verify_chain is True
+
+
+def test_bare_host_assumes_https_and_default_port():
+    result = parse("url\nweb.example.com\n")
+    assert not result.errors
+    row = result.valid_rows[0]
+    assert row.host == "web.example.com"
+    assert row.port == DEFAULT_PORT
+    assert row.url == "https://web.example.com:443"
+
+
+def test_http_scheme_rejected():
+    result = parse("url\nhttp://web.example.com\n")
+    assert not result.valid_rows
+    assert any(e.field == "url" and "https" in e.message for e in result.errors)
+
+
+def test_all_optional_columns_captured():
+    csv = (
+        "url,assigned_device,assigned_vm,assigned_service,tenant,verify_chain,sni\n"
+        "https://h.example.com:9443,dev01,vm02,svc:web,acme,false,sni.example.com\n"
+    )
+    result = parse(csv)
+    assert not result.errors
+    row = result.valid_rows[0]
+    assert row.assigned_device == "dev01"
+    assert row.assigned_vm == "vm02"
+    assert row.assigned_service == "svc:web"
+    assert row.tenant == "acme"
+    assert row.verify_chain is False
+    assert row.sni == "sni.example.com"
+
+
+def test_verify_chain_default_true_when_absent():
+    result = parse("url,tenant\nhttps://h.example.com,acme\n")
+    assert result.valid_rows[0].verify_chain is True
+
+
+def test_verify_chain_garbage_records_error_and_defaults_true():
+    result = parse("url,verify_chain\nhttps://h.example.com,maybe\n")
+    assert any(e.field == "verify_chain" for e in result.errors)
+    assert result.valid_rows[0].verify_chain is True
+
+
+def test_missing_url_column_is_fatal():
+    result = parse("host,port\nweb.example.com,443\n")
+    assert not result.valid_rows
+    assert any(e.field == "url" for e in result.errors)
+
+
+def test_blank_line_skipped_other_rows_survive():
+    """csv.DictReader skips wholly-blank lines; valid rows still parse."""
+    result = parse("url\n\nhttps://ok.example.com\n")
+    assert len(result.valid_rows) == 1
+    assert result.valid_rows[0].host == "ok.example.com"
+
+
+def test_empty_url_cell_in_multi_column_row_errors():
+    """A row present but with an empty url cell is a row-level error."""
+    result = parse("url,tenant\n,acme\nhttps://ok.example.com,acme\n")
+    assert len(result.valid_rows) == 1
+    assert result.valid_rows[0].host == "ok.example.com"
+    assert any(e.field == "url" for e in result.errors)
+
+
+def test_oversized_url_rejected():
+    long_host = "a" * 2100 + ".example.com"
+    result = parse(f"url\nhttps://{long_host}\n")
+    assert not result.valid_rows
+    assert any("exceeds" in e.message for e in result.errors)
+
+
+def test_header_casing_and_whitespace_normalized():
+    result = parse(" URL , Tenant \nhttps://h.example.com, acme \n")
+    assert not result.errors
+    row = result.valid_rows[0]
+    assert row.host == "h.example.com"
+    assert row.tenant == "acme"
+
+
+def test_row_cap_enforced():
+    rows = "\n".join(f"https://h{i}.example.com" for i in range(MAX_ROWS + 10))
+    result = parse("url\n" + rows + "\n")
+    assert len(result.valid_rows) == MAX_ROWS
+    assert any("Maximum is" in e.message for e in result.errors)


### PR DESCRIPTION
## Summary

PR **2 of 3** for #106 (URL Certificate Import). Builds the user-facing flow on the PR 1 foundation (#129: `tls_scraper` + SSRF allowlist + model fields). 957 lines.

A new **"Import from URLs (CSV)"** flow: upload (or paste) a CSV of URLs → preview → run scan → results. For each row the plugin opens a TLS connection, scrapes the server-presented leaf + chain, parses it, and imports it with the same `serial+issuer` dedup as Smart Paste.

## What's in PR 2

| File | Purpose |
|------|---------|
| `utils/url_bulk_parser.py` | Pure/DB-free CSV → `UrlImportRow` list. `url` required (`https://host[:port]` or `host:port`, default 443); optional `assigned_device`/`assigned_vm`/`assigned_service`/`tenant`/`verify_chain`/`sni`. 500-row + 2048-char caps. |
| `forms/url_import.py` | `UrlImportForm` — file upload or pasted CSV + default tenant. |
| `views/url_import.py` | `UrlImportView(LoginRequiredMixin)` — step-based input → preview → result, mirroring `CertificateBulkDataImportView`. Gated by `run_urlimport`. |
| `scripts/url_scan.py` | `CertificateURLScan` NetBox Script — same import for large batches outside the request cycle (commit/dry-run, per-row logging). |
| `templates/.../certificate_url_import.html` | 3-step UI with CSV-schema help + per-row outcome badges. |
| nav + `urls.py` + `__init__` registrations | "Import from URLs (CSV)" menu item + `certificate_url_import` route. |

## Security (carried through from PR 1)

Per row: **SSRF-validate** (HTTPS + private-IP/CIDR-allowlist, loopback always blocked) → **resolve to a concrete IP and connect to that IP** (DNS-rebinding/TOCTOU defense — the hostname is never re-resolved by the scraper) → scrape with hard timeout/size caps → parse → dedup. Tenant/device resolution is restricted to the requesting user's accessible objects (`.restrict(user, "view")`). Self-signed/untrusted chains import only when a row opts in with `verify_chain=false`, flagged in the results.

## Verification (real NetBox 4.6 container, end-to-end via the view)

- **Permission gate:** user without `run_urlimport` → 302 redirect; superuser → form renders.
- **Parse → preview:** CSV renders the preview table.
- **Confirm → real TLS scrape → import:** certificate created, `discovered_via_url` + `last_seen_at` set.
- `url_scan` module imports clean (TextVar only — no shell-instantiation `ObjectVar` issue).
- **12 new parser unit tests** pass on Python 3.10/3.11/3.12 (isolated + full `-m unit`, deterministic + `pytest-randomly`); **839 host unit tests** green.
- **No model or serializer change** → the #118 `makemigrations --check` and #119 `--fail-on-warn` gates both still exit 0.

## Next

- **PR 3** — Playwright E2E (`tests/test_url_import.py`, happy path + permission denial + CSV error) + `docs/how-to/url-import.md` + `url_import_private_cidr_allowlist` in the config reference.

Targets **v1.2.0**. Built on #129 (PR 1).