### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-31
+
+**Minor release** — three new features (URL certificate import, public-PEM display,
+certificate contacts), schema-generation hardening, and migration-drift fixes. Two
+additive migrations (`0023`, `0024`), no breaking changes; safe to upgrade from
+1.1.x.
+
 ### Added
 
 - **Contact assignment on certificates** ([#128](https://github.com/ctrl-alt-automate/netbox-ssl/issues/128)):

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Managing SSL certificates across your infrastructure shouldn't be a scavenger hu
 
 | Dependency | Version |
 |------------|---------|
-| NetBox     | 4.4.0 - 4.5.x |
+| NetBox     | 4.4.0 - 4.6.x |
 | Python     | 3.10+ |
 
 The plugin uses the Python [`cryptography`](https://cryptography.io/) library for X.509 certificate parsing (installed automatically as a dependency).
@@ -252,8 +252,9 @@ Add the widget to your NetBox dashboard to see:
 
 | NetBox Version | Plugin Version | Status |
 |:--------------:|:--------------:|:------:|
-| 4.5.x          | 0.7.x          | ✅ Primary |
-| 4.4.x          | 0.7.x          | ✅ Supported |
+| 4.6.x          | 1.1.x - 1.2.x  | ✅ Primary |
+| 4.5.x          | 1.1.x - 1.2.x  | ✅ Supported |
+| 4.4.x          | 1.1.x - 1.2.x  | ✅ Supported |
 | 4.3.x and older| —              | ❌ Unsupported |
 
 ## 📚 Documentation

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "1.1.1"
+version = "1.2.0"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## v1.2.0 release

Version bump 1.1.1 → 1.2.0 + CHANGELOG finalization + README support-matrix refresh (flagged by the pre-release audit).

**Payload** (all backward-compatible; two additive migrations 0023/0024):
- feat: URL Certificate Import — TLS-handshake scraping (#106)
- feat: contact assignment on certificates via ContactsMixin (#128)
- feat: public certificate PEM on the detail page for view-only users (#113)
- feat: OpenAPI schema warning-free + `--fail-on-warn` gate (#119)
- fix: compliance/ExternalSource migration drift + `makemigrations --check` gate (#118)
- fix: serialize gh-pages docs deploys to end the release-time race (#110)
- test: Python 3.10 mock patch-resolution fix + widen unit job (#116)

**Pre-flight audit (3 agents):** migration safety container-verified (additive, reversible, data preserved); CHANGELOG complete and accurate vs the diff; version ordering correct (MINOR). Two README blockers found + fixed in this PR.

Next: admin-merge → `dev → main` → tag v1.2.0 → publish.yml (verify-ci gate → PyPI) + docs.