### PR TITLE
fix: send expiry notifications from SERVER_EMAIL (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Expiry notification emails sent from the wrong address** ([#147](https://github.com/ctrl-alt-automate/netbox-ssl/issues/147)):
+  the expiry report used Django's `DEFAULT_FROM_EMAIL` (which defaults to
+  `webmaster@localhost`) as the From address. NetBox maps the operator's
+  `EMAIL_FROM` configuration onto `SERVER_EMAIL`, not `DEFAULT_FROM_EMAIL`, so
+  the configured sender was ignored. The notification now sends from
+  `SERVER_EMAIL`, falling back to `DEFAULT_FROM_EMAIL` only when `SERVER_EMAIL`
+  is unset so an empty From header is never produced.
+
 ## [1.2.2] - 2026-06-05
 
 **Patch release** — the bundled NetBox Scripts (expiry scan, expiry

--- a/netbox_ssl/utils/email.py
+++ b/netbox_ssl/utils/email.py
@@ -66,7 +66,10 @@ def send_expiry_report(
     text_body = render_to_string("netbox_ssl/email/expiry_report.txt", context)
     html_body = render_to_string("netbox_ssl/email/expiry_report.html", context)
 
-    from_email = settings.DEFAULT_FROM_EMAIL
+    # NetBox maps the operator's EMAIL_FROM config onto Django's SERVER_EMAIL,
+    # not DEFAULT_FROM_EMAIL (see #147). Prefer it, but fall back so an unset
+    # SERVER_EMAIL never produces an empty From header.
+    from_email = getattr(settings, "SERVER_EMAIL", None) or settings.DEFAULT_FROM_EMAIL
 
     try:
         msg = EmailMultiAlternatives(subject, text_body, from_email, recipients)

--- a/tests/test_email_notification.py
+++ b/tests/test_email_notification.py
@@ -123,13 +123,21 @@ EMPTY_REPORT = {
 }
 
 
-def _make_settings_mock(enabled: bool = True, recipients: list | None = None):
+def _make_settings_mock(
+    enabled: bool = True,
+    recipients: list | None = None,
+    server_email: str | None = "server@example.com",
+):
     """Create a mock settings object.
 
     Note: distinguish an explicit empty list (``[]`` — the "no recipients
     configured" case) from the default (``None`` → a sample recipient). Using
     ``recipients or [...]`` would collapse ``[]`` to the fallback and silently
     break the no-recipients test.
+
+    ``server_email`` mirrors Django's ``SERVER_EMAIL``, which NetBox populates
+    from the ``EMAIL_FROM`` config setting (see #147). It is kept distinct from
+    ``DEFAULT_FROM_EMAIL`` so the from-address tests can tell which one is used.
     """
     mock = MagicMock()
     mock.PLUGINS_CONFIG = {
@@ -140,6 +148,7 @@ def _make_settings_mock(enabled: bool = True, recipients: list | None = None):
         }
     }
     mock.DEFAULT_FROM_EMAIL = "netbox@example.com"
+    mock.SERVER_EMAIL = server_email
     return mock
 
 
@@ -231,3 +240,45 @@ class TestSendExpiryReport:
 
         result = send_expiry_report(SAMPLE_REPORT)
         assert result is False
+
+    @patch("netbox_ssl.utils.email.EmailMultiAlternatives")
+    @patch("netbox_ssl.utils.email.render_to_string", side_effect=lambda t, c: f"rendered:{t}")
+    @patch("netbox_ssl.utils.email.settings", new=_make_settings_mock(True))
+    def test_uses_server_email_as_from_address(self, mock_render, mock_email_cls):
+        """Regression for #147.
+
+        NetBox maps the ``EMAIL_FROM`` configuration setting onto Django's
+        ``SERVER_EMAIL``, not ``DEFAULT_FROM_EMAIL``. The expiry report must
+        therefore send from ``SERVER_EMAIL`` so the operator's configured
+        address is honoured instead of the ``webmaster@localhost`` default.
+        """
+        from netbox_ssl.utils.email import send_expiry_report
+
+        mock_msg = MagicMock()
+        mock_email_cls.return_value = mock_msg
+
+        result = send_expiry_report(SAMPLE_REPORT)
+
+        assert result is True
+        # EmailMultiAlternatives(subject, body, from_email, recipients)
+        from_email = mock_email_cls.call_args[0][2]
+        assert from_email == "server@example.com"
+
+    @patch("netbox_ssl.utils.email.EmailMultiAlternatives")
+    @patch("netbox_ssl.utils.email.render_to_string", side_effect=lambda t, c: f"rendered:{t}")
+    @patch("netbox_ssl.utils.email.settings", new=_make_settings_mock(True, server_email=""))
+    def test_falls_back_to_default_from_email_when_server_email_unset(self, mock_render, mock_email_cls):
+        """If ``SERVER_EMAIL`` is empty, fall back to ``DEFAULT_FROM_EMAIL``.
+
+        Guards against a naive ``settings.SERVER_EMAIL`` fix sending mail with
+        an empty From header on installs that never configured ``EMAIL_FROM``.
+        """
+        from netbox_ssl.utils.email import send_expiry_report
+
+        mock_msg = MagicMock()
+        mock_email_cls.return_value = mock_msg
+
+        send_expiry_report(SAMPLE_REPORT)
+
+        from_email = mock_email_cls.call_args[0][2]
+        assert from_email == "netbox@example.com"


### PR DESCRIPTION
## Summary

The Certificate Expiry Notification email used Django's `DEFAULT_FROM_EMAIL` (default `webmaster@localhost`) as the From address. NetBox maps the operator's `EMAIL_FROM` configuration onto Django's **`SERVER_EMAIL`**, not `DEFAULT_FROM_EMAIL` — so the configured sender was silently ignored.

## Change

`netbox_ssl/utils/email.py` now resolves the From address as:

```python
from_email = getattr(settings, "SERVER_EMAIL", None) or settings.DEFAULT_FROM_EMAIL
```

This honours the operator's `EMAIL_FROM` while falling back to `DEFAULT_FROM_EMAIL` only when `SERVER_EMAIL` is unset, so an empty From header is never produced.

## Tests (TDD)

Two regression tests added to `tests/test_email_notification.py`:
- `test_uses_server_email_as_from_address` — From == `SERVER_EMAIL` (failed before the fix).
- `test_falls_back_to_default_from_email_when_server_email_unset` — empty `SERVER_EMAIL` falls back to `DEFAULT_FROM_EMAIL` (guards against a naive one-line fix sending an empty From).

Full email suite: 9 passed. Ruff clean.

Reported by @mkarel with a precise root-cause and fix suggestion. 🙏

Closes #147