### PR TITLE
release: v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.2] - 2026-06-05
+
+**Patch release** — the bundled NetBox Scripts (expiry scan, expiry
+notification, auto-archive, ARI poll, scheduled export, external sync) could not
+be loaded on NetBox 4.x; they now register correctly. Includes a docs section on
+how to make the scripts available via `SCRIPTS_ROOT`. No migrations, no breaking
+changes; safe to upgrade from 1.2.x.
 
 ### Fixed
 

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "1.2.1"
+version = "1.2.2"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## v1.2.2 — patch release

Finalizes the version bump and CHANGELOG for **v1.2.2**. The fix already landed on `dev`:

- **#143** — bundled NetBox Scripts failed to load (`ObjectVar(model=...)` given a string instead of a model class) — PR #144. All 6 affected scripts fixed; AST regression guard added; `SCRIPTS_ROOT` registration documented.

### This PR
- Bump version `1.2.1 → 1.2.2`
- Finalize CHANGELOG `[1.2.2]` section

No migrations, no breaking changes; safe to upgrade from 1.2.x. (`COMPATIBILITY.md` already covers `1.2.x`.)

Release flow: this PR → `dev`, then `dev → main`, then annotated tag `v1.2.2`. The publish gate now uses the widened timeout (#142), so the verify-ci step should not time out.