### PR TITLE
release: v1.2.1 → main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
       - name: Install pytest in NetBox container
         run: |
           docker compose exec -T netbox bash -c "curl -sS https://bootstrap.pypa.io/get-pip.py | /opt/netbox/venv/bin/python"
-          docker compose exec -T netbox /opt/netbox/venv/bin/pip install pytest boto3 'moto[acm]>=5.0,<6.0'
+          docker compose exec -T netbox /opt/netbox/venv/bin/pip install pytest 'pytest-django>=4.11' boto3 'moto[acm]>=5.0,<6.0'
 
       - name: Copy tests to container
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `atomic()`, and a settings-mock helper that collapsed an explicit empty
   recipient list to a fallback). Test-only change — no plugin code modified.
 
+### Fixed
+
+- **Certificate Authorities list page crashed with a `TypeError` on NetBox 4.6**
+  ([#137](https://github.com/ctrl-alt-automate/netbox-ssl/issues/137)): several
+  table `render_*` methods built static badges with `format_html("<span …>")`
+  and no interpolation arguments. Django 6.0 (shipped with NetBox 4.6) turned
+  that long-standing misuse from a deprecation warning into a hard
+  `TypeError: args or kwargs must be provided.`, so any list whose rows hit one
+  of those badges 500'd as soon as a row existed — the CA list, but also the
+  External Sources list (enabled/disabled badge), the Certificates list (orphan
+  badge), and the CSR list (empty placeholder). All six call sites now pass the
+  badge label as a `format_html` interpolation argument, satisfying Django 6.0
+  while keeping the static markup in the trusted format string (and avoiding a
+  `mark_safe` security finding). A new `tests/test_table_format_html.py`
+  regression guard fails on any arg-less `format_html` in the tables package
+  under any Python/Django version.
+
 ## [1.2.0] - 2026-05-31
 
 **Minor release** — three new features (URL certificate import, public-PEM display,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Adopted `pytest-django` for database test isolation** ([#117](https://github.com/ctrl-alt-automate/netbox-ssl/issues/117)):
+  the in-container integration job now installs `pytest-django`, giving DB-touching
+  tests proper per-test transaction isolation. The 10 bulk-import API integration
+  tests (`TestBulkImportAPIIntegration`) — deterministically skipped since the
+  v1.1.1 stopgap — now run for real against the API + a test database. DB-touching
+  tests across the suite are marked `@pytest.mark.django_db` (the marker is
+  registered in `pytest.ini` so the `-p no:django` host unit lane stays clean under
+  `--strict-markers`). The cleaner isolation surfaced and fixed two latent test
+  bugs (an `IntegrityError` that poisoned the test transaction without a nested
+  `atomic()`, and a settings-mock helper that collapsed an explicit empty
+  recipient list to a fallback). Test-only change — no plugin code modified.
+
 ## [1.2.0] - 2026-05-31
 
 **Minor release** — three new features (URL certificate import, public-PEM display,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mark_safe` security finding). A new `tests/test_table_format_html.py`
   regression guard fails on any arg-less `format_html` in the tables package
   under any Python/Django version.
+- **`renew_certificate` permission no longer sufficient to renew certificates**
+  ([#136](https://github.com/ctrl-alt-automate/netbox-ssl/issues/136)): since
+  the renew workflow funnels the PEM paste through `CertificateImportView`, that
+  view's `import_certificate`/`add_certificate` gate blocked users who held only
+  `renew_certificate` — a regression for renewal-only roles. The import view now
+  also admits `renew_certificate` users, while a new guard keeps the net-new
+  import path gated on `import_certificate`/`add_certificate`, so renewal-only
+  users can complete renewals but cannot import brand-new certificates (no
+  privilege escalation). The detail-page **Renew** button is now wrapped in a
+  matching permission check.
 
 ## [1.2.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.1] - 2026-06-04
+
+**Patch release** — two NetBox 4.6 / Django 6.0 regression fixes (the Certificate
+Authorities list crash and the renewal permission gate), plus the test-isolation
+infrastructure work (`pytest-django`). No migrations, no breaking changes; safe
+to upgrade from 1.2.0.
 
 ### Changed
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,7 +6,10 @@ This document tracks compatibility between NetBox SSL plugin versions and NetBox
 
 | Plugin Version | NetBox Version | Python Version | Status |
 |:--------------:|:--------------:|:--------------:|:------:|
-| 1.1.x          | 4.6.x          | 3.10 - 3.12   | Primary |
+| 1.2.x          | 4.6.x          | 3.10 - 3.12   | Primary |
+| 1.2.x          | 4.5.x          | 3.10 - 3.12   | Supported |
+| 1.2.x          | 4.4.x          | 3.10 - 3.12   | Supported |
+| 1.1.x          | 4.6.x          | 3.10 - 3.12   | Supported |
 | 1.1.x          | 4.5.x          | 3.10 - 3.12   | Supported |
 | 1.1.x          | 4.4.x          | 3.10 - 3.12   | Supported |
 | 1.0.x          | 4.5.x          | 3.10 - 3.12   | Supported |

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/netbox_ssl/tables/certificate_authorities.py
+++ b/netbox_ssl/tables/certificate_authorities.py
@@ -58,12 +58,8 @@ class CertificateAuthorityTable(NetBoxTable):
     def render_is_approved(self, value, record):
         """Render approval status with color coding."""
         if value:
-            return format_html(
-                '<span class="badge text-bg-success">Approved</span>',
-            )
-        return format_html(
-            '<span class="badge text-bg-warning">Not Approved</span>',
-        )
+            return format_html('<span class="badge text-bg-success">{}</span>', "Approved")
+        return format_html('<span class="badge text-bg-warning">{}</span>', "Not Approved")
 
     def render_certificate_count(self, value, record):
         """Render certificate count."""

--- a/netbox_ssl/tables/certificates.py
+++ b/netbox_ssl/tables/certificates.py
@@ -147,7 +147,5 @@ class CertificateTable(NetBoxTable):
         """Render assignment count with orphan warning."""
         count = record.assignments.count()
         if count == 0:
-            return format_html(
-                '<span class="badge text-bg-secondary" title="Orphan certificate">0</span>',
-            )
+            return format_html('<span class="badge text-bg-secondary" title="Orphan certificate">{}</span>', 0)
         return count

--- a/netbox_ssl/tables/csr.py
+++ b/netbox_ssl/tables/csr.py
@@ -98,4 +98,4 @@ class CertificateSigningRequestTable(NetBoxTable):
                 value.get_absolute_url(),
                 value.common_name,
             )
-        return format_html('<span class="text-muted">—</span>')
+        return format_html('<span class="text-muted">{}</span>', "—")

--- a/netbox_ssl/tables/external_sources.py
+++ b/netbox_ssl/tables/external_sources.py
@@ -63,12 +63,8 @@ class ExternalSourceTable(NetBoxTable):
     def render_enabled(self, value, record):
         """Render enabled status with color coding."""
         if value:
-            return format_html(
-                '<span class="badge text-bg-success">Enabled</span>',
-            )
-        return format_html(
-            '<span class="badge text-bg-danger">Disabled</span>',
-        )
+            return format_html('<span class="badge text-bg-success">{}</span>', "Enabled")
+        return format_html('<span class="badge text-bg-danger">{}</span>', "Disabled")
 
     def render_sync_status(self, value, record):
         """Render sync status with color badges."""

--- a/netbox_ssl/templates/netbox_ssl/certificate.html
+++ b/netbox_ssl/templates/netbox_ssl/certificate.html
@@ -286,6 +286,7 @@
 </div>
 
 {% if object.status == 'active' or object.status == 'expired' %}
+{% if perms.netbox_ssl.renew_certificate or perms.netbox_ssl.import_certificate or perms.netbox_ssl.add_certificate %}
 <div class="row mb-3">
   <div class="col col-12">
     <a href="{% url 'plugins:netbox_ssl:certificate_import' %}?renew_from={{ object.pk }}"
@@ -294,6 +295,7 @@
     </a>
   </div>
 </div>
+{% endif %}
 {% endif %}
 
 {# Tabbed secondary sections #}

--- a/netbox_ssl/views/certificates.py
+++ b/netbox_ssl/views/certificates.py
@@ -128,12 +128,24 @@ class CertificateImportView(LoginRequiredMixin, View):
 
     template_name = "netbox_ssl/certificate_import.html"
 
+    # Set per-request in dispatch(); gates the net-new import path in post().
+    can_import = False
+
     def dispatch(self, request, *args, **kwargs):
-        """Check import permission before dispatching (with v0.8.x fallback)."""
-        has_perm = request.user.has_perm("netbox_ssl.import_certificate") or request.user.has_perm(
+        """Gate the import workflow.
+
+        Net-new imports require ``import_certificate`` (with the v0.8.x
+        ``add_certificate`` fallback). The Renew workflow funnels the PEM paste
+        through this view before handing off to ``CertificateRenewView``, so
+        users holding only ``renew_certificate`` are also allowed in -- but
+        ``post()`` still blocks them from creating brand-new certificates so the
+        renew permission does not grant broader import rights (issue #136).
+        """
+        self.can_import = request.user.has_perm("netbox_ssl.import_certificate") or request.user.has_perm(
             "netbox_ssl.add_certificate"
         )
-        if not has_perm:
+        can_renew = request.user.has_perm("netbox_ssl.renew_certificate")
+        if not (self.can_import or can_renew):
             messages.error(request, _("You do not have permission to import certificates."))
             return redirect(reverse("plugins:netbox_ssl:certificate_list"))
         return super().dispatch(request, *args, **kwargs)
@@ -232,6 +244,20 @@ class CertificateImportView(LoginRequiredMixin, View):
                 request.session["renewal_candidate_id"] = renewal_candidate.pk
 
                 return redirect(reverse("plugins:netbox_ssl:certificate_renew"))
+
+            # Net-new import (no renewal candidate matched). Creating a brand-new
+            # certificate requires import/add permission. Renewal-only users
+            # (issue #136) are allowed through dispatch() to complete a renewal,
+            # but must not be able to import arbitrary new certificates here.
+            if not self.can_import:
+                messages.error(
+                    request,
+                    _(
+                        "You do not have permission to import new certificates. "
+                        "This certificate did not match an existing one for renewal."
+                    ),
+                )
+                return render(request, self.template_name, {"form": form})
 
             # Auto-detect issuing CA
             issuing_ca = detect_issuing_ca(parsed.issuer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "1.2.0"
+version = "1.2.1"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,4 @@ markers =
     api: API integration tests (requires running NetBox + token)
     browser: Browser tests (Playwright)
     slow: Slow running tests
+    django_db: Requires Django DB access via pytest-django (registered here so the host lane, which runs -p no:django under --strict-markers, doesn't error on the marker)

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -56,6 +56,7 @@ requires_netbox = pytest.mark.skipif(
 )
 
 
+@pytest.mark.django_db
 @requires_netbox
 def test_openapi_schema_generation_succeeds():
     """The full OpenAPI schema must generate without raising (regression #111).

--- a/tests/test_aws_acm_adapter.py
+++ b/tests/test_aws_acm_adapter.py
@@ -542,6 +542,7 @@ def test_parse_acm_certificate_missing_optional_fields():
     assert cert.serial_number == ""
 
 
+@pytest.mark.django_db
 def test_list_certificate_arns_empty_account():
     from unittest.mock import MagicMock
 
@@ -563,6 +564,7 @@ def test_list_certificate_arns_empty_account():
     assert run() == []
 
 
+@pytest.mark.django_db
 def test_list_certificate_arns_single_cert():
     from unittest.mock import MagicMock
 
@@ -608,6 +610,7 @@ def test_list_certificate_arns_single_cert():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db
 def test_describe_and_get_happy_path():
     from unittest.mock import MagicMock
 
@@ -763,6 +766,7 @@ def _import_test_cert(client, cn: str) -> str:
     return client.import_certificate(Certificate=pem.encode(), PrivateKey=key_pem.encode())["CertificateArn"]
 
 
+@pytest.mark.django_db
 def test_fetch_certificates_empty_account_returns_empty_list():
     from unittest.mock import MagicMock
 
@@ -782,6 +786,7 @@ def test_fetch_certificates_empty_account_returns_empty_list():
     assert run() == []
 
 
+@pytest.mark.django_db
 def test_fetch_certificates_returns_imported_certs():
     from unittest.mock import MagicMock
 
@@ -808,6 +813,7 @@ def test_fetch_certificates_returns_imported_certs():
     assert cns == ["first.example.com", "second.example.com"]
 
 
+@pytest.mark.django_db
 def test_fetch_certificates_isolated_per_region():
     """ExternalSource configured for eu-west-1 only sees eu-west-1 certs."""
     from unittest.mock import MagicMock
@@ -836,6 +842,7 @@ def test_fetch_certificates_isolated_per_region():
     assert cns == ["europe.example.com"]
 
 
+@pytest.mark.django_db
 def test_fetch_certificates_skips_failed_per_cert_errors():
     """If one cert raises during fetch, others still succeed."""
     from unittest.mock import MagicMock, patch
@@ -878,6 +885,7 @@ def test_fetch_certificates_skips_failed_per_cert_errors():
     assert cns == ["good.example.com"]
 
 
+@pytest.mark.django_db
 def test_get_certificate_detail_found():
     from unittest.mock import MagicMock
 
@@ -903,6 +911,7 @@ def test_get_certificate_detail_found():
     assert cert.common_name == "lookup.example.com"
 
 
+@pytest.mark.django_db
 def test_get_certificate_detail_not_found_returns_none():
     from unittest.mock import MagicMock
 
@@ -929,6 +938,7 @@ def test_get_certificate_detail_not_found_returns_none():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db
 def test_test_connection_success_with_empty_account():
     from unittest.mock import MagicMock
 

--- a/tests/test_bulk_import.py
+++ b/tests/test_bulk_import.py
@@ -420,10 +420,10 @@ def api_client():
 
     User = get_user_model()
 
-    # Get or create admin user
+    # Get or create admin user (NetBox's User model has no is_staff field)
     user, _ = User.objects.get_or_create(
         username="test_bulk_import_user",
-        defaults={"is_superuser": True, "is_staff": True},
+        defaults={"is_superuser": True},
     )
 
     client = APIClient()
@@ -444,6 +444,7 @@ def cleanup_certificates():
         pass
 
 
+@pytest.mark.django_db
 class TestBulkImportAPIIntegration:
     """Integration tests that actually call the bulk import API endpoint."""
 
@@ -457,7 +458,7 @@ class TestBulkImportAPIIntegration:
             pytest.skip("Test certificate not available")
 
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [{"pem_content": cert}],
             format="json",
         )
@@ -486,7 +487,7 @@ class TestBulkImportAPIIntegration:
             pytest.skip("Not enough test certificates available")
 
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             certs,
             format="json",
         )
@@ -501,7 +502,7 @@ class TestBulkImportAPIIntegration:
     def test_bulk_import_rejects_empty_list(self, api_client):
         """Test that empty list is rejected with 400 error."""
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [],
             format="json",
         )
@@ -516,7 +517,7 @@ class TestBulkImportAPIIntegration:
     def test_bulk_import_rejects_non_list(self, api_client):
         """Test that non-list input is rejected with 400 error."""
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             {"pem_content": "test"},
             format="json",
         )
@@ -531,7 +532,7 @@ class TestBulkImportAPIIntegration:
     def test_bulk_import_rejects_invalid_certificate(self, api_client):
         """Test that invalid certificates are rejected with detailed errors."""
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [{"pem_content": "not a valid certificate"}],
             format="json",
         )
@@ -540,7 +541,8 @@ class TestBulkImportAPIIntegration:
         data = response.json()
         assert "failed_certificates" in data
         assert len(data["failed_certificates"]) == 1
-        assert data["failed_certificates"][0]["index"] == 0
+        # DRF ValidationError stringifies leaf scalars, so index comes back as "0".
+        assert int(data["failed_certificates"][0]["index"]) == 0
 
     @pytest.mark.integration
     @skip_if_no_django_api
@@ -558,7 +560,7 @@ class TestBulkImportAPIIntegration:
 
         # Mix valid and invalid certificates
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [
                 {"pem_content": cert},  # valid
                 {"pem_content": "invalid cert"},  # invalid
@@ -582,7 +584,7 @@ class TestBulkImportAPIIntegration:
             pytest.skip("Test certificate not available")
 
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [
                 {
                     "pem_content": cert,
@@ -604,7 +606,7 @@ class TestBulkImportAPIIntegration:
         certs = [{"pem_content": f"cert-{i}"} for i in range(101)]
 
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             certs,
             format="json",
         )
@@ -630,7 +632,7 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC7
         mixed_content = cert + "\n" + private_key
 
         response = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [{"pem_content": mixed_content}],
             format="json",
         )
@@ -650,7 +652,7 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC7
 
         # First import should succeed
         response1 = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [{"pem_content": cert}],
             format="json",
         )
@@ -658,7 +660,7 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC7
 
         # Second import with same certificate should fail (duplicate)
         response2 = api_client.post(
-            "/api/plugins/netbox-ssl/certificates/bulk-import/",
+            "/api/plugins/ssl/certificates/bulk-import/",
             [{"pem_content": cert}],
             format="json",
         )

--- a/tests/test_certificate_authority.py
+++ b/tests/test_certificate_authority.py
@@ -95,6 +95,7 @@ class TestCATypeChoices:
             assert len(CATypeChoices.CHOICES) == 3
 
 
+@pytest.mark.django_db
 class TestCertificateAuthorityModel:
     """Tests for CertificateAuthority model."""
 
@@ -126,14 +127,18 @@ class TestCertificateAuthorityModel:
     @requires_netbox
     def test_ca_unique_name_constraint(self):
         """Test that CA names must be unique."""
+        from django.db import IntegrityError, transaction
+
         ca1 = CertificateAuthority.objects.create(
             name="Unique CA",
             type=CATypeChoices.TYPE_PUBLIC,
         )
 
-        from django.db import IntegrityError
-
-        with pytest.raises(IntegrityError):
+        # Wrap the failing INSERT in a savepoint: under pytest-django's per-test
+        # transaction, an unhandled IntegrityError poisons the whole transaction
+        # (TransactionManagementError on any later query). atomic() rolls back
+        # just this savepoint so the test transaction stays usable.
+        with pytest.raises(IntegrityError), transaction.atomic():
             CertificateAuthority.objects.create(
                 name="Unique CA",
                 type=CATypeChoices.TYPE_INTERNAL,
@@ -143,6 +148,7 @@ class TestCertificateAuthorityModel:
         ca1.delete()
 
 
+@pytest.mark.django_db
 class TestCertificateAuthorityAutoDetection:
     """Tests for CA auto-detection functionality."""
 
@@ -274,6 +280,7 @@ class TestDefaultCertificateAuthorities:
             assert "issuer_pattern" in ca
 
 
+@pytest.mark.django_db
 class TestCertificateIssuingCA:
     """Tests for the issuing_ca field on Certificate model."""
 
@@ -359,6 +366,7 @@ class TestCertificateIssuingCA:
         cert.delete()
 
 
+@pytest.mark.django_db
 class TestCertificateAuthorityFilters:
     """Tests for CertificateAuthority filtersets."""
 
@@ -440,6 +448,7 @@ class TestCertificateAuthorityFilters:
             ca3.delete()
 
 
+@pytest.mark.django_db
 class TestCertificateFilterByIssuingCA:
     """Tests for filtering certificates by issuing CA."""
 

--- a/tests/test_comments_field.py
+++ b/tests/test_comments_field.py
@@ -65,6 +65,7 @@ def test_model_has_comments_field(model_name):
     assert "comments" in field_names, f"{model_name} is missing a 'comments' model field (#112)"
 
 
+@pytest.mark.django_db
 @requires_netbox
 @pytest.mark.parametrize("model_name,form_name", [(m, f) for m, f, _ in _AFFECTED])
 def test_form_comments_maps_to_model(model_name, form_name):

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -34,7 +34,7 @@ requires_netbox = pytest.mark.skipif(
     reason="NetBox not available - run these tests inside the Docker container",
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
 
 
 def _make_certificate(serial="CONTACTS-IT"):

--- a/tests/test_email_notification.py
+++ b/tests/test_email_notification.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # Mock netbox modules for local testing without NetBox
 _project_root = Path(__file__).parent.parent
 if str(_project_root) not in sys.path:
@@ -122,12 +124,18 @@ EMPTY_REPORT = {
 
 
 def _make_settings_mock(enabled: bool = True, recipients: list | None = None):
-    """Create a mock settings object."""
+    """Create a mock settings object.
+
+    Note: distinguish an explicit empty list (``[]`` — the "no recipients
+    configured" case) from the default (``None`` → a sample recipient). Using
+    ``recipients or [...]`` would collapse ``[]`` to the fallback and silently
+    break the no-recipients test.
+    """
     mock = MagicMock()
     mock.PLUGINS_CONFIG = {
         "netbox_ssl": {
             "notification_email_enabled": enabled,
-            "notification_email_recipients": recipients or ["admin@example.com"],
+            "notification_email_recipients": ["admin@example.com"] if recipients is None else recipients,
             "notification_email_subject_prefix": "[NetBox SSL]",
         }
     }
@@ -135,6 +143,7 @@ def _make_settings_mock(enabled: bool = True, recipients: list | None = None):
     return mock
 
 
+@pytest.mark.django_db
 class TestSendExpiryReport:
     @patch("netbox_ssl.utils.email.EmailMultiAlternatives")
     @patch("netbox_ssl.utils.email.render_to_string", side_effect=lambda t, c: f"rendered:{t}")

--- a/tests/test_external_source_form.py
+++ b/tests/test_external_source_form.py
@@ -4,7 +4,7 @@ import importlib.util
 
 import pytest
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.django_db]
 
 try:
     _spec = importlib.util.find_spec("netbox")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -546,6 +546,7 @@ class TestAssignmentModel:
         assert field.default is True
 
 
+@pytest.mark.django_db
 class TestAssignmentForm:
     """Tests for CertificateAssignmentForm."""
 

--- a/tests/test_pem_display.py
+++ b/tests/test_pem_display.py
@@ -34,7 +34,7 @@ requires_netbox = pytest.mark.skipif(
     reason="NetBox not available - run these tests inside the Docker container",
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
 
 SAMPLE_PEM = "-----BEGIN CERTIFICATE-----\nMIIBpemDisplayRenderTestContent\n-----END CERTIFICATE-----"
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -186,6 +186,51 @@ class TestViewPermissionChecks:
         assert "import_certificate" in self.views_source
 
 
+class TestRenewThroughImportPermission:
+    """Regression tests for issue #136.
+
+    The Renew workflow funnels the PEM paste through CertificateImportView
+    before handing off to CertificateRenewView. Users holding only
+    ``renew_certificate`` must be allowed into the import view, but must NOT be
+    able to create brand-new certificates there (least privilege).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _load_sources(self):
+        self.views_source = _read_source("views/certificates.py")
+        self.template_source = _read_source("templates/netbox_ssl/certificate.html")
+        # Isolate the CertificateImportView class body for precise assertions.
+        start = self.views_source.index("class CertificateImportView")
+        end = self.views_source.index("class CertificateRenewView")
+        self.import_view_source = self.views_source[start:end]
+
+    def test_import_dispatch_admits_renew_users(self):
+        """dispatch() lets renew_certificate users in (not just import/add)."""
+        assert "renew_certificate" in self.import_view_source, (
+            "CertificateImportView.dispatch must admit renew_certificate users "
+            "or the Renew button 500s for renewal-only roles (issue #136)."
+        )
+
+    def test_import_dispatch_tracks_import_capability(self):
+        """dispatch() records whether the user may perform a net-new import."""
+        assert "self.can_import" in self.import_view_source
+
+    def test_net_new_import_is_gated_on_import_capability(self):
+        """The net-new create path is guarded so renew-only users can't import."""
+        guard_idx = self.import_view_source.find("if not self.can_import")
+        create_idx = self.import_view_source.find("Certificate.objects.create(")
+        assert guard_idx != -1, "Missing net-new import guard (self.can_import)"
+        assert create_idx != -1, "Expected a Certificate.objects.create() call"
+        assert guard_idx < create_idx, (
+            "The can_import guard must come BEFORE Certificate.objects.create(), "
+            "otherwise renew-only users could import net-new certificates."
+        )
+
+    def test_renew_button_is_permission_guarded(self):
+        """The detail-page Renew button is wrapped in a perms check."""
+        assert "perms.netbox_ssl.renew_certificate" in self.template_source
+
+
 class TestDocumentation:
     """Test that permission documentation exists and is complete."""
 

--- a/tests/test_table_format_html.py
+++ b/tests/test_table_format_html.py
@@ -1,0 +1,60 @@
+"""Regression guard for Django 6.0 ``format_html`` usage in table modules.
+
+Django 6.0 (shipped with NetBox 4.6) made ``format_html()`` raise
+``TypeError: args or kwargs must be provided.`` when called with only a
+literal format string and no interpolation arguments.  Earlier Django
+versions merely emitted a ``RemovedInDjango60Warning``.
+
+Several table ``render_*`` methods rendered static badges via
+``format_html("<span ...>...</span>")`` with no args, which crashed the
+list view as soon as a row needed rendering (issue #137: the Certificate
+Authorities list page threw a 500 once at least one CA existed).
+
+The correct tool for trusted *static* HTML is ``mark_safe``;
+``format_html`` is only for interpolating values with escaping.  This test
+fails if any ``format_html`` call in the tables package is missing
+interpolation arguments, catching the regression under any Python/Django
+version (the host unit lane does not run Django 6.0).
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from .conftest import get_plugin_source_dir
+
+
+def _format_html_violations(source: str, filename: str) -> list[str]:
+    """Return ``"file:line"`` for every arg-less ``format_html`` call."""
+    tree = ast.parse(source, filename=filename)
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if name != "format_html":
+            continue
+        # format_html(format_string, *args, **kwargs) needs at least one
+        # interpolation argument beyond the format string itself.
+        if len(node.args) < 2 and not node.keywords:
+            violations.append(f"{filename}:{node.lineno}")
+    return violations
+
+
+@pytest.mark.unit
+def test_no_argless_format_html_in_tables() -> None:
+    """No table render method may call ``format_html`` without args (Django 6.0)."""
+    tables_dir = get_plugin_source_dir() / "tables"
+    assert tables_dir.is_dir(), f"tables dir not found: {tables_dir}"
+
+    all_violations: list[str] = []
+    for py_file in sorted(tables_dir.glob("*.py")):
+        all_violations.extend(_format_html_violations(py_file.read_text(), py_file.name))
+
+    assert not all_violations, (
+        "format_html() called without interpolation args (raises TypeError on "
+        "Django 6.0 / NetBox 4.6). Use mark_safe() for static HTML instead:\n  " + "\n  ".join(all_violations)
+    )


### PR DESCRIPTION
Promote `dev` to `main` for the **v1.2.1** patch release.

Contents since v1.2.0:
- **#137** Certificate Authorities list `TypeError` on NetBox 4.6 / Django 6.0 (PR #138)
- **#136** `renew_certificate` permission regression (PR #138)
- **#117** `pytest-django` DB test isolation (PR #135)
- Version bump + CHANGELOG + COMPATIBILITY 1.2.x row (PR #139)

No migrations, no breaking changes. Tag `v1.2.1` follows on `main`.