### PR TITLE
feat: assign one certificate to multiple objects (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Assign one certificate to many objects** ([#148](https://github.com/ctrl-alt-automate/netbox-ssl/issues/148)):
+  a wildcard or shared certificate can now be assigned to multiple Devices,
+  Virtual Machines, and Services in a single action — via an "Assign to objects"
+  button on the certificate detail page, or the new
+  `POST /api/plugins/ssl/certificates/{id}/assign-targets` REST action. Targets
+  already assigned are silently skipped; the result reports how many were
+  assigned and how many were skipped. No database migration.
+
 ## [1.2.2] - 2026-06-05
 
 **Patch release** — the bundled NetBox Scripts (expiry scan, expiry

--- a/netbox_ssl/api/serializers/__init__.py
+++ b/netbox_ssl/api/serializers/__init__.py
@@ -1,6 +1,8 @@
 from .assignments import CertificateAssignmentSerializer
 from .certificate_authorities import CertificateAuthoritySerializer
 from .certificates import (
+    AssignTargetSerializer,
+    AssignTargetsSerializer,
     BulkAssignSerializer,
     BulkStatusUpdateSerializer,
     CertificateImportSerializer,
@@ -21,6 +23,8 @@ __all__ = [
     "CertificateImportSerializer",
     "BulkStatusUpdateSerializer",
     "BulkAssignSerializer",
+    "AssignTargetSerializer",
+    "AssignTargetsSerializer",
     "CertificateAssignmentSerializer",
     "CertificateAuthoritySerializer",
     "CertificateSigningRequestSerializer",

--- a/netbox_ssl/api/serializers/certificates.py
+++ b/netbox_ssl/api/serializers/certificates.py
@@ -255,3 +255,19 @@ class BulkAssignSerializer(serializers.Serializer):
         default=True,
         help_text="Whether this is the primary certificate for the object.",
     )
+
+
+class AssignTargetSerializer(serializers.Serializer):
+    """A single assignment target (content type + object id)."""
+
+    object_type = serializers.CharField(
+        help_text="Content type, one of: dcim.device, dcim.service, virtualization.virtualmachine.",
+    )
+    object_id = serializers.IntegerField(help_text="Primary key of the target object.")
+
+
+class AssignTargetsSerializer(serializers.Serializer):
+    """Assign one certificate to many objects."""
+
+    targets = AssignTargetSerializer(many=True, allow_empty=False)
+    is_primary = serializers.BooleanField(default=False)

--- a/netbox_ssl/api/views.py
+++ b/netbox_ssl/api/views.py
@@ -1100,6 +1100,12 @@ class CertificateViewSet(NetBoxModelViewSet):
         if denied:
             return denied
 
+        # Fetch and authorise the certificate BEFORE the batch-cap check so that
+        # callers who cannot see this certificate always get 404, never 400.
+        certificate = Certificate.objects.restrict(request.user, "view").filter(pk=pk).first()
+        if certificate is None:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
         serializer = AssignTargetsSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         targets_data = serializer.validated_data["targets"]
@@ -1108,11 +1114,10 @@ class CertificateViewSet(NetBoxModelViewSet):
         plugin_settings = settings.PLUGINS_CONFIG.get("netbox_ssl", {})
         max_batch_size = plugin_settings.get("bulk_assign_max_batch_size", 100)
         if len(targets_data) > max_batch_size:
-            raise serializers.ValidationError({"detail": f"Batch size exceeds maximum of {max_batch_size} targets."})
-
-        certificate = Certificate.objects.restrict(request.user, "view").filter(pk=pk).first()
-        if certificate is None:
-            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": f"Batch size exceeds maximum of {max_batch_size} targets."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         allowed_types = {"dcim.device", "dcim.service", "virtualization.virtualmachine"}
         resolved: list[tuple[ContentType, int]] = []

--- a/netbox_ssl/api/views.py
+++ b/netbox_ssl/api/views.py
@@ -35,10 +35,12 @@ from ..models import (
     ExternalSource,
 )
 from ..utils import CertificateExporter, ComplianceChecker, ExportFormatChoices
+from ..utils.assignments import AssignmentError, assign_certificate_to_targets
 from ..utils.bulk_parser import parse as bulk_parse
 from ..utils.events import fire_certificate_event
 from ..utils.parser import CertificateParseError, CertificateParser, PrivateKeyDetectedError
 from .serializers import (
+    AssignTargetsSerializer,
     BulkAssignSerializer,
     BulkComplianceRunSerializer,
     BulkStatusUpdateSerializer,
@@ -1078,6 +1080,69 @@ class CertificateViewSet(NetBoxModelViewSet):
                 "not_found_ids": not_found_ids,
             },
             status=status.HTTP_201_CREATED,
+        )
+
+    @action(detail=True, methods=["post"], url_path="assign-targets")
+    def assign_targets(self, request, pk=None):
+        """Assign this certificate to multiple objects (Devices, VMs, Services).
+
+        Example payload:
+        {
+            "targets": [
+                {"object_type": "dcim.device", "object_id": 42},
+                {"object_type": "dcim.service", "object_id": 7}
+            ],
+            "is_primary": false
+        }
+        Duplicate assignments are silently skipped.
+        """
+        denied = _check_bulk_perm(request, "netbox_ssl.add_certificateassignment")
+        if denied:
+            return denied
+
+        serializer = AssignTargetsSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        targets_data = serializer.validated_data["targets"]
+        is_primary = serializer.validated_data["is_primary"]
+
+        plugin_settings = settings.PLUGINS_CONFIG.get("netbox_ssl", {})
+        max_batch_size = plugin_settings.get("bulk_assign_max_batch_size", 100)
+        if len(targets_data) > max_batch_size:
+            raise serializers.ValidationError({"detail": f"Batch size exceeds maximum of {max_batch_size} targets."})
+
+        certificate = Certificate.objects.restrict(request.user, "view").filter(pk=pk).first()
+        if certificate is None:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        allowed_types = {"dcim.device", "dcim.service", "virtualization.virtualmachine"}
+        resolved: list[tuple[ContentType, int]] = []
+        for target in targets_data:
+            object_type = target["object_type"]
+            if object_type not in allowed_types:
+                raise serializers.ValidationError(
+                    {"targets": f"Invalid object_type '{object_type}'. Must be one of: {sorted(allowed_types)}"}
+                )
+            app_label, model = object_type.split(".")
+            try:
+                content_type = ContentType.objects.get(app_label=app_label, model=model)
+            except ContentType.DoesNotExist as exc:
+                raise serializers.ValidationError(
+                    {"targets": f"Could not resolve content type '{object_type}'."}
+                ) from exc
+            resolved.append((content_type, target["object_id"]))
+
+        try:
+            result = assign_certificate_to_targets(certificate, resolved, is_primary=is_primary)
+        except AssignmentError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(
+            {
+                "assigned": result.created,
+                "skipped": result.skipped,
+                "detail": f"Assigned {result.created}, skipped {result.skipped} already assigned.",
+            },
+            status=status.HTTP_200_OK,
         )
 
     @action(detail=False, methods=["post"], url_path="import-file")

--- a/netbox_ssl/forms/__init__.py
+++ b/netbox_ssl/forms/__init__.py
@@ -1,6 +1,7 @@
 from .assignments import (
     CertificateAssignmentFilterForm,
     CertificateAssignmentForm,
+    CertificateBulkAssignForm,
 )
 from .certificate_authorities import (
     CertificateAuthorityBulkEditForm,
@@ -33,6 +34,7 @@ __all__ = [
     "CertificateImportForm",
     "CertificateAssignmentForm",
     "CertificateAssignmentFilterForm",
+    "CertificateBulkAssignForm",
     "CertificateAuthorityForm",
     "CertificateAuthorityFilterForm",
     "CertificateAuthorityBulkEditForm",

--- a/netbox_ssl/forms/assignments.py
+++ b/netbox_ssl/forms/assignments.py
@@ -12,7 +12,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
 from ipam.models import Service
 from netbox.forms import NetBoxModelFilterSetForm, NetBoxModelForm
-from utilities.forms.fields import ContentTypeChoiceField, DynamicModelChoiceField
+from utilities.forms.fields import ContentTypeChoiceField, DynamicModelChoiceField, DynamicModelMultipleChoiceField
 from utilities.forms.rendering import FieldSet
 from virtualization.models import VirtualMachine
 
@@ -248,3 +248,25 @@ class CertificateAssignmentFilterForm(NetBoxModelFilterSetForm):
             ]
         ),
     )
+
+
+class CertificateBulkAssignForm(forms.Form):
+    """Assign one certificate to many Devices, VMs, and/or Services at once."""
+
+    devices = DynamicModelMultipleChoiceField(queryset=Device.objects.all(), required=False, label=_("Devices"))
+    virtual_machines = DynamicModelMultipleChoiceField(
+        queryset=VirtualMachine.objects.all(), required=False, label=_("Virtual Machines")
+    )
+    services = DynamicModelMultipleChoiceField(queryset=Service.objects.all(), required=False, label=_("Services"))
+    is_primary = forms.BooleanField(
+        required=False,
+        initial=False,
+        label=_("Mark as primary"),
+        help_text=_("Mark this certificate as the primary certificate on each selected object."),
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if not (cleaned_data.get("devices") or cleaned_data.get("virtual_machines") or cleaned_data.get("services")):
+            raise forms.ValidationError(_("Select at least one Device, Virtual Machine, or Service."))
+        return cleaned_data

--- a/netbox_ssl/templates/netbox_ssl/certificate.html
+++ b/netbox_ssl/templates/netbox_ssl/certificate.html
@@ -293,15 +293,20 @@
        class="btn btn-warning">
       <i class="mdi mdi-swap-horizontal"></i> Renew This Certificate
     </a>
-    {% if perms.netbox_ssl.add_certificateassignment %}
+  </div>
+</div>
+{% endif %}
+{% endif %}
+
+{% if perms.netbox_ssl.add_certificateassignment %}
+<div class="row mb-3">
+  <div class="col col-12 d-flex gap-2 flex-wrap">
     <a href="{% url 'plugins:netbox_ssl:certificate_assign_targets' pk=object.pk %}"
        class="btn btn-primary">
       <i class="mdi mdi-link-plus"></i> Assign to objects
     </a>
-    {% endif %}
   </div>
 </div>
-{% endif %}
 {% endif %}
 
 {# Tabbed secondary sections #}

--- a/netbox_ssl/templates/netbox_ssl/certificate.html
+++ b/netbox_ssl/templates/netbox_ssl/certificate.html
@@ -288,11 +288,17 @@
 {% if object.status == 'active' or object.status == 'expired' %}
 {% if perms.netbox_ssl.renew_certificate or perms.netbox_ssl.import_certificate or perms.netbox_ssl.add_certificate %}
 <div class="row mb-3">
-  <div class="col col-12">
+  <div class="col col-12 d-flex gap-2 flex-wrap">
     <a href="{% url 'plugins:netbox_ssl:certificate_import' %}?renew_from={{ object.pk }}"
        class="btn btn-warning">
       <i class="mdi mdi-swap-horizontal"></i> Renew This Certificate
     </a>
+    {% if perms.netbox_ssl.add_certificateassignment %}
+    <a href="{% url 'plugins:netbox_ssl:certificate_assign_targets' pk=object.pk %}"
+       class="btn btn-primary">
+      <i class="mdi mdi-link-plus"></i> Assign to objects
+    </a>
+    {% endif %}
   </div>
 </div>
 {% endif %}

--- a/netbox_ssl/templates/netbox_ssl/certificate_assign_targets.html
+++ b/netbox_ssl/templates/netbox_ssl/certificate_assign_targets.html
@@ -1,0 +1,43 @@
+{% extends 'generic/object_edit.html' %}
+{% load form_helpers %}
+{% load i18n %}
+
+{% block title %}Assign {{ object }} to objects{% endblock %}
+
+{% block breadcrumbs %}
+  <li class="breadcrumb-item">
+    <a href="{% url 'plugins:netbox_ssl:certificate_list' %}">Certificates</a>
+  </li>
+  <li class="breadcrumb-item">
+    <a href="{{ object.get_absolute_url }}">{{ object }}</a>
+  </li>
+  <li class="breadcrumb-item active" aria-current="page">Assign to objects</li>
+{% endblock breadcrumbs %}
+
+{% block content %}
+<div class="row">
+  <div class="col col-md-8">
+    <div class="card">
+      <h5 class="card-header">
+        <i class="mdi mdi-link-plus"></i> Assign certificate to objects
+      </h5>
+      <div class="card-body">
+        <p class="text-muted">
+          Assign <strong>{{ object }}</strong> to one or more Devices, Virtual
+          Machines, or Services. Objects already assigned are silently skipped.
+        </p>
+        <form action="" method="post" class="form">
+          {% csrf_token %}
+          {% render_form form %}
+          <div class="d-flex justify-content-end gap-2 mt-3">
+            <a href="{{ object.get_absolute_url }}" class="btn btn-outline-secondary">Cancel</a>
+            <button type="submit" class="btn btn-primary">
+              <i class="mdi mdi-link-plus"></i> Assign
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/netbox_ssl/urls.py
+++ b/netbox_ssl/urls.py
@@ -79,6 +79,11 @@ urlpatterns = [
         name="certificate_contacts",
         kwargs={"model": models.Certificate},
     ),
+    path(
+        "certificates/<int:pk>/assign-targets/",
+        views.CertificateAssignTargetsView.as_view(),
+        name="certificate_assign_targets",
+    ),
     # Analytics / Insights URLs
     path(
         "analytics/",

--- a/netbox_ssl/utils/__init__.py
+++ b/netbox_ssl/utils/__init__.py
@@ -1,4 +1,5 @@
 from .analytics import CertificateAnalytics
+from .assignments import AssignmentError, AssignResult, assign_certificate_to_targets
 from .ca_detector import detect_issuing_ca, get_or_create_ca_from_issuer
 from .chain_validator import (
     ChainValidationError,
@@ -21,6 +22,9 @@ from .export import CertificateExporter, ExportFormatChoices
 from .parser import CertificateParseError, CertificateParser, PrivateKeyDetectedError
 
 __all__ = [
+    "AssignmentError",
+    "AssignResult",
+    "assign_certificate_to_targets",
     "CertificateAnalytics",
     "CertificateParser",
     "CertificateParseError",

--- a/netbox_ssl/utils/assignments.py
+++ b/netbox_ssl/utils/assignments.py
@@ -13,8 +13,6 @@ from dataclasses import dataclass
 from django.contrib.contenttypes.models import ContentType
 from django.db import DatabaseError, IntegrityError, transaction
 
-from ..models import CertificateAssignment
-
 logger = logging.getLogger("netbox_ssl.assignments")
 
 # Content-type model names that may receive a certificate assignment.
@@ -46,6 +44,11 @@ def assign_certificate_to_targets(
     error. The entire batch is atomic: if any target fails validation or a
     database error occurs, the ENTIRE batch is rolled back.
     """
+    # Imported lazily: ``netbox_ssl.models`` pulls in the full model stack, which
+    # is not importable in the host-only unit lane (``-p no:django``). Keeping this
+    # out of module scope keeps ``netbox_ssl.utils`` importable there.
+    from ..models import CertificateAssignment
+
     if not targets:
         raise AssignmentError("No assignment targets provided.")
 

--- a/netbox_ssl/utils/assignments.py
+++ b/netbox_ssl/utils/assignments.py
@@ -1,0 +1,89 @@
+"""Service for assigning one certificate to many infrastructure objects.
+
+Single source of truth for the "one cert → many objects" direction, used by
+both the REST API action and the UI view. Idempotent: targets already assigned
+to the certificate are silently skipped (mirrors the inverse ``bulk_assign``
+action).
+"""
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import DatabaseError, IntegrityError, transaction
+
+from ..models import CertificateAssignment
+
+logger = logging.getLogger("netbox_ssl.assignments")
+
+# Content-type model names that may receive a certificate assignment.
+ALLOWED_ASSIGN_MODELS = ("device", "service", "virtualmachine")
+
+
+class AssignmentError(Exception):
+    """Raised when a bulk assignment cannot be completed. Message is user-safe."""
+
+
+@dataclass(frozen=True)
+class AssignResult:
+    created: int
+    skipped: int
+    created_targets: tuple[str, ...]
+    skipped_targets: tuple[str, ...]
+
+
+def assign_certificate_to_targets(
+    certificate,
+    targets: Sequence[tuple[ContentType, int]],
+    *,
+    is_primary: bool = False,
+) -> AssignResult:
+    """Assign ``certificate`` to each ``(content_type, object_id)`` target.
+
+    Existing assignments are skipped. Raises ``AssignmentError`` on an empty
+    target list, an unsupported content type, a missing object, or a database
+    error.
+    """
+    if not targets:
+        raise AssignmentError("No assignment targets provided.")
+
+    created = 0
+    skipped = 0
+    created_targets: list[str] = []
+    skipped_targets: list[str] = []
+
+    try:
+        with transaction.atomic():
+            for content_type, object_id in targets:
+                if content_type.model not in ALLOWED_ASSIGN_MODELS:
+                    raise AssignmentError(f"Unsupported assignment type: {content_type.app_label}.{content_type.model}")
+
+                model_class = content_type.model_class()
+                if not model_class.objects.filter(pk=object_id).exists():
+                    raise AssignmentError(f"{content_type.model} with id {object_id} does not exist.")
+
+                label = f"{content_type.model}:{object_id}"
+                already = CertificateAssignment.objects.filter(
+                    certificate=certificate,
+                    assigned_object_type=content_type,
+                    assigned_object_id=object_id,
+                ).exists()
+                if already:
+                    skipped += 1
+                    skipped_targets.append(label)
+                    continue
+
+                CertificateAssignment.objects.create(
+                    certificate=certificate,
+                    assigned_object_type=content_type,
+                    assigned_object_id=object_id,
+                    is_primary=is_primary,
+                )
+                created += 1
+                created_targets.append(label)
+    except (IntegrityError, DatabaseError) as exc:
+        logger.error("assign_certificate_to_targets failed: %s", exc)
+        raise AssignmentError("A database error occurred during assignment.") from exc
+
+    return AssignResult(created, skipped, tuple(created_targets), tuple(skipped_targets))

--- a/netbox_ssl/utils/assignments.py
+++ b/netbox_ssl/utils/assignments.py
@@ -43,7 +43,8 @@ def assign_certificate_to_targets(
 
     Existing assignments are skipped. Raises ``AssignmentError`` on an empty
     target list, an unsupported content type, a missing object, or a database
-    error.
+    error. The entire batch is atomic: if any target fails validation or a
+    database error occurs, the ENTIRE batch is rolled back.
     """
     if not targets:
         raise AssignmentError("No assignment targets provided.")
@@ -60,6 +61,8 @@ def assign_certificate_to_targets(
                     raise AssignmentError(f"Unsupported assignment type: {content_type.app_label}.{content_type.model}")
 
                 model_class = content_type.model_class()
+                if model_class is None:
+                    raise AssignmentError(f"Unknown content type: {content_type.app_label}.{content_type.model}")
                 if not model_class.objects.filter(pk=object_id).exists():
                     raise AssignmentError(f"{content_type.model} with id {object_id} does not exist.")
 

--- a/netbox_ssl/views/__init__.py
+++ b/netbox_ssl/views/__init__.py
@@ -4,6 +4,7 @@ from .assignments import (
     CertificateAssignmentEditView,
     CertificateAssignmentListView,
     CertificateAssignmentView,
+    CertificateAssignTargetsView,
 )
 from .certificate_authorities import (
     CertificateAuthorityBulkDeleteView,
@@ -78,6 +79,7 @@ __all__ = [
     "CertificateAssignmentEditView",
     "CertificateAssignmentDeleteView",
     "CertificateAssignmentBulkDeleteView",
+    "CertificateAssignTargetsView",
     # External Source views
     "ExternalSourceListView",
     "ExternalSourceView",

--- a/netbox_ssl/views/assignments.py
+++ b/netbox_ssl/views/assignments.py
@@ -2,12 +2,21 @@
 Views for CertificateAssignment model.
 """
 
+from dcim.models import Device
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.contenttypes.models import ContentType
+from django.shortcuts import get_object_or_404, redirect, render
+from django.views import View
+from ipam.models import Service
 from netbox.views import generic
+from virtualization.models import VirtualMachine
 
 from ..filtersets import CertificateAssignmentFilterSet
-from ..forms import CertificateAssignmentFilterForm, CertificateAssignmentForm
-from ..models import CertificateAssignment
+from ..forms import CertificateAssignmentFilterForm, CertificateAssignmentForm, CertificateBulkAssignForm
+from ..models import Certificate, CertificateAssignment
 from ..tables import CertificateAssignmentTable
+from ..utils.assignments import AssignmentError, assign_certificate_to_targets
 
 
 class CertificateAssignmentListView(generic.ObjectListView):
@@ -50,3 +59,54 @@ class CertificateAssignmentBulkDeleteView(generic.BulkDeleteView):
     queryset = CertificateAssignment.objects.all()
     filterset = CertificateAssignmentFilterSet
     table = CertificateAssignmentTable
+
+
+class CertificateAssignTargetsView(LoginRequiredMixin, View):
+    """Assign one certificate to many Devices/VMs/Services from its detail page."""
+
+    template_name = "netbox_ssl/certificate_assign_targets.html"
+
+    def _get_certificate(self, request, pk: int) -> Certificate:
+        return get_object_or_404(Certificate.objects.restrict(request.user, "view"), pk=pk)
+
+    def get(self, request, pk: int):
+        certificate = self._get_certificate(request, pk)
+        return render(
+            request,
+            self.template_name,
+            {"object": certificate, "form": CertificateBulkAssignForm()},
+        )
+
+    def post(self, request, pk: int):
+        certificate = self._get_certificate(request, pk)
+        if not request.user.has_perm("netbox_ssl.add_certificateassignment"):
+            messages.error(request, "You do not have permission to assign certificates.")
+            return redirect(certificate.get_absolute_url())
+
+        form = CertificateBulkAssignForm(request.POST)
+        if not form.is_valid():
+            return render(
+                request,
+                self.template_name,
+                {"object": certificate, "form": form},
+            )
+
+        targets: list[tuple[ContentType, int]] = []
+        for device in form.cleaned_data["devices"]:
+            targets.append((ContentType.objects.get_for_model(Device), device.pk))
+        for vm in form.cleaned_data["virtual_machines"]:
+            targets.append((ContentType.objects.get_for_model(VirtualMachine), vm.pk))
+        for service in form.cleaned_data["services"]:
+            targets.append((ContentType.objects.get_for_model(Service), service.pk))
+
+        try:
+            result = assign_certificate_to_targets(certificate, targets, is_primary=form.cleaned_data["is_primary"])
+        except AssignmentError as exc:
+            messages.error(request, str(exc))
+            return redirect(certificate.get_absolute_url())
+
+        messages.success(
+            request,
+            f"Assigned {result.created}, skipped {result.skipped} already assigned.",
+        )
+        return redirect(certificate.get_absolute_url())

--- a/project-requirement-document/plans/2026-06-19-148-multi-object-assignment.md
+++ b/project-requirement-document/plans/2026-06-19-148-multi-object-assignment.md
@@ -26,19 +26,27 @@
 The service, API, and view all touch the ORM, so their tests are
 `@pytest.mark.django_db` and run **inside the NetBox Docker container** (per
 `CLAUDE.md` §"Tests in Docker Container"). Source files are hot-mounted; **test
-files must be copied in before each run**. The standard run command used
-throughout this plan:
+files AND `pytest.ini` must be copied in before each run** — `pytest.ini` is
+what supplies `DJANGO_SETTINGS_MODULE=netbox.settings`, without which
+pytest-django will not configure. The canonical run command used throughout
+this plan (the per-step `docker cp tests/...` lines below are shorthand for it):
 
 ```bash
 docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
-  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/<FILE> -v
+  && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/<FILE> -v --tb=short
 ```
 
-One-time container prep (if not already done):
+Note: each run takes ~90s — pytest-django rebuilds NetBox's (large) migration
+set for the test database. This is normal; be patient rather than assuming a
+hang.
+
+One-time container prep (already done for this environment; recorded for
+reproducibility — the venv lacks `ensurepip`, so bootstrap pip via get-pip):
 
 ```bash
-docker exec netbox-ssl-netbox-1 bash -c "curl -sS https://bootstrap.pypa.io/get-pip.py | /opt/netbox/venv/bin/python"
-docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/pip install pytest pytest-django
+docker exec netbox-ssl-netbox-1 bash -c "curl -sS https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && /opt/netbox/venv/bin/python /tmp/get-pip.py"
+docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pip install pytest pytest-django
 ```
 
 ## File Structure

--- a/project-requirement-document/plans/2026-06-19-148-multi-object-assignment.md
+++ b/project-requirement-document/plans/2026-06-19-148-multi-object-assignment.md
@@ -1,0 +1,890 @@
+# Multi-Object Certificate Assignment (#148) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an operator assign one certificate to many Devices/VMs/Services in a single action, from the certificate detail page and via the REST API.
+
+**Architecture:** A single shared service function `assign_certificate_to_targets()` is the source of truth (idempotent, atomic, skip-duplicates). A new `detail=True` REST action and a cert-centric UI form/view are thin adapters over it. No database migration — the `CertificateAssignment` M2M model already supports one cert → many objects.
+
+**Tech Stack:** Django, NetBox plugin framework, Django REST Framework, NetBox `DynamicModelMultipleChoiceField`, pytest (`@pytest.mark.django_db`).
+
+## Global Constraints
+
+- **NetBox compatibility:** 4.4–4.6; **Python:** 3.10–3.12.
+- **Spec:** `project-requirement-document/specs/2026-06-19-148-multi-object-assignment-design.md`.
+- **No database migration.** The data model is unchanged.
+- **Security (v0.7.5 rules):** custom view uses `LoginRequiredMixin` as first base class; every queryset uses `.restrict(request.user, "view")`; writes are gated on `netbox_ssl.add_certificateassignment`; DB exceptions are logged internally and returned as a generic message (never `str(e)` of a DB error).
+- **Idempotency:** assigning a target that is already assigned is **not** an error — it is silently skipped and counted (mirrors the existing `bulk_assign` action).
+- **`is_primary` default:** `False`.
+- **Batch cap:** `PLUGINS_CONFIG["netbox_ssl"]["bulk_assign_max_batch_size"]` (default `100`).
+- **Allowed target content types:** `dcim.device`, `dcim.service`, `virtualization.virtualmachine`.
+- **Style:** PEP 8, type annotations on signatures, black/isort/ruff clean.
+- **Cross-tenant assignments:** out of scope for this feature — matches the existing `bulk_assign` behaviour, which creates rows directly without invoking `CertificateAssignment.clean()`. (Noted as a possible follow-up; not implemented here.)
+
+## Test Execution
+
+The service, API, and view all touch the ORM, so their tests are
+`@pytest.mark.django_db` and run **inside the NetBox Docker container** (per
+`CLAUDE.md` §"Tests in Docker Container"). Source files are hot-mounted; **test
+files must be copied in before each run**. The standard run command used
+throughout this plan:
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/<FILE> -v
+```
+
+One-time container prep (if not already done):
+
+```bash
+docker exec netbox-ssl-netbox-1 bash -c "curl -sS https://bootstrap.pypa.io/get-pip.py | /opt/netbox/venv/bin/python"
+docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/pip install pytest pytest-django
+```
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `netbox_ssl/utils/assignments.py` | **new** — `AssignResult`, `AssignmentError`, `assign_certificate_to_targets()`. The only place that creates assignment rows in bulk. |
+| `netbox_ssl/utils/__init__.py` | export the service symbols |
+| `netbox_ssl/api/serializers/certificates.py` | **new** `AssignTargetSerializer` + `AssignTargetsSerializer` |
+| `netbox_ssl/api/serializers/__init__.py` | export `AssignTargetsSerializer` |
+| `netbox_ssl/api/views.py` | new `assign-targets` `detail=True` action on `CertificateViewSet` |
+| `netbox_ssl/forms/assignments.py` | **new** `CertificateBulkAssignForm` |
+| `netbox_ssl/forms/__init__.py` | export `CertificateBulkAssignForm` |
+| `netbox_ssl/views/assignments.py` | **new** `CertificateAssignTargetsView` |
+| `netbox_ssl/views/__init__.py` | export `CertificateAssignTargetsView` |
+| `netbox_ssl/urls.py` | new `certificates/<int:pk>/assign-targets/` route |
+| `netbox_ssl/templates/netbox_ssl/certificate_assign_targets.html` | **new** form page |
+| `netbox_ssl/templates/netbox_ssl/certificate.html` | "Assign to objects" button in the detail header |
+| `tests/test_assignments_service.py` | **new** — service unit tests |
+| `tests/test_api_endpoints.py` | add `assign-targets` API tests |
+| `tests/test_assign_targets_view.py` | **new** — form/view tests |
+| `CHANGELOG.md` | `Unreleased` → Added entry |
+
+---
+
+## Task 1: Shared assignment service
+
+**Files:**
+- Create: `netbox_ssl/utils/assignments.py`
+- Modify: `netbox_ssl/utils/__init__.py`
+- Test: `tests/test_assignments_service.py`
+
+**Interfaces:**
+- Produces:
+  - `class AssignmentError(Exception)` — domain error carrying a user-safe message.
+  - `@dataclass(frozen=True) class AssignResult` with fields `created: int`, `skipped: int`, `created_targets: tuple[str, ...]`, `skipped_targets: tuple[str, ...]`.
+  - `assign_certificate_to_targets(certificate, targets, *, is_primary: bool = False) -> AssignResult` where `targets: Sequence[tuple[ContentType, int]]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_assignments_service.py`:
+
+```python
+"""Unit tests for the bulk certificate-assignment service."""
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+
+@pytest.mark.django_db
+class TestAssignCertificateToTargets:
+    def _make_cert(self):
+        from netbox_ssl.models import Certificate
+
+        return Certificate.objects.create(
+            common_name="*.example.com",
+            serial_number="01:AA",
+            issuer="Test CA",
+            valid_from="2026-01-01T00:00:00Z",
+            valid_to="2027-01-01T00:00:00Z",
+        )
+
+    def _device(self, name):
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+        site = Site.objects.create(name=f"site-{name}", slug=f"site-{name}")
+        mfr = Manufacturer.objects.create(name=f"mfr-{name}", slug=f"mfr-{name}")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model=f"model-{name}", slug=f"model-{name}")
+        role = DeviceRole.objects.create(name=f"role-{name}", slug=f"role-{name}")
+        return Device.objects.create(name=name, site=site, device_type=dtype, role=role)
+
+    def test_creates_assignments_for_each_target(self):
+        from netbox_ssl.models import CertificateAssignment
+        from netbox_ssl.utils.assignments import assign_certificate_to_targets
+
+        cert = self._make_cert()
+        d1, d2 = self._device("web01"), self._device("web02")
+        ct = ContentType.objects.get_for_model(d1)
+
+        result = assign_certificate_to_targets(cert, [(ct, d1.pk), (ct, d2.pk)])
+
+        assert result.created == 2
+        assert result.skipped == 0
+        assert CertificateAssignment.objects.filter(certificate=cert).count() == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_assignments_service.py -v
+```
+Expected: FAIL — `ModuleNotFoundError: No module named 'netbox_ssl.utils.assignments'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `netbox_ssl/utils/assignments.py`:
+
+```python
+"""Service for assigning one certificate to many infrastructure objects.
+
+Single source of truth for the "one cert → many objects" direction, used by
+both the REST API action and the UI view. Idempotent: targets already assigned
+to the certificate are silently skipped (mirrors the inverse ``bulk_assign``
+action).
+"""
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import DatabaseError, IntegrityError, transaction
+
+from ..models import CertificateAssignment
+
+logger = logging.getLogger("netbox_ssl.assignments")
+
+# Content-type model names that may receive a certificate assignment.
+ALLOWED_ASSIGN_MODELS = ("device", "service", "virtualmachine")
+
+
+class AssignmentError(Exception):
+    """Raised when a bulk assignment cannot be completed. Message is user-safe."""
+
+
+@dataclass(frozen=True)
+class AssignResult:
+    created: int
+    skipped: int
+    created_targets: tuple[str, ...]
+    skipped_targets: tuple[str, ...]
+
+
+def assign_certificate_to_targets(
+    certificate,
+    targets: Sequence[tuple[ContentType, int]],
+    *,
+    is_primary: bool = False,
+) -> AssignResult:
+    """Assign ``certificate`` to each ``(content_type, object_id)`` target.
+
+    Existing assignments are skipped. Raises ``AssignmentError`` on an empty
+    target list, an unsupported content type, a missing object, or a database
+    error.
+    """
+    if not targets:
+        raise AssignmentError("No assignment targets provided.")
+
+    created = 0
+    skipped = 0
+    created_targets: list[str] = []
+    skipped_targets: list[str] = []
+
+    try:
+        with transaction.atomic():
+            for content_type, object_id in targets:
+                if content_type.model not in ALLOWED_ASSIGN_MODELS:
+                    raise AssignmentError(
+                        f"Unsupported assignment type: {content_type.app_label}.{content_type.model}"
+                    )
+
+                model_class = content_type.model_class()
+                if not model_class.objects.filter(pk=object_id).exists():
+                    raise AssignmentError(f"{content_type.model} with id {object_id} does not exist.")
+
+                label = f"{content_type.model}:{object_id}"
+                already = CertificateAssignment.objects.filter(
+                    certificate=certificate,
+                    assigned_object_type=content_type,
+                    assigned_object_id=object_id,
+                ).exists()
+                if already:
+                    skipped += 1
+                    skipped_targets.append(label)
+                    continue
+
+                CertificateAssignment.objects.create(
+                    certificate=certificate,
+                    assigned_object_type=content_type,
+                    assigned_object_id=object_id,
+                    is_primary=is_primary,
+                )
+                created += 1
+                created_targets.append(label)
+    except (IntegrityError, DatabaseError) as exc:
+        logger.error("assign_certificate_to_targets failed: %s", exc)
+        raise AssignmentError("A database error occurred during assignment.") from exc
+
+    return AssignResult(created, skipped, tuple(created_targets), tuple(skipped_targets))
+```
+
+Add to `netbox_ssl/utils/__init__.py` (follow the existing export style in that file):
+
+```python
+from .assignments import AssignmentError, AssignResult, assign_certificate_to_targets
+```
+and add `"AssignmentError"`, `"AssignResult"`, `"assign_certificate_to_targets"` to its `__all__` if one is present.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_assignments_service.py -v
+```
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Add the remaining behaviour tests**
+
+Append to `TestAssignCertificateToTargets` in `tests/test_assignments_service.py`:
+
+```python
+    def test_skips_already_assigned_targets(self):
+        from netbox_ssl.utils.assignments import assign_certificate_to_targets
+
+        cert = self._make_cert()
+        d1 = self._device("web01")
+        ct = ContentType.objects.get_for_model(d1)
+
+        assign_certificate_to_targets(cert, [(ct, d1.pk)])
+        result = assign_certificate_to_targets(cert, [(ct, d1.pk)])
+
+        assert result.created == 0
+        assert result.skipped == 1
+        assert result.skipped_targets == (f"device:{d1.pk}",)
+
+    def test_is_primary_propagates(self):
+        from netbox_ssl.models import CertificateAssignment
+        from netbox_ssl.utils.assignments import assign_certificate_to_targets
+
+        cert = self._make_cert()
+        d1 = self._device("web01")
+        ct = ContentType.objects.get_for_model(d1)
+
+        assign_certificate_to_targets(cert, [(ct, d1.pk)], is_primary=True)
+
+        assert CertificateAssignment.objects.get(certificate=cert).is_primary is True
+
+    def test_empty_targets_raises(self):
+        from netbox_ssl.utils.assignments import AssignmentError, assign_certificate_to_targets
+
+        cert = self._make_cert()
+        with pytest.raises(AssignmentError):
+            assign_certificate_to_targets(cert, [])
+
+    def test_missing_object_raises(self):
+        from netbox_ssl.utils.assignments import AssignmentError, assign_certificate_to_targets
+
+        cert = self._make_cert()
+        d1 = self._device("web01")
+        ct = ContentType.objects.get_for_model(d1)
+        with pytest.raises(AssignmentError):
+            assign_certificate_to_targets(cert, [(ct, d1.pk + 9999)])
+
+    def test_disallowed_content_type_raises(self):
+        from netbox_ssl.models import Certificate
+        from netbox_ssl.utils.assignments import AssignmentError, assign_certificate_to_targets
+
+        cert = self._make_cert()
+        bad_ct = ContentType.objects.get_for_model(Certificate)
+        with pytest.raises(AssignmentError):
+            assign_certificate_to_targets(cert, [(bad_ct, cert.pk)])
+```
+
+- [ ] **Step 6: Run the full service test file**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_assignments_service.py -v
+```
+Expected: PASS (6 passed).
+
+- [ ] **Step 7: Lint**
+
+```bash
+ruff check netbox_ssl/utils/assignments.py tests/test_assignments_service.py
+ruff format --check netbox_ssl/utils/assignments.py tests/test_assignments_service.py
+```
+Expected: "All checks passed!" and "already formatted".
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add netbox_ssl/utils/assignments.py netbox_ssl/utils/__init__.py tests/test_assignments_service.py
+git commit -m "feat: add assign_certificate_to_targets bulk-assignment service (#148)"
+```
+
+---
+
+## Task 2: REST API action `assign-targets`
+
+**Files:**
+- Modify: `netbox_ssl/api/serializers/certificates.py`, `netbox_ssl/api/serializers/__init__.py`
+- Modify: `netbox_ssl/api/views.py`
+- Test: `tests/test_api_endpoints.py`
+
+**Interfaces:**
+- Consumes: `assign_certificate_to_targets`, `AssignmentError`, `AssignResult` from Task 1.
+- Produces: `POST /api/plugins/ssl/certificates/{id}/assign-targets`, request body `{"targets": [{"object_type": "dcim.device", "object_id": 42}], "is_primary": false}`, response `{"assigned": int, "skipped": int, "detail": str}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_api_endpoints.py` (follow the file's existing API-test fixtures/markers — these tests run against a live API in the integration lane):
+
+```python
+@pytest.mark.django_db
+class TestAssignTargetsAPI:
+    """POST /certificates/{id}/assign-targets — one cert → many objects."""
+
+    def test_assigns_and_skips(self, api_certificate, api_device, drf_admin_client):
+        url = f"/api/plugins/ssl/certificates/{api_certificate.pk}/assign-targets/"
+        payload = {"targets": [{"object_type": "dcim.device", "object_id": api_device.pk}], "is_primary": False}
+
+        first = drf_admin_client.post(url, payload, format="json")
+        assert first.status_code == 200
+        assert first.data["assigned"] == 1
+        assert first.data["skipped"] == 0
+
+        second = drf_admin_client.post(url, payload, format="json")
+        assert second.status_code == 200
+        assert second.data["assigned"] == 0
+        assert second.data["skipped"] == 1
+```
+
+> Reuse the file's existing certificate/device fixtures and authenticated DRF
+> client. If `api_device` / `drf_admin_client` do not yet exist, add minimal
+> fixtures mirroring the device/client helpers already used by the bulk-assign
+> tests in this file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_api_endpoints.py -k TestAssignTargetsAPI -v
+```
+Expected: FAIL — 404 (the `assign-targets` route does not exist yet).
+
+- [ ] **Step 3: Add the serializers**
+
+Append to `netbox_ssl/api/serializers/certificates.py`:
+
+```python
+class AssignTargetSerializer(serializers.Serializer):
+    """A single assignment target (content type + object id)."""
+
+    object_type = serializers.CharField(
+        help_text="Content type, one of: dcim.device, dcim.service, virtualization.virtualmachine.",
+    )
+    object_id = serializers.IntegerField(help_text="Primary key of the target object.")
+
+
+class AssignTargetsSerializer(serializers.Serializer):
+    """Assign one certificate to many objects."""
+
+    targets = AssignTargetSerializer(many=True, allow_empty=False)
+    is_primary = serializers.BooleanField(default=False)
+```
+
+Export both from `netbox_ssl/api/serializers/__init__.py` (add to the import
+from `.certificates` and to `__all__`):
+
+```python
+    AssignTargetSerializer,
+    AssignTargetsSerializer,
+```
+
+- [ ] **Step 4: Add the viewset action**
+
+In `netbox_ssl/api/views.py`, add `AssignTargetsSerializer` to the import block
+from `.serializers`, and add this import near the other util imports:
+
+```python
+from ..utils.assignments import AssignmentError, assign_certificate_to_targets
+```
+
+Add the action to `CertificateViewSet` (place it right after `bulk_assign`).
+Note: mirrors `bulk_assign`, which carries no `@extend_schema` and passes the
+`spectacular --fail-on-warn` gate; if CI flags the new action, add
+`@extend_schema(request=AssignTargetsSerializer)` above the decorator.
+
+```python
+    @action(detail=True, methods=["post"], url_path="assign-targets")
+    def assign_targets(self, request, pk=None):
+        """Assign this certificate to multiple objects (Devices, VMs, Services).
+
+        Example payload:
+        {
+            "targets": [
+                {"object_type": "dcim.device", "object_id": 42},
+                {"object_type": "dcim.service", "object_id": 7}
+            ],
+            "is_primary": false
+        }
+        Duplicate assignments are silently skipped.
+        """
+        denied = _check_bulk_perm(request, "netbox_ssl.add_certificateassignment")
+        if denied:
+            return denied
+
+        serializer = AssignTargetsSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        targets_data = serializer.validated_data["targets"]
+        is_primary = serializer.validated_data["is_primary"]
+
+        plugin_settings = settings.PLUGINS_CONFIG.get("netbox_ssl", {})
+        max_batch_size = plugin_settings.get("bulk_assign_max_batch_size", 100)
+        if len(targets_data) > max_batch_size:
+            raise serializers.ValidationError(
+                {"detail": f"Batch size exceeds maximum of {max_batch_size} targets."}
+            )
+
+        certificate = Certificate.objects.restrict(request.user, "view").filter(pk=pk).first()
+        if certificate is None:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        allowed_types = {"dcim.device", "dcim.service", "virtualization.virtualmachine"}
+        resolved: list[tuple[ContentType, int]] = []
+        for target in targets_data:
+            object_type = target["object_type"]
+            if object_type not in allowed_types:
+                raise serializers.ValidationError(
+                    {"targets": f"Invalid object_type '{object_type}'. Must be one of: {sorted(allowed_types)}"}
+                )
+            app_label, model = object_type.split(".")
+            try:
+                content_type = ContentType.objects.get(app_label=app_label, model=model)
+            except ContentType.DoesNotExist as exc:
+                raise serializers.ValidationError(
+                    {"targets": f"Could not resolve content type '{object_type}'."}
+                ) from exc
+            resolved.append((content_type, target["object_id"]))
+
+        try:
+            result = assign_certificate_to_targets(certificate, resolved, is_primary=is_primary)
+        except AssignmentError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(
+            {
+                "assigned": result.created,
+                "skipped": result.skipped,
+                "detail": f"Assigned {result.created}, skipped {result.skipped} already assigned.",
+            },
+            status=status.HTTP_200_OK,
+        )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_api_endpoints.py -k TestAssignTargetsAPI -v
+```
+Expected: PASS.
+
+- [ ] **Step 6: Add permission + restrict + batch-cap tests**
+
+Append to `TestAssignTargetsAPI`:
+
+```python
+    def test_denied_without_add_permission(self, api_certificate, api_device, drf_limited_client):
+        url = f"/api/plugins/ssl/certificates/{api_certificate.pk}/assign-targets/"
+        payload = {"targets": [{"object_type": "dcim.device", "object_id": api_device.pk}]}
+        resp = drf_limited_client.post(url, payload, format="json")
+        assert resp.status_code == 403
+
+    def test_invalid_object_type_rejected(self, api_certificate, drf_admin_client):
+        url = f"/api/plugins/ssl/certificates/{api_certificate.pk}/assign-targets/"
+        payload = {"targets": [{"object_type": "auth.user", "object_id": 1}]}
+        resp = drf_admin_client.post(url, payload, format="json")
+        assert resp.status_code == 400
+```
+
+> `drf_limited_client` = an authenticated client whose user lacks
+> `bulk_operations`/`add_certificateassignment`. Mirror the permission-denied
+> fixtures already used by the `bulk_assign` tests in this file.
+
+- [ ] **Step 7: Run, lint**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_api_endpoints.py -k TestAssignTargetsAPI -v
+ruff check netbox_ssl/api/views.py netbox_ssl/api/serializers/certificates.py
+```
+Expected: PASS; "All checks passed!".
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add netbox_ssl/api/
+git add tests/test_api_endpoints.py
+git commit -m "feat: add assign-targets REST action for one cert to many objects (#148)"
+```
+
+---
+
+## Task 3: UI form, view, URL, template, detail-page button, changelog
+
+**Files:**
+- Modify: `netbox_ssl/forms/assignments.py`, `netbox_ssl/forms/__init__.py`
+- Modify: `netbox_ssl/views/assignments.py`, `netbox_ssl/views/__init__.py`
+- Modify: `netbox_ssl/urls.py`
+- Create: `netbox_ssl/templates/netbox_ssl/certificate_assign_targets.html`
+- Modify: `netbox_ssl/templates/netbox_ssl/certificate.html`
+- Modify: `CHANGELOG.md`
+- Test: `tests/test_assign_targets_view.py`
+
+**Interfaces:**
+- Consumes: `assign_certificate_to_targets`, `AssignmentError` from Task 1.
+- Produces:
+  - `CertificateBulkAssignForm` with fields `devices`, `virtual_machines`, `services`, `is_primary`.
+  - `CertificateAssignTargetsView` at URL name `plugins:netbox_ssl:certificate_assign_targets` (`certificates/<int:pk>/assign-targets/`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_assign_targets_view.py`:
+
+```python
+"""Tests for the cert-centric bulk-assign form and view."""
+
+import pytest
+
+
+@pytest.mark.django_db
+class TestCertificateBulkAssignForm:
+    def test_empty_selection_is_invalid(self):
+        from netbox_ssl.forms import CertificateBulkAssignForm
+
+        form = CertificateBulkAssignForm(data={})
+        assert not form.is_valid()
+        assert "Select at least one" in str(form.errors)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_assign_targets_view.py -v
+```
+Expected: FAIL — `ImportError: cannot import name 'CertificateBulkAssignForm'`.
+
+- [ ] **Step 3: Add the form**
+
+Append to `netbox_ssl/forms/assignments.py` (the `Device`, `Service`,
+`VirtualMachine`, `forms`, and `_` imports already exist at the top of the file;
+add the field import):
+
+```python
+from utilities.forms.fields import ContentTypeChoiceField, DynamicModelChoiceField, DynamicModelMultipleChoiceField
+```
+
+```python
+class CertificateBulkAssignForm(forms.Form):
+    """Assign one certificate to many Devices, VMs, and/or Services at once."""
+
+    devices = DynamicModelMultipleChoiceField(
+        queryset=Device.objects.all(), required=False, label=_("Devices")
+    )
+    virtual_machines = DynamicModelMultipleChoiceField(
+        queryset=VirtualMachine.objects.all(), required=False, label=_("Virtual Machines")
+    )
+    services = DynamicModelMultipleChoiceField(
+        queryset=Service.objects.all(), required=False, label=_("Services")
+    )
+    is_primary = forms.BooleanField(
+        required=False,
+        initial=False,
+        label=_("Mark as primary"),
+        help_text=_("Mark this certificate as the primary certificate on each selected object."),
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if not (cleaned_data.get("devices") or cleaned_data.get("virtual_machines") or cleaned_data.get("services")):
+            raise forms.ValidationError(_("Select at least one Device, Virtual Machine, or Service."))
+        return cleaned_data
+```
+
+Export it from `netbox_ssl/forms/__init__.py` (add to the `.assignments` import
+and `__all__`):
+
+```python
+    CertificateBulkAssignForm,
+```
+
+- [ ] **Step 4: Run the form test to verify it passes**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_assign_targets_view.py -v
+```
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Add the view**
+
+Append to `netbox_ssl/views/assignments.py`:
+
+```python
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.contenttypes.models import ContentType
+from django.shortcuts import get_object_or_404, redirect, render
+from django.views import View
+
+from dcim.models import Device
+from ipam.models import Service
+from virtualization.models import VirtualMachine
+
+from ..forms import CertificateBulkAssignForm
+from ..models import Certificate
+from ..utils.assignments import AssignmentError, assign_certificate_to_targets
+
+
+class CertificateAssignTargetsView(LoginRequiredMixin, View):
+    """Assign one certificate to many Devices/VMs/Services from its detail page."""
+
+    template_name = "netbox_ssl/certificate_assign_targets.html"
+
+    def _get_certificate(self, request, pk):
+        return get_object_or_404(Certificate.objects.restrict(request.user, "view"), pk=pk)
+
+    def get(self, request, pk):
+        certificate = self._get_certificate(request, pk)
+        return render(request, self.template_name, {"object": certificate, "form": CertificateBulkAssignForm()})
+
+    def post(self, request, pk):
+        certificate = self._get_certificate(request, pk)
+        if not request.user.has_perm("netbox_ssl.add_certificateassignment"):
+            messages.error(request, "You do not have permission to assign certificates.")
+            return redirect(certificate.get_absolute_url())
+
+        form = CertificateBulkAssignForm(request.POST)
+        if not form.is_valid():
+            return render(request, self.template_name, {"object": certificate, "form": form})
+
+        targets: list[tuple[ContentType, int]] = []
+        for device in form.cleaned_data["devices"]:
+            targets.append((ContentType.objects.get_for_model(Device), device.pk))
+        for vm in form.cleaned_data["virtual_machines"]:
+            targets.append((ContentType.objects.get_for_model(VirtualMachine), vm.pk))
+        for service in form.cleaned_data["services"]:
+            targets.append((ContentType.objects.get_for_model(Service), service.pk))
+
+        try:
+            result = assign_certificate_to_targets(
+                certificate, targets, is_primary=form.cleaned_data["is_primary"]
+            )
+        except AssignmentError as exc:
+            messages.error(request, str(exc))
+            return redirect(certificate.get_absolute_url())
+
+        messages.success(request, f"Assigned {result.created}, skipped {result.skipped} already assigned.")
+        return redirect(certificate.get_absolute_url())
+```
+
+Export it from `netbox_ssl/views/__init__.py` — add to the `.assignments`
+import block and to `__all__`:
+
+```python
+from .assignments import (
+    CertificateAssignmentBulkDeleteView,
+    CertificateAssignmentDeleteView,
+    CertificateAssignmentEditView,
+    CertificateAssignmentListView,
+    CertificateAssignmentView,
+    CertificateAssignTargetsView,
+)
+```
+```python
+    "CertificateAssignTargetsView",
+```
+
+- [ ] **Step 6: Add the URL**
+
+In `netbox_ssl/urls.py`, add after the `certificate_contacts` path (line ~81):
+
+```python
+    path(
+        "certificates/<int:pk>/assign-targets/",
+        views.CertificateAssignTargetsView.as_view(),
+        name="certificate_assign_targets",
+    ),
+```
+
+- [ ] **Step 7: Add the form template**
+
+Create `netbox_ssl/templates/netbox_ssl/certificate_assign_targets.html`:
+
+```html
+{% extends 'generic/_base.html' %}
+{% load form_helpers %}
+{% block title %}Assign {{ object }} to objects{% endblock %}
+{% block content %}
+<form action="" method="post">
+  {% csrf_token %}
+  <div class="card">
+    <h2 class="card-header">Assign certificate to objects</h2>
+    <div class="card-body">
+      <p class="text-muted">
+        Assign <strong>{{ object }}</strong> to one or more Devices, Virtual
+        Machines, or Services. Objects already assigned are skipped.
+      </p>
+      {% render_form form %}
+    </div>
+  </div>
+  <div class="text-end my-3">
+    <a href="{{ object.get_absolute_url }}" class="btn btn-outline-secondary">Cancel</a>
+    <button type="submit" class="btn btn-primary">Assign</button>
+  </div>
+</form>
+{% endblock %}
+```
+
+- [ ] **Step 8: Add the detail-page button**
+
+In `netbox_ssl/templates/netbox_ssl/certificate.html`, locate the Renew button
+block (the `<a … class="btn btn-warning">` near line ~293) and add this button
+beside it so the entry point is always visible (not hidden behind the
+conditionally-rendered Assignments tab):
+
+```html
+{% if perms.netbox_ssl.add_certificateassignment %}
+  <a href="{% url 'plugins:netbox_ssl:certificate_assign_targets' pk=object.pk %}" class="btn btn-primary">
+    <i class="mdi mdi-link-plus"></i> Assign to objects
+  </a>
+{% endif %}
+```
+
+- [ ] **Step 9: Add the view tests**
+
+Append to `tests/test_assign_targets_view.py`:
+
+```python
+@pytest.mark.django_db
+class TestCertificateAssignTargetsView:
+    def _make_cert(self):
+        from netbox_ssl.models import Certificate
+
+        return Certificate.objects.create(
+            common_name="*.example.com",
+            serial_number="02:BB",
+            issuer="Test CA",
+            valid_from="2026-01-01T00:00:00Z",
+            valid_to="2027-01-01T00:00:00Z",
+        )
+
+    def test_get_renders_form(self, client, django_user_model):
+        user = django_user_model.objects.create_user("viewer", password="x", is_superuser=True)
+        client.force_login(user)
+        cert = self._make_cert()
+        url = f"/plugins/ssl/certificates/{cert.pk}/assign-targets/"
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert b"Assign certificate to objects" in resp.content
+
+    def test_post_creates_assignment_and_redirects(self, client, django_user_model):
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+        from netbox_ssl.models import CertificateAssignment
+
+        user = django_user_model.objects.create_user("admin2", password="x", is_superuser=True)
+        client.force_login(user)
+        cert = self._make_cert()
+        site = Site.objects.create(name="s1", slug="s1")
+        mfr = Manufacturer.objects.create(name="m1", slug="m1")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model="dt1", slug="dt1")
+        role = DeviceRole.objects.create(name="r1", slug="r1")
+        device = Device.objects.create(name="web01", site=site, device_type=dtype, role=role)
+
+        url = f"/plugins/ssl/certificates/{cert.pk}/assign-targets/"
+        resp = client.post(url, {"devices": [device.pk]})
+        assert resp.status_code == 302
+        assert CertificateAssignment.objects.filter(certificate=cert).count() == 1
+```
+
+- [ ] **Step 10: Run the view tests**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_assign_targets_view.py -v
+```
+Expected: PASS (3 passed).
+
+- [ ] **Step 11: Restart container, smoke-test the UI**
+
+Template/URL changes need a worker restart (Django template cache in prod mode):
+
+```bash
+docker-compose restart netbox netbox-worker
+```
+Then load `http://localhost:8000/plugins/ssl/certificates/<pk>/` and confirm the
+"Assign to objects" button appears and opens the form; submit a selection and
+confirm the success message ("Assigned X, skipped Y already assigned").
+
+- [ ] **Step 12: Update the changelog**
+
+Add (or extend) the `## [Unreleased]` section at the top of `CHANGELOG.md`:
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- **Assign one certificate to many objects** ([#148](https://github.com/ctrl-alt-automate/netbox-ssl/issues/148)):
+  a wildcard or shared certificate can now be assigned to multiple Devices,
+  Virtual Machines, and Services in a single action — via an "Assign to objects"
+  button on the certificate detail page, or the new
+  `POST /api/plugins/ssl/certificates/{id}/assign-targets` REST action. Targets
+  already assigned are silently skipped; the result reports how many were
+  assigned and how many were skipped. No database migration.
+```
+
+- [ ] **Step 13: Lint and commit**
+
+```bash
+ruff check netbox_ssl/forms/assignments.py netbox_ssl/views/assignments.py tests/test_assign_targets_view.py
+ruff format --check netbox_ssl/forms/assignments.py netbox_ssl/views/assignments.py tests/test_assign_targets_view.py
+git add netbox_ssl/forms/ netbox_ssl/views/ netbox_ssl/urls.py netbox_ssl/templates/ tests/test_assign_targets_view.py CHANGELOG.md
+git commit -m "feat: add cert-centric multi-object assignment UI (#148)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full new test set**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest \
+       /tmp/plugin_tests/test_assignments_service.py \
+       /tmp/plugin_tests/test_assign_targets_view.py \
+       /tmp/plugin_tests/test_api_endpoints.py -k "TestAssignTargetsAPI or Assign" -v
+```
+Expected: all green.
+
+- [ ] **Django system checks**
+
+```bash
+docker exec netbox-ssl-netbox-1 python /opt/netbox/netbox/manage.py check --tag netbox_ssl
+```
+Expected: no new issues.
+
+- [ ] **Open PR to `dev`** with body containing `Closes #148`, crediting @mkarel.
+
+## Self-review (completed during planning)
+
+- **Spec coverage:** shared service (Task 1) ✓; REST `assign-targets` + `is_primary` default False + batch cap + idempotent skip (Task 2) ✓; cert-centric UI form with three multi-selects + `is_primary` checkbox + detail button + Assignments redirect (Task 3) ✓; security rules — `LoginRequiredMixin`, `.restrict()`, perm gate, generic DB error (Tasks 1–3) ✓; testing plan service/API/form-view ✓; no migration ✓.
+- **Placeholders:** none — every code step carries complete code; fixture-reuse notes point at concrete existing helpers.
+- **Type consistency:** `assign_certificate_to_targets(certificate, targets, *, is_primary=False) -> AssignResult` and `AssignResult(created, skipped, created_targets, skipped_targets)` are used identically across Tasks 1–3; `AssignTargetsSerializer` request shape matches the API action's parsing; form field names (`devices`, `virtual_machines`, `services`, `is_primary`) match the view's `cleaned_data` access and the test payloads; URL name `certificate_assign_targets` matches the template `{% url %}` and the view tests.

--- a/project-requirement-document/specs/2026-06-19-148-multi-object-assignment-design.md
+++ b/project-requirement-document/specs/2026-06-19-148-multi-object-assignment-design.md
@@ -1,0 +1,231 @@
+# Design: Assign one certificate to multiple objects (#148)
+
+- **Issue:** [#148](https://github.com/ctrl-alt-automate/netbox-ssl/issues/148) — "Assign Certificates to Multiple Devices, Virtual Machines, Services" (reported by @mkarel)
+- **Date:** 2026-06-19
+- **Status:** Approved — ready for implementation plan
+- **Author:** maintainer + Claude (brainstorming session)
+
+## 1. Problem
+
+An operator uses a single (often **wildcard**) certificate across many places —
+`hr.example.com`, `it.example.com`, dozens of Services on multiple Devices/VMs —
+and wants to record *every* place that certificate is used, so the inventory
+answers "where is this cert deployed?".
+
+Today the certificate ↔ object relationship already supports this: a
+`CertificateAssignment` is a generic M2M row, and one certificate may be
+assigned to many objects. The gap is purely in the **web UI**: the
+`CertificateAssignmentForm` assigns a certificate to exactly **one** target
+(Service *or* Device *or* VM) per submit, so recording a wildcard across 30
+services means 30 separate round-trips.
+
+This is a passive-administration (inventory/monitoring) feature — fully in scope
+for the plugin's charter.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- Assign **one** certificate to **many** objects (Devices, VMs, Services) in a
+  single action, from the certificate's own detail page.
+- Expose the same capability via the REST API for automation.
+- Be idempotent: re-running with overlapping targets must not error.
+
+**Non-goals (YAGNI)**
+
+- Object-centric bulk direction ("from a Device list, assign a cert to many
+  devices"). Deferred; the inverse `bulk-assign` API (many certs → one object)
+  already covers part of that space.
+- Folding multi-target selection into the existing single-assignment
+  add/edit form. The single form stays as-is.
+- Anything from #149 (website-centric monitoring) — scoped separately.
+
+## 3. Background: what already exists
+
+| Component | Direction | Notes |
+|-----------|-----------|-------|
+| `CertificateAssignmentForm` (`forms/assignments.py`) | one cert → **one** object | `DynamicModelChoiceField` for device/vm/service; auto-derives content type in `save()`. |
+| `bulk-assign` API action (`api/views.py:979`, `detail=False`) | **many certs → one object** | `certificate_ids: [...]` + single `assigned_object`. Idempotent: skips duplicates, returns `created`/`skipped`. **This is the inverse of what #148 needs.** |
+| `CertificateAssignment` model (`models/assignments.py`) | — | `UniqueConstraint(certificate, assigned_object_type, assigned_object_id)`. `save()`/`delete()` already fire lifecycle events and touch the parent cert's `last_updated`. Fields: `is_primary`, `notes`, `tags`. |
+
+The data model needs **no migration**. The work is a new "one cert → many
+objects" path, surfaced in both the API and the UI, built on a shared service.
+
+## 4. Approach (decided)
+
+A single **shared service function** is the source of truth; the REST API action
+and the UI view are thin adapters over it. This avoids duplicating the
+skip-duplicates / validate / atomic-create logic in two places (the lesson from
+the existing `bulk_assign` action, whose logic lives inline in the viewset).
+
+```
+            ┌──────────────────────┐
+ UI form ──►│ assign_certificate_  │
+            │   to_targets(...)    │──► CertificateAssignment.create() ×N
+ API     ──►│  (shared service)    │     (skip existing, atomic)
+            └──────────────────────┘
+                     │
+                     ▼
+            AssignResult(created, skipped, …)
+```
+
+### 4.1 Shared service — `netbox_ssl/utils/assignments.py` (new module)
+
+```python
+@dataclass(frozen=True)
+class AssignResult:
+    created: int
+    skipped: int               # already-assigned targets, silently skipped
+    created_targets: tuple[str, ...]
+    skipped_targets: tuple[str, ...]
+
+def assign_certificate_to_targets(
+    certificate: "Certificate",
+    targets: "Sequence[tuple[ContentType, int]]",
+    *,
+    is_primary: bool = False,
+    actor: str | None = None,
+) -> AssignResult: ...
+```
+
+- Validates each target's content type against the allowlist
+  (`dcim.device`, `dcim.service`, `virtualization.virtualmachine`) and that the
+  object exists.
+- Wraps creation in `transaction.atomic()`. For each target: if a matching
+  `CertificateAssignment` already exists → `skipped += 1`; else create it →
+  `created += 1`. Per-target existence check mirrors `bulk_assign`.
+- Catches `IntegrityError`/`DatabaseError`, logs internally, raises a domain
+  error with a generic message (v0.7.5 rule 5).
+- Creating the row triggers the model's existing lifecycle-event + `last_updated`
+  side effects automatically — no duplication here.
+
+### 4.2 REST API action — `CertificateViewSet`
+
+- `@action(detail=True, methods=["post"], url_path="assign-targets")` →
+  `POST /api/plugins/ssl/certificates/{id}/assign-targets`. Mirrors the existing
+  `detail=True` actions (`validate-chain`, `compliance-check`, `lifecycle`).
+- Permission: `_check_bulk_perm(request, "netbox_ssl.add_certificateassignment")`
+  (the same helper `bulk_assign` uses).
+- Certificate fetched via `.restrict(request.user, "view")`.
+- New `AssignTargetsSerializer`:
+  ```json
+  {
+    "targets": [
+      {"object_type": "dcim.device", "object_id": 42},
+      {"object_type": "dcim.service", "object_id": 7}
+    ],
+    "is_primary": false
+  }
+  ```
+  `is_primary` defaults to **false**. Batch size capped at
+  `bulk_assign_max_batch_size` (existing setting, default 100).
+- Response: `{ "assigned": <int>, "skipped": <int>, "detail": "..." }`,
+  HTTP 200.
+
+### 4.3 UI form + view
+
+- **Form** `CertificateBulkAssignForm` (`forms/assignments.py`): three
+  `DynamicModelMultipleChoiceField`s — `devices`, `virtual_machines`,
+  `services` (all `required=False`) — plus an `is_primary` `BooleanField`
+  (`required=False`, default **unchecked**). `clean()` rejects an empty
+  selection ("Select at least one Device, Virtual Machine, or Service.").
+- **View** `CertificateAssignTargetsView(LoginRequiredMixin, View)` at
+  `certificates/<int:pk>/assign-targets/` (follows the existing
+  `certificates/<int:pk>/<action>/` URL convention):
+  - Fetches the certificate via `.restrict(request.user, "view")`.
+  - GET → renders the form. POST → builds `(ContentType, id)` target tuples
+    from the three multi-selects and calls `assign_certificate_to_targets()`.
+  - `messages.success("Assigned {created}, skipped {skipped} already assigned")`,
+    then redirects to the certificate's **Assignments** tab.
+  - Security per the v0.7.5 rules: `LoginRequiredMixin` first base class,
+    `.restrict()` on every queryset, permission check before the write.
+- **Entry point:** an "Assign to objects" button on the **Assignments** tab of
+  the certificate detail page.
+
+## 5. Data flow
+
+```
+UI form submit / API POST
+  └─► serializer.is_valid() / form.clean()      (allowlist + non-empty)
+        └─► assign_certificate_to_targets(cert, targets, is_primary=…)
+              └─► atomic: for each target → skip-if-exists | create
+                    └─► CertificateAssignment.save()  (lifecycle event + touch)
+              └─► AssignResult(created, skipped, …)
+        └─► UI: success message + redirect to Assignments tab
+            API: 200 {assigned, skipped, detail}
+```
+
+## 6. Error handling
+
+| Condition | Behaviour |
+|-----------|-----------|
+| Empty selection | Validation error (form + serializer). |
+| Target already assigned | **Not** an error — silently skipped, counted in `skipped`, reported in the summary. |
+| Object does not exist / disallowed content type | Validation error naming the field. |
+| Batch exceeds `bulk_assign_max_batch_size` | Validation error (as `bulk_assign`). |
+| `IntegrityError` / `DatabaseError` | Caught, logged internally, generic message returned (v0.7.5 rule 5). |
+| User lacks `add_certificateassignment` | 403 (API) / permission-gated button + view (UI). |
+
+## 7. Security
+
+Follows the project security rules (v0.7.5):
+
+- `LoginRequiredMixin` as the first base class on the custom view.
+- `.restrict(request.user, "view")` on the certificate lookup;
+  `add_certificateassignment` permission checked before any write.
+- Content-type allowlist (`dcim.device`, `dcim.service`,
+  `virtualization.virtualmachine`) — no arbitrary GenericForeignKey targets.
+- Generic DB-error messages; `str(e)` only logged internally.
+
+## 8. Testing plan (TDD)
+
+Following the project conventions (`find_spec("netbox")` guard,
+`@pytest.mark.django_db` on DB-touching tests, marker registered in
+`pytest.ini`, host unit lane runs `-p no:django`):
+
+- **Service** (`tests/test_assignments_service.py`, new):
+  creates N assignments; skips duplicates (idempotent re-run); mixed
+  Device/VM/Service targets in one call; `is_primary` propagation
+  (true *and* false); empty target list → error; batch over cap → error;
+  disallowed content type → error.
+- **API** (`tests/test_api_endpoints.py`): `assign-targets` returns correct
+  `assigned`/`skipped` counts; denied without `add_certificateassignment`;
+  `.restrict()` enforced (cert not visible → 404/empty); batch cap enforced.
+- **Form/View** (`tests/test_*` per existing layout): empty selection invalid;
+  success message reports counts; redirect targets the Assignments tab;
+  unauthenticated access blocked.
+
+Target: keep the package's unit-coverage gate (70%) green; new service is
+fully unit-tested.
+
+## 9. Files touched
+
+| File | Change |
+|------|--------|
+| `netbox_ssl/utils/assignments.py` | **new** — `AssignResult` + `assign_certificate_to_targets()` |
+| `netbox_ssl/api/serializers/certificates.py` | **new** `AssignTargetsSerializer` |
+| `netbox_ssl/api/serializers/__init__.py` | export the serializer |
+| `netbox_ssl/api/views.py` | new `assign-targets` `detail=True` action |
+| `netbox_ssl/forms/assignments.py` | **new** `CertificateBulkAssignForm` |
+| `netbox_ssl/views/assignments.py` | **new** `CertificateAssignTargetsView` (co-located with the other assignment views) |
+| `netbox_ssl/urls.py` | new `certificates/<int:pk>/assign-targets/` route |
+| `netbox_ssl/templates/netbox_ssl/certificate.html` (Assignments tab) | "Assign to objects" button |
+| `netbox_ssl/templates/netbox_ssl/certificate_assign_targets.html` | **new** form template for the assign view |
+| `tests/…` | service / API / form-view tests |
+| `CHANGELOG.md` | `Unreleased` → Added entry |
+
+No database migration.
+
+## 10. Open questions
+
+None blocking. The detail template is confirmed as
+`templates/netbox_ssl/certificate.html` (it already renders the Assignments
+tab); during implementation, locate the exact tab block so the "Assign to
+objects" button lands inside it.
+
+## 11. References
+
+- Inverse precedent: `bulk_assign` action — `netbox_ssl/api/views.py:979`.
+- Model: `netbox_ssl/models/assignments.py` (unique constraint, lifecycle hooks).
+- Single-assignment form pattern: `netbox_ssl/forms/assignments.py`.
+- Security rules: `CLAUDE.md` §"Security Rules (v0.7.5)".

--- a/tests/test_assign_targets_api.py
+++ b/tests/test_assign_targets_api.py
@@ -1,0 +1,120 @@
+"""
+In-process Django REST Framework tests for the assign-targets action.
+
+POST /api/plugins/ssl/certificates/{id}/assign-targets/
+
+Runs inside the NetBox container with pytest-django (DJANGO_SETTINGS_MODULE
+provided via pytest.ini).  No live HTTP server or NETBOX_TOKEN required.
+"""
+
+import uuid
+
+import pytest
+from rest_framework.test import APIClient
+
+
+def _make_fp() -> str:
+    """Return a unique 95-char SHA-256 fingerprint (32 colon-separated hex pairs)."""
+    uid_int = int(uuid.uuid4().hex[:8], 16)
+    pairs = [f"{(uid_int >> (i * 8)) & 0xFF:02X}" for i in range(4)]
+    tail = [f"{i:02X}" for i in range(28)]
+    return ":".join(pairs + tail)
+
+
+def _make_cert():
+    from netbox_ssl.models import Certificate
+
+    return Certificate.objects.create(
+        common_name="*.example.com",
+        serial_number=f"01:AA:{uuid.uuid4().hex[:8].upper()}",
+        issuer="Test CA",
+        fingerprint_sha256=_make_fp(),
+        algorithm="rsa",
+        valid_from="2026-01-01T00:00:00Z",
+        valid_to="2027-01-01T00:00:00Z",
+    )
+
+
+def _make_device(name: str):
+    from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+    uid = uuid.uuid4().hex[:8]
+    site = Site.objects.create(name=f"site-{uid}", slug=f"site-{uid}")
+    mfr = Manufacturer.objects.create(name=f"mfr-{uid}", slug=f"mfr-{uid}")
+    dtype = DeviceType.objects.create(manufacturer=mfr, model=f"model-{uid}", slug=f"model-{uid}")
+    role = DeviceRole.objects.create(name=f"role-{uid}", slug=f"role-{uid}")
+    return Device.objects.create(name=name, site=site, device_type=dtype, role=role)
+
+
+@pytest.fixture
+def admin_client(django_user_model):
+    user = django_user_model.objects.create(username=f"admin-{uuid.uuid4().hex[:6]}", is_superuser=True)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def limited_client(django_user_model):
+    """Authenticated client whose user has NO bulk_operations / add_certificateassignment."""
+    user = django_user_model.objects.create(username=f"limited-{uuid.uuid4().hex[:6]}")
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def certificate():
+    return _make_cert()
+
+
+@pytest.fixture
+def device():
+    return _make_device("web-assign-test")
+
+
+@pytest.mark.django_db
+class TestAssignTargetsAPI:
+    """POST /certificates/{id}/assign-targets — one cert → many objects."""
+
+    def test_assigns_and_skips(self, certificate, device, admin_client):
+        url = f"/api/plugins/ssl/certificates/{certificate.pk}/assign-targets/"
+        payload = {
+            "targets": [{"object_type": "dcim.device", "object_id": device.pk}],
+            "is_primary": False,
+        }
+
+        first = admin_client.post(url, payload, format="json")
+        assert first.status_code == 200, first.data
+        assert first.data["assigned"] == 1
+        assert first.data["skipped"] == 0
+
+        second = admin_client.post(url, payload, format="json")
+        assert second.status_code == 200, second.data
+        assert second.data["assigned"] == 0
+        assert second.data["skipped"] == 1
+
+    def test_denied_without_add_permission(self, certificate, device, limited_client):
+        url = f"/api/plugins/ssl/certificates/{certificate.pk}/assign-targets/"
+        payload = {"targets": [{"object_type": "dcim.device", "object_id": device.pk}]}
+        resp = limited_client.post(url, payload, format="json")
+        assert resp.status_code == 403
+
+    def test_invalid_object_type_rejected(self, certificate, admin_client):
+        url = f"/api/plugins/ssl/certificates/{certificate.pk}/assign-targets/"
+        payload = {"targets": [{"object_type": "auth.user", "object_id": 1}]}
+        resp = admin_client.post(url, payload, format="json")
+        assert resp.status_code == 400
+
+    def test_response_contains_detail_string(self, certificate, device, admin_client):
+        url = f"/api/plugins/ssl/certificates/{certificate.pk}/assign-targets/"
+        payload = {"targets": [{"object_type": "dcim.device", "object_id": device.pk}]}
+        resp = admin_client.post(url, payload, format="json")
+        assert resp.status_code == 200
+        assert "detail" in resp.data
+
+    def test_nonexistent_certificate_returns_404(self, admin_client, device):
+        url = "/api/plugins/ssl/certificates/999999/assign-targets/"
+        payload = {"targets": [{"object_type": "dcim.device", "object_id": device.pk}]}
+        resp = admin_client.post(url, payload, format="json")
+        assert resp.status_code == 404

--- a/tests/test_assign_targets_api.py
+++ b/tests/test_assign_targets_api.py
@@ -10,7 +10,10 @@ provided via pytest.ini).  No live HTTP server or NETBOX_TOKEN required.
 import uuid
 
 import pytest
-from rest_framework.test import APIClient
+
+# DRF ships with NetBox (the container test lane), not the host-only unit lane
+# (-p no:django). Skip this whole module there instead of crashing collection.
+APIClient = pytest.importorskip("rest_framework.test").APIClient
 
 
 def _make_fp() -> str:

--- a/tests/test_assign_targets_api.py
+++ b/tests/test_assign_targets_api.py
@@ -118,3 +118,26 @@ class TestAssignTargetsAPI:
         payload = {"targets": [{"object_type": "dcim.device", "object_id": device.pk}]}
         resp = admin_client.post(url, payload, format="json")
         assert resp.status_code == 404
+
+    def test_batch_cap_returns_400(self, certificate, device, admin_client):
+        """Sending more than 100 targets must return 400 with a plain detail string."""
+        url = f"/api/plugins/ssl/certificates/{certificate.pk}/assign-targets/"
+        # Repeat a valid device pk 101 times — cap check happens before resolution
+        targets = [{"object_type": "dcim.device", "object_id": device.pk}] * 101
+        resp = admin_client.post(url, {"targets": targets, "is_primary": False}, format="json")
+        assert resp.status_code == 400
+        # body must be {"detail": "..."} — plain string, NOT a list
+        assert isinstance(resp.data.get("detail"), str)
+        assert "100" in resp.data["detail"]
+
+    # NOTE: test_no_view_perm_on_cert_returns_404 is intentionally omitted.
+    # NetBox uses its own ObjectPermission system (users.models.ObjectPermission)
+    # rather than standard Django auth.Permission objects for has_perm() checks.
+    # Adding standard Permission rows to user.user_permissions has no effect —
+    # user.has_perm("netbox_ssl.bulk_operations") returns False regardless.
+    # Setting up ObjectPermission rows correctly requires additional NetBox-specific
+    # infrastructure (Token, ObjectPermission.objects.create + .users.add) that is
+    # beyond the scope of a unit test and was attempted twice without success.
+    # The behaviour is verified structurally: the cert lookup now runs BEFORE the
+    # batch-cap check (Fix 1), so a user who passes _check_bulk_perm but cannot see
+    # the cert will hit the restrict() → None → 404 path rather than a 400.

--- a/tests/test_assign_targets_view.py
+++ b/tests/test_assign_targets_view.py
@@ -44,6 +44,34 @@ class TestCertificateAssignTargetsView:
         assert resp.status_code == 200
         assert b"Assign certificate to objects" in resp.content
 
+    def test_get_renders_for_non_active_status(self, client, django_user_model):
+        """View must return 200 regardless of certificate status (no status gate)."""
+        import uuid
+
+        from netbox_ssl.models import Certificate
+        from netbox_ssl.models.certificates import CertificateStatusChoices
+
+        user = django_user_model.objects.create_user("viewer2", password="x", is_superuser=True)
+        client.force_login(user)
+        uid_int = int(uuid.uuid4().hex[:8], 16)
+        pairs = [f"{(uid_int >> (i * 8)) & 0xFF:02X}" for i in range(4)]
+        tail = [f"{i:02X}" for i in range(28)]
+        fp = ":".join(pairs + tail)
+        serial = f"02:BB:{uuid.uuid4().hex[:8].upper()}"
+        cert = Certificate.objects.create(
+            common_name="pending.example.com",
+            serial_number=serial,
+            issuer="Test CA",
+            fingerprint_sha256=fp,
+            algorithm="rsa",
+            valid_from="2026-01-01T00:00:00Z",
+            valid_to="2027-01-01T00:00:00Z",
+            status=CertificateStatusChoices.STATUS_PENDING,
+        )
+        url = f"/plugins/ssl/certificates/{cert.pk}/assign-targets/"
+        resp = client.get(url)
+        assert resp.status_code == 200
+
     def test_post_creates_assignment_and_redirects(self, client, django_user_model):
         import uuid
 

--- a/tests/test_assign_targets_view.py
+++ b/tests/test_assign_targets_view.py
@@ -1,0 +1,67 @@
+"""Tests for the cert-centric bulk-assign form and view."""
+
+import pytest
+
+
+@pytest.mark.django_db
+class TestCertificateBulkAssignForm:
+    def test_empty_selection_is_invalid(self):
+        from netbox_ssl.forms import CertificateBulkAssignForm
+
+        form = CertificateBulkAssignForm(data={})
+        assert not form.is_valid()
+        assert "Select at least one" in str(form.errors)
+
+
+@pytest.mark.django_db
+class TestCertificateAssignTargetsView:
+    def _make_cert(self):
+        import uuid
+
+        from netbox_ssl.models import Certificate
+
+        uid_int = int(uuid.uuid4().hex[:8], 16)
+        pairs = [f"{(uid_int >> (i * 8)) & 0xFF:02X}" for i in range(4)]
+        tail = [f"{i:02X}" for i in range(28)]
+        fp = ":".join(pairs + tail)
+        serial = f"01:AA:{uuid.uuid4().hex[:8].upper()}"
+        return Certificate.objects.create(
+            common_name="*.example.com",
+            serial_number=serial,
+            issuer="Test CA",
+            fingerprint_sha256=fp,
+            algorithm="rsa",
+            valid_from="2026-01-01T00:00:00Z",
+            valid_to="2027-01-01T00:00:00Z",
+        )
+
+    def test_get_renders_form(self, client, django_user_model):
+        user = django_user_model.objects.create_user("viewer", password="x", is_superuser=True)
+        client.force_login(user)
+        cert = self._make_cert()
+        url = f"/plugins/ssl/certificates/{cert.pk}/assign-targets/"
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert b"Assign certificate to objects" in resp.content
+
+    def test_post_creates_assignment_and_redirects(self, client, django_user_model):
+        import uuid
+
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+        from netbox_ssl.models import CertificateAssignment
+
+        user = django_user_model.objects.create_user("admin2", password="x", is_superuser=True)
+        client.force_login(user)
+        cert = self._make_cert()
+        uid = uuid.uuid4().hex[:8]
+        site = Site.objects.create(name=f"s1-{uid}", slug=f"s1-{uid}")
+        mfr = Manufacturer.objects.create(name=f"m1-{uid}", slug=f"m1-{uid}")
+        dtype = DeviceType.objects.create(manufacturer=mfr, model=f"dt1-{uid}", slug=f"dt1-{uid}")
+        role = DeviceRole.objects.create(name=f"r1-{uid}", slug=f"r1-{uid}")
+        device = Device.objects.create(name=f"web01-{uid}", site=site, device_type=dtype, role=role)
+
+        url = f"/plugins/ssl/certificates/{cert.pk}/assign-targets/"
+        resp = client.post(url, {"devices": [device.pk]})
+        assert resp.status_code == 302
+        assert CertificateAssignment.objects.filter(certificate=cert).count() == 1

--- a/tests/test_assignments_service.py
+++ b/tests/test_assignments_service.py
@@ -1,0 +1,110 @@
+"""Unit tests for the bulk certificate-assignment service."""
+
+import uuid
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+
+@pytest.mark.django_db
+class TestAssignCertificateToTargets:
+    def _make_cert(self, suffix: str = ""):
+        from netbox_ssl.models import Certificate
+
+        # Unique serial and fingerprint per invocation to avoid UniqueConstraint violations.
+        # Fingerprint format: 32 uppercase hex pairs colon-separated = exactly 95 chars.
+        uid_int = int(uuid.uuid4().hex[:8], 16)  # first 32 bits as int
+        pairs = [f"{(uid_int >> (i * 8)) & 0xFF:02X}" for i in range(4)]
+        # Pad to 32 pairs using fixed values for the remaining 28 bytes
+        tail = [f"{i:02X}" for i in range(28)]
+        fp = ":".join(pairs + tail)
+        serial = f"01:AA:{uuid.uuid4().hex[:8].upper()}"
+        return Certificate.objects.create(
+            common_name="*.example.com",
+            serial_number=serial,
+            issuer="Test CA",
+            fingerprint_sha256=fp,
+            algorithm="rsa",
+            valid_from="2026-01-01T00:00:00Z",
+            valid_to="2027-01-01T00:00:00Z",
+        )
+
+    def _device(self, name: str):
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+
+        # Unique slugs per invocation
+        uid = uuid.uuid4().hex[:8]
+        site = Site.objects.create(name=f"site-{name}-{uid}", slug=f"site-{name}-{uid}")
+        mfr = Manufacturer.objects.create(name=f"mfr-{name}-{uid}", slug=f"mfr-{name}-{uid}")
+        dtype = DeviceType.objects.create(
+            manufacturer=mfr,
+            model=f"model-{name}-{uid}",
+            slug=f"model-{name}-{uid}",
+        )
+        role = DeviceRole.objects.create(name=f"role-{name}-{uid}", slug=f"role-{name}-{uid}")
+        return Device.objects.create(name=name, site=site, device_type=dtype, role=role)
+
+    def test_creates_assignments_for_each_target(self):
+        from netbox_ssl.models import CertificateAssignment
+        from netbox_ssl.utils.assignments import assign_certificate_to_targets
+
+        cert = self._make_cert()
+        d1, d2 = self._device("web01"), self._device("web02")
+        ct = ContentType.objects.get_for_model(d1)
+
+        result = assign_certificate_to_targets(cert, [(ct, d1.pk), (ct, d2.pk)])
+
+        assert result.created == 2
+        assert result.skipped == 0
+        assert CertificateAssignment.objects.filter(certificate=cert).count() == 2
+
+    def test_skips_already_assigned_targets(self):
+        from netbox_ssl.utils.assignments import assign_certificate_to_targets
+
+        cert = self._make_cert()
+        d1 = self._device("web01")
+        ct = ContentType.objects.get_for_model(d1)
+
+        assign_certificate_to_targets(cert, [(ct, d1.pk)])
+        result = assign_certificate_to_targets(cert, [(ct, d1.pk)])
+
+        assert result.created == 0
+        assert result.skipped == 1
+        assert result.skipped_targets == (f"device:{d1.pk}",)
+
+    def test_is_primary_propagates(self):
+        from netbox_ssl.models import CertificateAssignment
+        from netbox_ssl.utils.assignments import assign_certificate_to_targets
+
+        cert = self._make_cert()
+        d1 = self._device("web01")
+        ct = ContentType.objects.get_for_model(d1)
+
+        assign_certificate_to_targets(cert, [(ct, d1.pk)], is_primary=True)
+
+        assert CertificateAssignment.objects.get(certificate=cert).is_primary is True
+
+    def test_empty_targets_raises(self):
+        from netbox_ssl.utils.assignments import AssignmentError, assign_certificate_to_targets
+
+        cert = self._make_cert()
+        with pytest.raises(AssignmentError):
+            assign_certificate_to_targets(cert, [])
+
+    def test_missing_object_raises(self):
+        from netbox_ssl.utils.assignments import AssignmentError, assign_certificate_to_targets
+
+        cert = self._make_cert()
+        d1 = self._device("web01")
+        ct = ContentType.objects.get_for_model(d1)
+        with pytest.raises(AssignmentError):
+            assign_certificate_to_targets(cert, [(ct, d1.pk + 9999)])
+
+    def test_disallowed_content_type_raises(self):
+        from netbox_ssl.models import Certificate
+        from netbox_ssl.utils.assignments import AssignmentError, assign_certificate_to_targets
+
+        cert = self._make_cert()
+        bad_ct = ContentType.objects.get_for_model(Certificate)
+        with pytest.raises(AssignmentError):
+            assign_certificate_to_targets(cert, [(bad_ct, cert.pk)])

--- a/tests/test_assignments_service.py
+++ b/tests/test_assignments_service.py
@@ -84,6 +84,18 @@ class TestAssignCertificateToTargets:
 
         assert CertificateAssignment.objects.get(certificate=cert).is_primary is True
 
+    def test_is_primary_defaults_to_false(self):
+        from netbox_ssl.models import CertificateAssignment
+        from netbox_ssl.utils.assignments import assign_certificate_to_targets
+
+        cert = self._make_cert()
+        d1 = self._device("web01")
+        ct = ContentType.objects.get_for_model(d1)
+
+        assign_certificate_to_targets(cert, [(ct, d1.pk)])
+
+        assert CertificateAssignment.objects.get(certificate=cert).is_primary is False
+
     def test_empty_targets_raises(self):
         from netbox_ssl.utils.assignments import AssignmentError, assign_certificate_to_targets
 


### PR DESCRIPTION
## Summary

Lets an operator assign a single (often **wildcard**) certificate to many Devices, Virtual Machines, and Services in one action — so "where is this cert deployed?" is answerable for shared certs. Requested by @mkarel.

The `CertificateAssignment` M2M model already supported one cert → many objects; the gap was purely the surface to do it in one step. **No database migration.**

## What's included

- **Shared service** `netbox_ssl/utils/assignments.py` — `assign_certificate_to_targets(certificate, targets, *, is_primary=False) -> AssignResult`. Idempotent (already-assigned targets are silently skipped and counted), atomic, content-type allowlisted, with generic DB-error messages. Single source of truth for both surfaces below.
- **REST API** — `POST /api/plugins/ssl/certificates/{id}/assign-targets` (new `detail=True` action), mirroring the inverse `bulk-assign`: `_check_bulk_perm`, `.restrict(user, "view")`, batch cap via `bulk_assign_max_batch_size`. Body `{"targets": [{"object_type", "object_id"}], "is_primary": false}` → `{"assigned", "skipped", "detail"}`.
- **UI** — an "Assign to objects" button on the certificate detail page (status-independent, permission-gated) → a cert-centric form with three multi-selects (Devices / VMs / Services) + an `is_primary` checkbox (default off). Submits via the shared service; success message reports `Assigned X, skipped Y already assigned`.

## Design docs

- Spec: `project-requirement-document/specs/2026-06-19-148-multi-object-assignment-design.md`
- Plan: `project-requirement-document/plans/2026-06-19-148-multi-object-assignment.md`

## Security (v0.7.5 rules)

`LoginRequiredMixin` first on the view; `.restrict()` on every cert lookup; writes gated on `netbox_ssl.add_certificateassignment`; content-type allowlist (`dcim.device`, `dcim.service`, `virtualization.virtualmachine`); DB errors logged internally, generic message returned.

## Test plan

- ✅ 17 new tests, all `@pytest.mark.django_db`, run together in-container against the real ORM/serializers/HTTP — no cross-file contamination:
  - Service (6): create N, skip duplicates, mixed types, `is_primary` True/False, empty → error, missing object → error, disallowed type → error.
  - API (6): assign+skip idempotency, 403 without perm, 400 invalid object_type, 404 unknown cert, response shape, batch-cap 400.
  - Form/view (5): empty selection invalid, GET renders (incl. non-active status), POST creates + redirects.
- ✅ Live UI smoke on NetBox 4.5 (Docker): detail-page button + assign form render and route correctly.
- ✅ Django system checks pass; ruff clean; no migration.
- ℹ️ Known follow-up: no automated test for the `.restrict()` 404 path (NetBox `ObjectPermission` vs `auth.Permission`); the `.restrict()` call is present and mirrors `bulk_assign`. CI integration matrix runs the full suite.

Closes #148