### PR TITLE
release: v1.2.2 → main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,17 @@ jobs:
           # A tag push publishes to PyPI. Without this gate a release ships even
           # if CI is red — which is exactly how #111/#112 reached v1.1.0. Require
           # the CI workflow for this commit to have concluded successfully.
+          #
+          # Budget note (#141): the tag is pushed right after the dev->main merge,
+          # so CI is still in_progress when this gate starts. The poll budget MUST
+          # exceed the slowest CI lane — the NetBox integration matrix (v4.4 + v4.5
+          # + v4.6) takes ~13 min, plus runner queue time. 90 * 20s = 30 min ceiling.
+          # Do NOT shrink this below the integration-matrix duration or releases
+          # will time out and need a manual re-run. The gate is idempotent: re-running
+          # once CI is green is always safe (nothing publishes until then).
           sha="${GITHUB_SHA}"
           echo "Requiring a successful 'CI' run for commit $sha before publishing."
-          for i in $(seq 1 30); do
+          for i in $(seq 1 90); do
             status=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow CI --commit "$sha" --json status -q '.[0].status' 2>/dev/null || true)
             concl=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow CI --commit "$sha" --json conclusion -q '.[0].conclusion' 2>/dev/null || true)
             echo "attempt $i: status='${status}' conclusion='${concl}'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.2] - 2026-06-05
