### PR TITLE
release: v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.1] - 2026-06-04
+
+**Patch release** — two NetBox 4.6 / Django 6.0 regression fixes (the Certificate
+Authorities list crash and the renewal permission gate), plus the test-isolation
+infrastructure work (`pytest-django`). No migrations, no breaking changes; safe
+to upgrade from 1.2.0.
 
 ### Changed
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,7 +6,10 @@ This document tracks compatibility between NetBox SSL plugin versions and NetBox
 
 | Plugin Version | NetBox Version | Python Version | Status |
 |:--------------:|:--------------:|:--------------:|:------:|
-| 1.1.x          | 4.6.x          | 3.10 - 3.12   | Primary |
+| 1.2.x          | 4.6.x          | 3.10 - 3.12   | Primary |
+| 1.2.x          | 4.5.x          | 3.10 - 3.12   | Supported |
+| 1.2.x          | 4.4.x          | 3.10 - 3.12   | Supported |
+| 1.1.x          | 4.6.x          | 3.10 - 3.12   | Supported |
 | 1.1.x          | 4.5.x          | 3.10 - 3.12   | Supported |
 | 1.1.x          | 4.4.x          | 3.10 - 3.12   | Supported |
 | 1.0.x          | 4.5.x          | 3.10 - 3.12   | Supported |

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "1.2.0"
+version = "1.2.1"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## v1.2.1 — patch release

Finalizes the version bump and CHANGELOG for **v1.2.1**. The actual fixes already landed on `dev`:

- **#137** — Certificate Authorities list `TypeError` (arg-less `format_html` under Django 6.0 / NetBox 4.6) — PR #138
- **#136** — `renew_certificate` no longer sufficient to renew (renew flow funneled through the import gate) — PR #138
- **#117** — `pytest-django` DB test isolation — PR #135

### This PR
- Bump version `1.2.0 → 1.2.1` (`pyproject.toml`, `netbox_ssl/__init__.py`)
- Finalize CHANGELOG `[1.2.1]` section (dated)
- Add the `1.2.x` row to `COMPATIBILITY.md` (NetBox 4.4–4.6, Python 3.10–3.12) — was stale at `1.1.x`

No migrations, no breaking changes; safe to upgrade from 1.2.0.

Release process: this PR → `dev`, then `dev → main`, then annotated tag `v1.2.1`.