### PR TITLE
test: adopt pytest-django for DB test isolation; restore bulk-import API tests (#117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
       - name: Install pytest in NetBox container
         run: |
           docker compose exec -T netbox bash -c "curl -sS https://bootstrap.pypa.io/get-pip.py | /opt/netbox/venv/bin/python"
-          docker compose exec -T netbox /opt/netbox/venv/bin/pip install pytest boto3 'moto[acm]>=5.0,<6.0'
+          docker compose exec -T netbox /opt/netbox/venv/bin/pip install pytest 'pytest-django>=4.11' boto3 'moto[acm]>=5.0,<6.0'
 
       - name: Copy tests to container
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Adopted `pytest-django` for database test isolation** ([#117](https://github.com/ctrl-alt-automate/netbox-ssl/issues/117)):
+  the in-container integration job now installs `pytest-django`, giving DB-touching
+  tests proper per-test transaction isolation. The 10 bulk-import API integration
+  tests (`TestBulkImportAPIIntegration`) — deterministically skipped since the
+  v1.1.1 stopgap — now run for real against the API + a test database. DB-touching
+  tests across the suite are marked `@pytest.mark.django_db` (the marker is
+  registered in `pytest.ini` so the `-p no:django` host unit lane stays clean under
+  `--strict-markers`). The cleaner isolation surfaced and fixed two latent test
+  bugs (an `IntegrityError` that poisoned the test transaction without a nested
+  `atomic()`, and a settings-mock helper that collapsed an explicit empty
+  recipient list to a fallback). Test-only change — no plugin code modified.
+
 ## [1.2.0] - 2026-05-31
 
 **Minor release** — three new features (URL certificate import, public-PEM display,

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,4 @@ markers =
     api: API integration tests (requires running NetBox + token)
     browser: Browser tests (Playwright)
     slow: Slow running tests
+    django_db: Requires Django DB access via pytest-django (registered here so the host lane, which runs -p no:django under --strict-markers, doesn't error on the marker)

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -56,6 +56,7 @@ requires_netbox = pytest.mark.skipif(
 )
 
 
+@pytest.mark.django_db
 @requires_netbox
 def test_openapi_schema_generation_succeeds():
     """The full OpenAPI schema must generate without raising (regression #111).

--- a/tests/test_aws_acm_adapter.py
+++ b/tests/test_aws_acm_adapter.py
@@ -542,6 +542,7 @@ def test_parse_acm_certificate_missing_optional_fields():
     assert cert.serial_number == ""
 
 
+@pytest.mark.django_db
 def test_list_certificate_arns_empty_account():
     from unittest.mock import MagicMock
 
@@ -563,6 +564,7 @@ def test_list_certificate_arns_empty_account():
     assert run() == []
 
 
+@pytest.mark.django_db
 def test_list_certificate_arns_single_cert():
     from unittest.mock import MagicMock
 
@@ -608,6 +610,7 @@ def test_list_certificate_arns_single_cert():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db
 def test_describe_and_get_happy_path():
     from unittest.mock import MagicMock
 
@@ -763,6 +766,7 @@ def _import_test_cert(client, cn: str) -> str:
     return client.import_certificate(Certificate=pem.encode(), PrivateKey=key_pem.encode())["CertificateArn"]
 
 
+@pytest.mark.django_db
 def test_fetch_certificates_empty_account_returns_empty_list():
     from unittest.mock import MagicMock
 
@@ -782,6 +786,7 @@ def test_fetch_certificates_empty_account_returns_empty_list():
     assert run() == []
 
 
+@pytest.mark.django_db
 def test_fetch_certificates_returns_imported_certs():
     from unittest.mock import MagicMock
 
@@ -808,6 +813,7 @@ def test_fetch_certificates_returns_imported_certs():
     assert cns == ["first.example.com", "second.example.com"]
 
 
+@pytest.mark.django_db
 def test_fetch_certificates_isolated_per_region():
     """ExternalSource configured for eu-west-1 only sees eu-west-1 certs."""
     from unittest.mock import MagicMock
@@ -836,6 +842,7 @@ def test_fetch_certificates_isolated_per_region():
     assert cns == ["europe.example.com"]
 
 
+@pytest.mark.django_db
 def test_fetch_certificates_skips_failed_per_cert_errors():
     """If one cert raises during fetch, others still succeed."""
     from unittest.mock import MagicMock, patch
@@ -878,6 +885,7 @@ def test_fetch_certificates_skips_failed_per_cert_errors():
     assert cns == ["good.example.com"]
 
 
+@pytest.mark.django_db
 def test_get_certificate_detail_found():
     from unittest.mock import MagicMock
 
@@ -903,6 +911,7 @@ def test_get_certificate_detail_found():
     assert cert.common_name == "lookup.example.com"
 
 
+@pytest.mark.django_db
 def test_get_certificate_detail_not_found_returns_none():
     from unittest.mock import MagicMock
 
@@ -929,6 +938,7 @@ def test_get_certificate_detail_not_found_returns_none():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db
 def test_test_connection_success_with_empty_account():
     from unittest.mock import MagicMock
 

--- a/tests/test_bulk_import.py
+++ b/tests/test_bulk_import.py
@@ -420,10 +420,10 @@ def api_client():
 
     User = get_user_model()
 
-    # Get or create admin user
+    # Get or create admin user (NetBox's User model has no is_staff field)
     user, _ = User.objects.get_or_create(
         username="test_bulk_import_user",
-        defaults={"is_superuser": True, "is_staff": True},
+        defaults={"is_superuser": True},
     )
 
     client = APIClient()
@@ -444,6 +444,7 @@ def cleanup_certificates():
         pass
 
 
+@pytest.mark.django_db
 class TestBulkImportAPIIntegration:
     """Integration tests that actually call the bulk import API endpoint."""
 
@@ -457,7 +458,7 @@ class TestBulkImportAPIIntegration:
             pytest.skip("Test certificate not available")
 
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [{"pem_content": cert}],
             format="json",
         )
@@ -486,7 +487,7 @@ class TestBulkImportAPIIntegration:
             pytest.skip("Not enough test certificates available")
 
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             certs,
             format="json",
         )
@@ -501,7 +502,7 @@ class TestBulkImportAPIIntegration:
     def test_bulk_import_rejects_empty_list(self, api_client):
         """Test that empty list is rejected with 400 error."""
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [],
             format="json",
         )
@@ -516,7 +517,7 @@ class TestBulkImportAPIIntegration:
     def test_bulk_import_rejects_non_list(self, api_client):
         """Test that non-list input is rejected with 400 error."""
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             {"pem_content": "test"},
             format="json",
         )
@@ -531,7 +532,7 @@ class TestBulkImportAPIIntegration:
     def test_bulk_import_rejects_invalid_certificate(self, api_client):
         """Test that invalid certificates are rejected with detailed errors."""
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [{"pem_content": "not a valid certificate"}],
             format="json",
         )
@@ -540,7 +541,8 @@ class TestBulkImportAPIIntegration:
         data = response.json()
         assert "failed_certificates" in data
         assert len(data["failed_certificates"]) == 1
-        assert data["failed_certificates"][0]["index"] == 0
+        # DRF ValidationError stringifies leaf scalars, so index comes back as "0".
+        assert int(data["failed_certificates"][0]["index"]) == 0
 
     @pytest.mark.integration
     @skip_if_no_django_api
@@ -558,7 +560,7 @@ class TestBulkImportAPIIntegration:
 
         # Mix valid and invalid certificates
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [
                 {"pem_content": cert},  # valid
                 {"pem_content": "invalid cert"},  # invalid
@@ -582,7 +584,7 @@ class TestBulkImportAPIIntegration:
             pytest.skip("Test certificate not available")
 
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [
                 {
                     "pem_content": cert,
@@ -604,7 +606,7 @@ class TestBulkImportAPIIntegration:
         certs = [{"pem_content": f"cert-{i}"} for i in range(101)]
 
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             certs,
             format="json",
         )
@@ -630,7 +632,7 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC7
         mixed_content = cert + "\n" + private_key
 
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [{"pem_content": mixed_content}],
             format="json",
         )
@@ -650,7 +652,7 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC7
 
         # First import should succeed
         response1 = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [{"pem_content": cert}],
             format="json",
         )
@@ -658,7 +660,7 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC7
 
         # Second import with same certificate should fail (duplicate)
         response2 = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [{"pem_content": cert}],
             format="json",
         )

--- a/tests/test_certificate_authority.py
+++ b/tests/test_certificate_authority.py
@@ -95,6 +95,7 @@ class TestCATypeChoices:
             assert len(CATypeChoices.CHOICES) == 3
 
 
+@pytest.mark.django_db
 class TestCertificateAuthorityModel:
     """Tests for CertificateAuthority model."""
 
@@ -126,14 +127,18 @@ class TestCertificateAuthorityModel:
     @requires_netbox
     def test_ca_unique_name_constraint(self):
         """Test that CA names must be unique."""
+        from django.db import IntegrityError, transaction
+
         ca1 = CertificateAuthority.objects.create(
             name="Unique CA",
             type=CATypeChoices.TYPE_PUBLIC,
         )
 
-        from django.db import IntegrityError
-
-        with pytest.raises(IntegrityError):
+        # Wrap the failing INSERT in a savepoint: under pytest-django's per-test
+        # transaction, an unhandled IntegrityError poisons the whole transaction
+        # (TransactionManagementError on any later query). atomic() rolls back
+        # just this savepoint so the test transaction stays usable.
+        with pytest.raises(IntegrityError), transaction.atomic():
             CertificateAuthority.objects.create(
                 name="Unique CA",
                 type=CATypeChoices.TYPE_INTERNAL,
@@ -143,6 +148,7 @@ class TestCertificateAuthorityModel:
         ca1.delete()
 
 
+@pytest.mark.django_db
 class TestCertificateAuthorityAutoDetection:
     """Tests for CA auto-detection functionality."""
 
@@ -274,6 +280,7 @@ class TestDefaultCertificateAuthorities:
             assert "issuer_pattern" in ca
 
 
+@pytest.mark.django_db
 class TestCertificateIssuingCA:
     """Tests for the issuing_ca field on Certificate model."""
 
@@ -359,6 +366,7 @@ class TestCertificateIssuingCA:
         cert.delete()
 
 
+@pytest.mark.django_db
 class TestCertificateAuthorityFilters:
     """Tests for CertificateAuthority filtersets."""
 
@@ -440,6 +448,7 @@ class TestCertificateAuthorityFilters:
             ca3.delete()
 
 
+@pytest.mark.django_db
 class TestCertificateFilterByIssuingCA:
     """Tests for filtering certificates by issuing CA."""
 

--- a/tests/test_comments_field.py
+++ b/tests/test_comments_field.py
@@ -65,6 +65,7 @@ def test_model_has_comments_field(model_name):
     assert "comments" in field_names, f"{model_name} is missing a 'comments' model field (#112)"
 
 
+@pytest.mark.django_db
 @requires_netbox
 @pytest.mark.parametrize("model_name,form_name", [(m, f) for m, f, _ in _AFFECTED])
 def test_form_comments_maps_to_model(model_name, form_name):

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -34,7 +34,7 @@ requires_netbox = pytest.mark.skipif(
     reason="NetBox not available - run these tests inside the Docker container",
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
 
 
 def _make_certificate(serial="CONTACTS-IT"):

--- a/tests/test_email_notification.py
+++ b/tests/test_email_notification.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # Mock netbox modules for local testing without NetBox
 _project_root = Path(__file__).parent.parent
 if str(_project_root) not in sys.path:
@@ -122,12 +124,18 @@ EMPTY_REPORT = {
 
 
 def _make_settings_mock(enabled: bool = True, recipients: list | None = None):
-    """Create a mock settings object."""
+    """Create a mock settings object.
+
+    Note: distinguish an explicit empty list (``[]`` — the "no recipients
+    configured" case) from the default (``None`` → a sample recipient). Using
+    ``recipients or [...]`` would collapse ``[]`` to the fallback and silently
+    break the no-recipients test.
+    """
     mock = MagicMock()
     mock.PLUGINS_CONFIG = {
         "netbox_ssl": {
             "notification_email_enabled": enabled,
-            "notification_email_recipients": recipients or ["admin@example.com"],
+            "notification_email_recipients": ["admin@example.com"] if recipients is None else recipients,
             "notification_email_subject_prefix": "[NetBox SSL]",
         }
     }
@@ -135,6 +143,7 @@ def _make_settings_mock(enabled: bool = True, recipients: list | None = None):
     return mock
 
 
+@pytest.mark.django_db
 class TestSendExpiryReport:
     @patch("netbox_ssl.utils.email.EmailMultiAlternatives")
     @patch("netbox_ssl.utils.email.render_to_string", side_effect=lambda t, c: f"rendered:{t}")

--- a/tests/test_external_source_form.py
+++ b/tests/test_external_source_form.py
@@ -4,7 +4,7 @@ import importlib.util
 
 import pytest
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.django_db]
 
 try:
     _spec = importlib.util.find_spec("netbox")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -546,6 +546,7 @@ class TestAssignmentModel:
         assert field.default is True
 
 
+@pytest.mark.django_db
 class TestAssignmentForm:
     """Tests for CertificateAssignmentForm."""
 

--- a/tests/test_pem_display.py
+++ b/tests/test_pem_display.py
@@ -34,7 +34,7 @@ requires_netbox = pytest.mark.skipif(
     reason="NetBox not available - run these tests inside the Docker container",
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
 
 SAMPLE_PEM = "-----BEGIN CERTIFICATE-----\nMIIBpemDisplayRenderTestContent\n-----END CERTIFICATE-----"
 


### PR DESCRIPTION
## Summary

Closes #117. Adopt `pytest-django` so DB-touching tests get proper per-test transaction isolation, and restore the 10 `TestBulkImportAPIIntegration` tests that have been deterministically **skipped** since the v1.1.1 #114 stopgap. They now run **for real** against the API + a test database.

Investigated empirically first (container experiments) — my earlier #117 findings feared a heavy isolated-step approach was needed; the investigation proved the simpler venv-wide install is clean because the in-container invocation runs from `/opt/netbox/netbox` (NetBox's WORKDIR) where pytest-django bootstraps Django via the shipped `pytest.ini`.

## Changes (test-only — no plugin code modified)

- **`ci.yml`**: install `pytest-django>=4.11` in the integration job's pip line. **No new step** — the existing `pytest /tmp/plugin_tests/ -v` invocation already runs from the right cwd. Verified: full suite collects 1162 tests cleanly, mock-based tests unaffected.
- **`pytest.ini`**: register the `django_db` marker. **Required** — the host unit lane runs `-p no:django --strict-markers`, where pytest-django doesn't register it, so a bare `@pytest.mark.django_db` would error host collection without this.
- **`@pytest.mark.django_db` on 42 DB-touching tests across 9 files** — per class where all methods hit the DB; surgical per-function in mixed files (e.g. `test_aws_acm_adapter`, where only 10/56 touch the DB).
- **`test_bulk_import.py`**: restore the API tests — fix the endpoint URL (`netbox-ssl` → `ssl`, the real plugin base_url; all 11 calls were 404ing), drop the nonexistent `is_staff` field from the superuser fixture, accept the stringified `failed_certificates` index (DRF `ValidationError` stringifies leaf scalars).

## Two latent bugs surfaced by the cleaner isolation (and fixed)

- `test_ca_unique_name_constraint`: an unhandled `IntegrityError` poisoned the per-test transaction (`TransactionManagementError` on cleanup). Wrapped the failing INSERT in a nested `transaction.atomic()` savepoint.
- `_make_settings_mock(True, [])`: `recipients or [...]` collapsed an explicit empty list to a sample recipient, so `test_skips_when_no_recipients` never actually tested the no-recipients path. Now distinguishes `[]` from `None`.

These passed before only because the old sys.modules-mock contamination ran them differently — exactly the kind of latent bug cleaner isolation is meant to expose.

## Verification

- Host unit lane: **839 passed** (deterministic + `pytest-randomly` seed 1337) — `django_db` marker registered, no strict-marker error.
- Full in-container suite with pytest-django: **1019 passed, 0 failed** (was 42 "Database access not allowed" failures).
- The 10 bulk-import API tests: **10/10 pass** against the real endpoint.
- `#118` `makemigrations --check` and `#119` `--fail-on-warn` gates: unaffected (no model/serializer change).

Targets the next release (test-infra only; could ride a patch or minor).