+
+**Patch release** — the bundled NetBox Scripts (expiry scan, expiry
+notification, auto-archive, ARI poll, scheduled export, external sync) could not
+be loaded on NetBox 4.x; they now register correctly. Includes a docs section on
+how to make the scripts available via `SCRIPTS_ROOT`. No migrations, no breaking
+changes; safe to upgrade from 1.2.x.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Bundled NetBox Scripts could not be loaded** ([#143](https://github.com/ctrl-alt-automate/netbox-ssl/issues/143)):
+  every script exposing a tenant/source filter passed `model=` to `ObjectVar` as
+  a **string** (e.g. `ObjectVar(model="tenancy.Tenant")`). NetBox's `ObjectVar`
+  requires a model **class** — it calls `model.objects.all()` — so the script
+  module raised `AttributeError: 'str' object has no attribute 'objects'` at
+  import time and could never be registered or run. Affected the expiry scan,
+  expiry notification, auto-archive, ARI poll, scheduled export, and external
+  sync scripts. All now import the model and pass the class
+  (`model=Tenant` / `model=ExternalSource`). The bug had hidden because NetBox
+  never imports plugin-bundled scripts at startup and the script tests skipped
+  themselves when the import failed; a new AST regression guard
+  (`tests/test_script_objectvar.py`) now fails on any string-model `ObjectVar`.
+
+### Documentation
+
+- **How to register the bundled scripts** ([#143](https://github.com/ctrl-alt-automate/netbox-ssl/issues/143)):
+  documented that NetBox does not auto-discover plugin-bundled scripts and added
+  a `SCRIPTS_ROOT` wrapper recipe to [Custom Scripts](reference/scripts.md) so
+  the expiry scan and friends actually appear under **Customization → Scripts**.
+
 ## [1.2.1] - 2026-06-04
 
 **Patch release** — two NetBox 4.6 / Django 6.0 regression fixes (the Certificate

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -2,6 +2,42 @@
 
 NetBox SSL includes built-in custom scripts for certificate management automation.
 
+## Making the scripts available to NetBox
+
+!!! important "Plugin scripts are not auto-registered"
+    NetBox only discovers scripts that live in its **`SCRIPTS_ROOT`** directory
+    (default `/opt/netbox/netbox/scripts/`). Scripts bundled *inside* a plugin
+    package — like the ones below — do **not** appear in
+    **Customization → Scripts** automatically when you install the plugin. You
+    expose them with a one-line wrapper module.
+
+Create a file in your `SCRIPTS_ROOT` (for example
+`/opt/netbox/netbox/scripts/netbox_ssl_scripts.py`) that imports the script
+classes you want:
+
+```python
+# /opt/netbox/netbox/scripts/netbox_ssl_scripts.py
+from netbox_ssl.scripts import (
+    CertificateExpiryScan,
+    CertificateExpiryNotification,
+    CertificateAutoArchive,
+    CertificateARIPoll,
+    ExternalSourceSync,
+    ScheduledCertificateExport,
+    CertificateURLScan,
+)
+```
+
+Then open **Customization → Scripts** in NetBox — the scripts now appear and can
+be run manually, scheduled, or invoked via the REST API (see below). The file
+must be readable by the NetBox service user; no restart is required.
+
+!!! note "Requires v1.2.2 or newer"
+    Earlier releases shipped scripts that failed to load on NetBox 4.x because a
+    filter field passed a model as a string to `ObjectVar`
+    ([#143](https://github.com/ctrl-alt-automate/netbox-ssl/issues/143)). Upgrade
+    to **1.2.2+** before registering the scripts.
+
 ## Certificate Expiry Notification
 
 The `CertificateExpiryNotification` script checks for certificates that are expiring soon and generates detailed reports suitable for webhook notifications.

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/netbox_ssl/scripts/ari_poll.py
+++ b/netbox_ssl/scripts/ari_poll.py
@@ -13,6 +13,7 @@ has elapsed.
 from django.db import models
 from django.utils import timezone
 from extras.scripts import BooleanVar, ObjectVar, Script
+from tenancy.models import Tenant
 
 from netbox_ssl.models import Certificate
 from netbox_ssl.utils.ari import ARI_DIRECTORIES, ARIError, build_cert_id, discover_ari_endpoint, poll_ari
@@ -35,7 +36,7 @@ class CertificateARIPoll(Script):
         job_timeout = 600
 
     tenant = ObjectVar(
-        model="tenancy.Tenant",
+        model=Tenant,
         description="Filter by tenant (empty = all)",
         required=False,
     )

--- a/netbox_ssl/scripts/auto_archive.py
+++ b/netbox_ssl/scripts/auto_archive.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 from extras.scripts import BooleanVar, IntegerVar, ObjectVar, Script
+from tenancy.models import Tenant
 
 from netbox_ssl.models import Certificate, CertificateStatusChoices
 from netbox_ssl.utils.events import (
@@ -45,7 +46,7 @@ class CertificateAutoArchive(Script):
 
     # Script variables
     tenant = ObjectVar(
-        model="tenancy.Tenant",
+        model=Tenant,
         description="Filter certificates by tenant (optional)",
         required=False,
     )

--- a/netbox_ssl/scripts/expiry_notification.py
+++ b/netbox_ssl/scripts/expiry_notification.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 from extras.scripts import BooleanVar, IntegerVar, ObjectVar, Script, StringVar
+from tenancy.models import Tenant
 
 from netbox_ssl.models import Certificate, CertificateStatusChoices
 
@@ -42,7 +43,7 @@ class CertificateExpiryNotification(Script):
         required=False,
     )
     tenant = ObjectVar(
-        model="tenancy.Tenant",
+        model=Tenant,
         description="Filter certificates by tenant (optional)",
         required=False,
     )

--- a/netbox_ssl/scripts/expiry_scan.py
+++ b/netbox_ssl/scripts/expiry_scan.py
@@ -17,6 +17,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 from extras.scripts import BooleanVar, ObjectVar, Script
+from tenancy.models import Tenant
 
 from netbox_ssl.models import Certificate, CertificateStatusChoices
 from netbox_ssl.models.event_log import CertificateEventLog
@@ -51,7 +52,7 @@ class CertificateExpiryScan(Script):
 
     # Script variables
     tenant = ObjectVar(
-        model="tenancy.Tenant",
+        model=Tenant,
         description="Filter certificates by tenant (optional)",
         required=False,
     )

--- a/netbox_ssl/scripts/external_sync.py
+++ b/netbox_ssl/scripts/external_sync.py
@@ -13,6 +13,8 @@ import logging
 from django.utils import timezone
 from extras.scripts import BooleanVar, ObjectVar, Script
 
+from netbox_ssl.models import ExternalSource
+
 logger = logging.getLogger("netbox_ssl.scripts.external_sync")
 
 
@@ -37,7 +39,7 @@ class ExternalSourceSync(Script):
         job_timeout = 1800
 
     source = ObjectVar(
-        model="netbox_ssl.ExternalSource",
+        model=ExternalSource,
         description="Sync a specific source (leave empty for all enabled sources)",
         required=False,
     )

--- a/netbox_ssl/scripts/scheduled_export.py
+++ b/netbox_ssl/scripts/scheduled_export.py
@@ -9,6 +9,7 @@ Supported formats: CSV, JSON, YAML.
 
 from django.conf import settings
 from extras.scripts import ChoiceVar, ObjectVar, Script
+from tenancy.models import Tenant
 
 from netbox_ssl.models import Certificate, CertificateStatusChoices
 from netbox_ssl.utils.export import CertificateExporter
@@ -38,7 +39,7 @@ class ScheduledCertificateExport(Script):
         description="Export format",
     )
     tenant = ObjectVar(
-        model="tenancy.Tenant",
+        model=Tenant,
         description="Filter by tenant (empty = all)",
         required=False,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "1.2.1"
+version = "1.2.2"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_script_objectvar.py
+++ b/tests/test_script_objectvar.py
@@ -1,0 +1,59 @@
+"""Regression guard for ``ObjectVar`` usage in bundled NetBox Scripts.
+
+NetBox's ``ObjectVar`` requires ``model`` to be a model **class** — its
+``__init__`` immediately calls ``model.objects.all()``. Passing a dotted
+string (e.g. ``ObjectVar(model="tenancy.Tenant")``) raises
+``AttributeError: 'str' object has no attribute 'objects'`` at class-body
+evaluation time, which makes the whole script module fail to import — so the
+script can never be registered or run in NetBox (issue #143).
+
+This stayed hidden because NetBox never imports plugin-bundled scripts at
+startup, and the script unit tests skip themselves when the import fails
+(``script_available()`` swallows the error). This AST guard fails fast on any
+``ObjectVar``/``MultiObjectVar`` call whose ``model`` is a string literal,
+under any Python/Django version (the host unit lane does not run real NetBox).
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from .conftest import get_plugin_source_dir
+
+_OBJECT_VAR_NAMES = {"ObjectVar", "MultiObjectVar"}
+
+
+def _string_model_violations(source: str, filename: str) -> list[str]:
+    """Return ``"file:line"`` for every ObjectVar called with a string model."""
+    tree = ast.parse(source, filename=filename)
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if name not in _OBJECT_VAR_NAMES:
+            continue
+        for kw in node.keywords:
+            if kw.arg == "model" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                violations.append(f"{filename}:{kw.value.lineno}")
+    return violations
+
+
+@pytest.mark.unit
+def test_objectvar_model_is_a_class_not_a_string() -> None:
+    """No bundled script may pass a string to ObjectVar(model=...) (issue #143)."""
+    scripts_dir = get_plugin_source_dir() / "scripts"
+    assert scripts_dir.is_dir(), f"scripts dir not found: {scripts_dir}"
+
+    all_violations: list[str] = []
+    for py_file in sorted(scripts_dir.glob("*.py")):
+        all_violations.extend(_string_model_violations(py_file.read_text(), py_file.name))
+
+    assert not all_violations, (
+        "ObjectVar(model=...) was given a string instead of a model class. NetBox "
+        "calls model.objects.all(), so the script fails to import and cannot be "
+        "registered. Import the model and pass the class (e.g. model=Tenant):\n  " + "\n  ".join(all_violations)
+    )


### PR DESCRIPTION
Promote `dev` to `main` for the **v1.2.2** patch release.

Contents since v1.2.1:
- **#143** bundled NetBox Scripts failed to load (ObjectVar string model) — PR #144 (+ AST regression guard, SCRIPTS_ROOT docs)
- **#141** verify-ci publish gate timeout widened to ~30 min — PR #142
- Version bump + CHANGELOG — PR #145

No migrations, no breaking changes. Tag `v1.2.2` follows on `main`.