### PR TITLE
ci: raise verify-ci publish gate timeout above the integration matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,17 @@ jobs:
           # A tag push publishes to PyPI. Without this gate a release ships even
           # if CI is red — which is exactly how #111/#112 reached v1.1.0. Require
           # the CI workflow for this commit to have concluded successfully.
+          #
+          # Budget note (#141): the tag is pushed right after the dev->main merge,
+          # so CI is still in_progress when this gate starts. The poll budget MUST
+          # exceed the slowest CI lane — the NetBox integration matrix (v4.4 + v4.5
+          # + v4.6) takes ~13 min, plus runner queue time. 90 * 20s = 30 min ceiling.
+          # Do NOT shrink this below the integration-matrix duration or releases
+          # will time out and need a manual re-run. The gate is idempotent: re-running
+          # once CI is green is always safe (nothing publishes until then).
           sha="${GITHUB_SHA}"
           echo "Requiring a successful 'CI' run for commit $sha before publishing."
-          for i in $(seq 1 30); do
+          for i in $(seq 1 90); do
             status=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow CI --commit "$sha" --json status -q '.[0].status' 2>/dev/null || true)
             concl=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow CI --commit "$sha" --json conclusion -q '.[0].conclusion' 2>/dev/null || true)
             echo "attempt $i: status='${status}' conclusion='${concl}'"


### PR DESCRIPTION
Fixes the release-timing friction hit during the v1.2.1 cut.

The `verify-ci` gate in `publish.yml` polled `seq 1 30` × `sleep 20` ≈ **10 min**. The NetBox integration matrix (v4.4 + v4.5 + v4.6) takes **~13 min**, and the release tag is pushed right after the `dev → main` merge — so the gate started while CI was still `in_progress` and timed out before it went green, failing the Publish run (recovered manually via `gh run rerun`).

### Change
- `seq 1 30` → `seq 1 90` (~30 min ceiling) — comfortably exceeds the slowest CI lane plus runner queue time.
- Inline comment documenting the budget constraint so it isn't shrunk again.

No behavioural change to the gate's logic — it still refuses to publish on non-green CI and stays idempotent (re-running once CI is green is always safe).

Closes #141