### PR TITLE
fix: bundled NetBox Scripts fail to load (ObjectVar string model, #143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Bundled NetBox Scripts could not be loaded** ([#143](https://github.com/ctrl-alt-automate/netbox-ssl/issues/143)):
+  every script exposing a tenant/source filter passed `model=` to `ObjectVar` as
+  a **string** (e.g. `ObjectVar(model="tenancy.Tenant")`). NetBox's `ObjectVar`
+  requires a model **class** — it calls `model.objects.all()` — so the script
+  module raised `AttributeError: 'str' object has no attribute 'objects'` at
+  import time and could never be registered or run. Affected the expiry scan,
+  expiry notification, auto-archive, ARI poll, scheduled export, and external
+  sync scripts. All now import the model and pass the class
+  (`model=Tenant` / `model=ExternalSource`). The bug had hidden because NetBox
+  never imports plugin-bundled scripts at startup and the script tests skipped
+  themselves when the import failed; a new AST regression guard
+  (`tests/test_script_objectvar.py`) now fails on any string-model `ObjectVar`.
+
+### Documentation
+
+- **How to register the bundled scripts** ([#143](https://github.com/ctrl-alt-automate/netbox-ssl/issues/143)):
+  documented that NetBox does not auto-discover plugin-bundled scripts and added
+  a `SCRIPTS_ROOT` wrapper recipe to [Custom Scripts](reference/scripts.md) so
+  the expiry scan and friends actually appear under **Customization → Scripts**.
+
 ## [1.2.1] - 2026-06-04
 
 **Patch release** — two NetBox 4.6 / Django 6.0 regression fixes (the Certificate

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -2,6 +2,42 @@
 
 NetBox SSL includes built-in custom scripts for certificate management automation.
 
+## Making the scripts available to NetBox
+
+!!! important "Plugin scripts are not auto-registered"
+    NetBox only discovers scripts that live in its **`SCRIPTS_ROOT`** directory
+    (default `/opt/netbox/netbox/scripts/`). Scripts bundled *inside* a plugin
+    package — like the ones below — do **not** appear in
+    **Customization → Scripts** automatically when you install the plugin. You
+    expose them with a one-line wrapper module.
+
+Create a file in your `SCRIPTS_ROOT` (for example
+`/opt/netbox/netbox/scripts/netbox_ssl_scripts.py`) that imports the script
+classes you want:
+
+```python
+# /opt/netbox/netbox/scripts/netbox_ssl_scripts.py
+from netbox_ssl.scripts import (
+    CertificateExpiryScan,
+    CertificateExpiryNotification,
+    CertificateAutoArchive,
+    CertificateARIPoll,
+    ExternalSourceSync,
+    ScheduledCertificateExport,
+    CertificateURLScan,
+)
+```
+
+Then open **Customization → Scripts** in NetBox — the scripts now appear and can
+be run manually, scheduled, or invoked via the REST API (see below). The file
+must be readable by the NetBox service user; no restart is required.
+
+!!! note "Requires v1.2.2 or newer"
+    Earlier releases shipped scripts that failed to load on NetBox 4.x because a
+    filter field passed a model as a string to `ObjectVar`
+    ([#143](https://github.com/ctrl-alt-automate/netbox-ssl/issues/143)). Upgrade
+    to **1.2.2+** before registering the scripts.
+
 ## Certificate Expiry Notification
 
 The `CertificateExpiryNotification` script checks for certificates that are expiring soon and generates detailed reports suitable for webhook notifications.

--- a/netbox_ssl/scripts/ari_poll.py
+++ b/netbox_ssl/scripts/ari_poll.py
@@ -13,6 +13,7 @@ has elapsed.
 from django.db import models
 from django.utils import timezone
 from extras.scripts import BooleanVar, ObjectVar, Script
+from tenancy.models import Tenant
 
 from netbox_ssl.models import Certificate
 from netbox_ssl.utils.ari import ARI_DIRECTORIES, ARIError, build_cert_id, discover_ari_endpoint, poll_ari
@@ -35,7 +36,7 @@ class CertificateARIPoll(Script):
         job_timeout = 600
 
     tenant = ObjectVar(
-        model="tenancy.Tenant",
+        model=Tenant,
         description="Filter by tenant (empty = all)",
         required=False,
     )

--- a/netbox_ssl/scripts/auto_archive.py
+++ b/netbox_ssl/scripts/auto_archive.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 from extras.scripts import BooleanVar, IntegerVar, ObjectVar, Script
+from tenancy.models import Tenant
 
 from netbox_ssl.models import Certificate, CertificateStatusChoices
 from netbox_ssl.utils.events import (
@@ -45,7 +46,7 @@ class CertificateAutoArchive(Script):
 
     # Script variables
     tenant = ObjectVar(
-        model="tenancy.Tenant",
+        model=Tenant,
         description="Filter certificates by tenant (optional)",
         required=False,
     )

--- a/netbox_ssl/scripts/expiry_notification.py
+++ b/netbox_ssl/scripts/expiry_notification.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 from extras.scripts import BooleanVar, IntegerVar, ObjectVar, Script, StringVar
+from tenancy.models import Tenant
 
 from netbox_ssl.models import Certificate, CertificateStatusChoices
 
@@ -42,7 +43,7 @@ class CertificateExpiryNotification(Script):
         required=False,
     )
     tenant = ObjectVar(
-        model="tenancy.Tenant",
+        model=Tenant,
         description="Filter certificates by tenant (optional)",
         required=False,
     )

--- a/netbox_ssl/scripts/expiry_scan.py
+++ b/netbox_ssl/scripts/expiry_scan.py
@@ -17,6 +17,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 from extras.scripts import BooleanVar, ObjectVar, Script
+from tenancy.models import Tenant
 
 from netbox_ssl.models import Certificate, CertificateStatusChoices
 from netbox_ssl.models.event_log import CertificateEventLog
@@ -51,7 +52,7 @@ class CertificateExpiryScan(Script):
 
     # Script variables
     tenant = ObjectVar(
-        model="tenancy.Tenant",
+        model=Tenant,
         description="Filter certificates by tenant (optional)",
         required=False,
     )

--- a/netbox_ssl/scripts/external_sync.py
+++ b/netbox_ssl/scripts/external_sync.py
@@ -13,6 +13,8 @@ import logging
 from django.utils import timezone
 from extras.scripts import BooleanVar, ObjectVar, Script
 
+from netbox_ssl.models import ExternalSource
+
 logger = logging.getLogger("netbox_ssl.scripts.external_sync")
 
 
@@ -37,7 +39,7 @@ class ExternalSourceSync(Script):
         job_timeout = 1800
 
     source = ObjectVar(
-        model="netbox_ssl.ExternalSource",
+        model=ExternalSource,
         description="Sync a specific source (leave empty for all enabled sources)",
         required=False,
     )

--- a/netbox_ssl/scripts/scheduled_export.py
+++ b/netbox_ssl/scripts/scheduled_export.py
@@ -9,6 +9,7 @@ Supported formats: CSV, JSON, YAML.
 
 from django.conf import settings
 from extras.scripts import ChoiceVar, ObjectVar, Script
+from tenancy.models import Tenant
 
 from netbox_ssl.models import Certificate, CertificateStatusChoices
 from netbox_ssl.utils.export import CertificateExporter
@@ -38,7 +39,7 @@ class ScheduledCertificateExport(Script):
         description="Export format",
     )
     tenant = ObjectVar(
-        model="tenancy.Tenant",
+        model=Tenant,
         description="Filter by tenant (empty = all)",
         required=False,
     )

--- a/tests/test_script_objectvar.py
+++ b/tests/test_script_objectvar.py
@@ -1,0 +1,59 @@
+"""Regression guard for ``ObjectVar`` usage in bundled NetBox Scripts.
+
+NetBox's ``ObjectVar`` requires ``model`` to be a model **class** — its
+``__init__`` immediately calls ``model.objects.all()``. Passing a dotted
+string (e.g. ``ObjectVar(model="tenancy.Tenant")``) raises
+``AttributeError: 'str' object has no attribute 'objects'`` at class-body
+evaluation time, which makes the whole script module fail to import — so the
+script can never be registered or run in NetBox (issue #143).
+
+This stayed hidden because NetBox never imports plugin-bundled scripts at
+startup, and the script unit tests skip themselves when the import fails
+(``script_available()`` swallows the error). This AST guard fails fast on any
+``ObjectVar``/``MultiObjectVar`` call whose ``model`` is a string literal,
+under any Python/Django version (the host unit lane does not run real NetBox).
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from .conftest import get_plugin_source_dir
+
+_OBJECT_VAR_NAMES = {"ObjectVar", "MultiObjectVar"}
+
+
+def _string_model_violations(source: str, filename: str) -> list[str]:
+    """Return ``"file:line"`` for every ObjectVar called with a string model."""
+    tree = ast.parse(source, filename=filename)
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if name not in _OBJECT_VAR_NAMES:
+            continue
+        for kw in node.keywords:
+            if kw.arg == "model" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                violations.append(f"{filename}:{kw.value.lineno}")
+    return violations
+
+
+@pytest.mark.unit
+def test_objectvar_model_is_a_class_not_a_string() -> None:
+    """No bundled script may pass a string to ObjectVar(model=...) (issue #143)."""
+    scripts_dir = get_plugin_source_dir() / "scripts"
+    assert scripts_dir.is_dir(), f"scripts dir not found: {scripts_dir}"
+
+    all_violations: list[str] = []
+    for py_file in sorted(scripts_dir.glob("*.py")):
+        all_violations.extend(_string_model_violations(py_file.read_text(), py_file.name))
+
+    assert not all_violations, (
+        "ObjectVar(model=...) was given a string instead of a model class. NetBox "
+        "calls model.objects.all(), so the script fails to import and cannot be "
+        "registered. Import the model and pass the class (e.g. model=Tenant):\n  " + "\n  ".join(all_violations)
+    )


### PR DESCRIPTION
## Summary

Every bundled NetBox Script that exposes a tenant/source filter passed `model=` to `ObjectVar` as a **string** (e.g. `ObjectVar(model="tenancy.Tenant")`). NetBox's `ObjectVar` requires a model **class** — it calls `model.objects.all()` — so the script module raised `AttributeError: 'str' object has no attribute 'objects'` at import time and **could never be registered or run**.

Surfaced by a user (Matt Karel) asking whether the expiry-scan script is auto-installed on plugin install.

## Why it went unnoticed
- NetBox never imports plugin-bundled scripts at startup, so the broken `ObjectVar(...)` was never triggered in normal operation.
- The script unit tests guard imports with `script_available()` → `except: return False`, so they **silently skipped** when the import failed — in both the host and in-container lanes.

## Changes
- `model=Tenant` / `model=ExternalSource` (class import) in `expiry_scan`, `expiry_notification`, `auto_archive`, `ari_poll`, `scheduled_export`, `external_sync`.
- New host-lane AST guard `tests/test_script_objectvar.py` — fails on any `ObjectVar(model="<string>")` under any Python/Django version.
- Docs: a `SCRIPTS_ROOT` wrapper recipe in [Custom Scripts](../blob/dev/docs/reference/scripts.md) (NetBox does **not** auto-discover plugin-bundled scripts — the previously-undocumented gap behind the user's question).

## Verification (live NetBox 4.6 / Django 6.0)
- Before: SCRIPTS_ROOT wrapper → `ScriptModule` registers **0** scripts (`AttributeError` on load).
- After: registers **7** scripts (`load error: None`); all 7 classes instantiate cleanly.
- Full host unit lane: **845 passed**, ruff + format clean.

Closes #143