### PR TITLE
feat: NetBox contact assignment support on certificates (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Contact assignment on certificates** ([#128](https://github.com/ctrl-alt-automate/netbox-ssl/issues/128)):
+  certificates now support NetBox's native contact assignment via `ContactsMixin`,
+  the same mechanism used by Devices, VMs, and prefixes. Assign administrative /
+  technical / renewal / security contacts (using your own NetBox contact roles)
+  from a **Contacts** tab on the certificate detail page — so "who owns this cert?"
+  is answerable at renewal time. No new permission (uses the standard
+  `tenancy.*_contactassignment` permissions) and no database migration (contact
+  assignments live in NetBox's existing `tenancy.ContactAssignment` table).
+
 - **URL Certificate Import** ([#106](https://github.com/ctrl-alt-automate/netbox-ssl/issues/106)):
   import certificates by scraping them over a TLS handshake. A new
   "Import from URLs (CSV)" flow (Certificates menu) takes a CSV of URLs

--- a/netbox_ssl/models/certificates.py
+++ b/netbox_ssl/models/certificates.py
@@ -14,6 +14,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 from netbox.models import NetBoxModel
+from netbox.models.features import ContactsMixin
 from utilities.choices import ChoiceSet
 
 logger = logging.getLogger("netbox_ssl.models")
@@ -141,7 +142,7 @@ _ACME_PATTERNS = {
 }
 
 
-class Certificate(NetBoxModel):
+class Certificate(ContactsMixin, NetBoxModel):
     """
     A TLS/SSL certificate.
 

--- a/netbox_ssl/urls.py
+++ b/netbox_ssl/urls.py
@@ -3,7 +3,7 @@ URL configuration for NetBox SSL plugin.
 """
 
 from django.urls import path
-from netbox.views.generic import ObjectChangeLogView
+from netbox.views.generic import ObjectChangeLogView, ObjectContactsView
 
 from . import models, views
 from .views.analytics import CertificateAnalyticsDashboardView
@@ -71,6 +71,12 @@ urlpatterns = [
         "certificates/<int:pk>/changelog/",
         ObjectChangeLogView.as_view(),
         name="certificate_changelog",
+        kwargs={"model": models.Certificate},
+    ),
+    path(
+        "certificates/<int:pk>/contacts/",
+        ObjectContactsView.as_view(),
+        name="certificate_contacts",
         kwargs={"model": models.Certificate},
     ),
     # Analytics / Insights URLs

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1,0 +1,109 @@
+"""
+Integration tests for Certificate contact-assignment support (#128).
+
+ContactsMixin gives Certificate a contacts tab + sub-page, backed by NetBox's
+tenancy.ContactAssignment. The model-level facts are covered by host unit tests
+in test_models.py (TestCertificateContacts); these tests guard the URL wiring
+(the one non-automatic part — the plugin hand-routes feature views) and the
+end-to-end assign → read-back path. They require a real NetBox DB and run in the
+Docker integration job.
+"""
+
+import contextlib
+import importlib.util
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+try:
+    _spec = importlib.util.find_spec("netbox")
+    NETBOX_AVAILABLE = _spec is not None and _spec.origin is not None
+except (ValueError, ModuleNotFoundError):
+    NETBOX_AVAILABLE = False
+
+if NETBOX_AVAILABLE:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+    import django
+
+    with contextlib.suppress(Exception):
+        django.setup()
+
+requires_netbox = pytest.mark.skipif(
+    not NETBOX_AVAILABLE,
+    reason="NetBox not available - run these tests inside the Docker container",
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _make_certificate(serial="CONTACTS-IT"):
+    from netbox_ssl.models import Certificate
+
+    return Certificate.objects.create(
+        common_name="contacts-it.example.com",
+        serial_number=serial,
+        issuer="Test CA",
+        valid_from=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        valid_to=datetime(2027, 1, 1, tzinfo=timezone.utc),
+        status="active",
+    )
+
+
+@requires_netbox
+def test_contacts_url_reverses():
+    """The hand-wired certificate_contacts route resolves (guards the URL gap)."""
+    from django.urls import reverse
+
+    url = reverse("plugins:netbox_ssl:certificate_contacts", args=[1])
+    assert url.endswith("/certificates/1/contacts/")
+
+
+@requires_netbox
+def test_detail_page_shows_contacts_tab():
+    """The certificate detail page renders the auto-registered Contacts tab."""
+    from django.contrib.auth import get_user_model
+    from django.test import Client
+
+    User = get_user_model()
+    user, _ = User.objects.get_or_create(username="contacts_it_user", defaults={"is_superuser": True})
+    if not user.is_superuser:
+        user.is_superuser = True
+        user.save()
+
+    cert = _make_certificate()
+    try:
+        client = Client()
+        client.force_login(user)
+        resp = client.get(cert.get_absolute_url())
+        assert resp.status_code == 200
+        # The Contacts tab links to the contacts sub-page.
+        assert f"/certificates/{cert.pk}/contacts/" in resp.content.decode()
+    finally:
+        cert.delete()
+
+
+@requires_netbox
+def test_assign_and_read_back_contact():
+    """A ContactAssignment to a Certificate is returned by get_contacts()."""
+    from django.contrib.contenttypes.models import ContentType
+    from tenancy.models import Contact, ContactAssignment, ContactRole
+
+    from netbox_ssl.models import Certificate
+
+    cert = _make_certificate(serial="CONTACTS-IT-RB")
+    role, _ = ContactRole.objects.get_or_create(name="Technical", slug="technical")
+    contact, _ = Contact.objects.get_or_create(name="Jane Ops")
+    assignment = ContactAssignment.objects.create(
+        object_type=ContentType.objects.get_for_model(Certificate),
+        object_id=cert.pk,
+        contact=contact,
+        role=role,
+    )
+    try:
+        contacts = cert.get_contacts()
+        assert contacts.count() == 1
+        assert contacts.first().contact.name == "Jane Ops"
+    finally:
+        assignment.delete()
+        cert.delete()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -705,3 +705,37 @@ class TestAssignmentTableRendering:
 
         source = inspect.getsource(CertificateAssignmentTable.render_assigned_object)
         assert "format_html" in source
+
+
+class TestCertificateContacts:
+    """Tests for NetBox contact assignment support on Certificate (#128)."""
+
+    @requires_netbox
+    @pytest.mark.unit
+    def test_certificate_has_contacts_mixin(self):
+        """Certificate inherits NetBox's ContactsMixin."""
+        from netbox.models.features import ContactsMixin
+
+        from netbox_ssl.models import Certificate
+
+        assert ContactsMixin in Certificate.__mro__
+
+    @requires_netbox
+    @pytest.mark.unit
+    def test_contacts_is_non_concrete_generic_relation(self):
+        """The contacts field is a GenericRelation — no DB column, so migration-free."""
+        from django.contrib.contenttypes.fields import GenericRelation
+
+        from netbox_ssl.models import Certificate
+
+        field = Certificate._meta.get_field("contacts")
+        assert isinstance(field, GenericRelation)
+        assert field.concrete is False
+
+    @requires_netbox
+    @pytest.mark.unit
+    def test_get_contacts_is_callable(self):
+        """ContactsMixin provides get_contacts()."""
+        from netbox_ssl.models import Certificate
+
+        assert callable(getattr(Certificate, "get_contacts", None))


### PR DESCRIPTION
## Summary

Implements #128 (community request by @gehogan3). Certificates now support NetBox's **native contact assignment** via `ContactsMixin` — the same mechanism Devices, VMs, and prefixes use. Assign administrative / technical / renewal / security contacts (using your own NetBox contact roles) from a **Contacts** tab on the certificate detail page, so "who owns this cert?" is answerable at renewal time.

Investigated first (empirically, against a live NetBox 4.6 instance) and scoped on the issue. Honoring the literal scope: **Certificate only** (CertificateAuthority is a trivial follow-up if wanted — same 2-line pattern).

## Changes (≈6 lines, 2 files)

| File | Change |
|------|--------|
| `models/certificates.py` | `Certificate(ContactsMixin, NetBoxModel)` + import. The mixin adds only a `GenericRelation` (`concrete=False`) backed by the existing `tenancy.ContactAssignment` table — **no column, no migration**. |
| `urls.py` | Explicit `ObjectContactsView` route (`certificate_contacts`). Required because this plugin hand-wires detail-page feature routes rather than using `get_model_urls()` — the contacts view auto-registers via `PluginConfig.ready()` but its URL must be added like the existing changelog route. |

**Framework-automatic — no work needed** (verified): the Contacts tab renders from the inherited `generic/object.html` template (no template edit), and **no serializer/GraphQL change** is required (`NetBoxModelSerializer` doesn't auto-expose contacts), so the REST API and OpenAPI schema are untouched.

## CI gates

- **#118 `makemigrations --check` (v4.6): passes** — migration-free, verified exit 0.
- **#119 `spectacular --validate --fail-on-warn` (v4.6): passes** — no serializer change, verified exit 0.

## Tests

- **Host unit** (`test_models.py::TestCertificateContacts`): `ContactsMixin` in MRO; `contacts` is a non-concrete `GenericRelation` (proves migration-free); `get_contacts` callable.
- **Integration** (`tests/test_contacts.py`, `@requires_netbox`): the `certificate_contacts` URL reverses (guards the hand-wiring gap), the detail page renders the Contacts tab, and an assigned `ContactAssignment` is returned by `get_contacts()`.

Verified in a real NetBox 4.6 container: all 3 integration tests + 3 unit tests pass, contact assigned + read back, tab + sub-page return 200. Host unit suite: **839 passed**.

> Note: the integration tests run without `pytest-django` (matching the CI integration job, which installs only `pytest boto3 moto`). pytest-django's default DB-block is not present there — confirmed per the #117 finding.

## Permissions

No new plugin permission — contact assignment uses NetBox's standard `tenancy.add_contactassignment` / `view_contactassignment` permissions.

Part of **v1.2.0**.