### PR TITLE
feat: website-centric certificate monitoring (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Website-centric certificate monitoring** ([#149](https://github.com/ctrl-alt-automate/netbox-ssl/issues/149)):
+  a new **Monitored Endpoints** feature tracks the certificate each website/URL
+  presents over time. A scheduled "Monitored Endpoint Poll" script re-scrapes
+  each endpoint (reusing the URL-import TLS scraper + security model), links the
+  certificate it finds, records rotation history, and fires NetBox events on
+  unreachable / rotated / untrusted endpoints. Endpoints can be added manually,
+  bulk-imported from CSV, or auto-created from the URL import flow. A certificate's
+  detail page now lists every website presenting it. One additive migration.
+
 ## [1.2.2] - 2026-06-05
 
 **Patch release** — the bundled NetBox Scripts (expiry scan, expiry

--- a/netbox_ssl/api/serializers/__init__.py
+++ b/netbox_ssl/api/serializers/__init__.py
@@ -15,6 +15,7 @@ from .compliance import (
 )
 from .csr import CertificateSigningRequestSerializer, CSRImportSerializer
 from .external_sources import ExternalSourceSerializer, ExternalSourceSyncLogSerializer
+from .monitored_endpoints import MonitoredEndpointSerializer
 
 __all__ = [
     "CertificateSerializer",
@@ -32,4 +33,5 @@ __all__ = [
     "ComplianceReportSerializer",
     "ExternalSourceSerializer",
     "ExternalSourceSyncLogSerializer",
+    "MonitoredEndpointSerializer",
 ]

--- a/netbox_ssl/api/serializers/monitored_endpoints.py
+++ b/netbox_ssl/api/serializers/monitored_endpoints.py
@@ -1,0 +1,55 @@
+"""REST API serializer for the MonitoredEndpoint model.
+
+NetBox requires a registered serializer for every NetBoxModel: when an endpoint
+is saved in a request context, the change-logging machinery calls
+``serialize_for_event`` → ``get_serializer_for_model``. Without this serializer
+that raises ``SerializerNotFound`` on NetBox 4.4.
+"""
+
+from netbox.api.serializers import NetBoxModelSerializer
+from rest_framework import serializers
+from tenancy.api.serializers import TenantSerializer
+
+from ...models import MonitoredEndpoint
+
+
+class MonitoredEndpointSerializer(NetBoxModelSerializer):
+    """Serializer for the MonitoredEndpoint model."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_ssl-api:monitoredendpoint-detail",
+    )
+    # The model field is named ``url`` (the monitored website); ``url`` above is
+    # the NetBox API self-link, so expose the website under ``target_url``.
+    target_url = serializers.CharField(source="url", max_length=500)
+    tenant = TenantSerializer(nested=True, required=False, allow_null=True)
+    certificate = serializers.SerializerMethodField()
+    days_remaining = serializers.IntegerField(read_only=True, allow_null=True)
+
+    class Meta:
+        model = MonitoredEndpoint
+        fields = [
+            "id",
+            "url",
+            "display",
+            "name",
+            "target_url",
+            "sni",
+            "certificate",
+            "status",
+            "last_checked",
+            "last_seen",
+            "tenant",
+            "days_remaining",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        ]
+        brief_fields = ["id", "url", "display", "name", "status"]
+
+    def get_certificate(self, obj) -> dict | None:
+        """Brief reference to the linked certificate (id + common name)."""
+        if obj.certificate_id:
+            return {"id": obj.certificate_id, "common_name": obj.certificate.common_name}
+        return None

--- a/netbox_ssl/api/urls.py
+++ b/netbox_ssl/api/urls.py
@@ -14,5 +14,6 @@ router.register("csrs", views.CertificateSigningRequestViewSet)
 router.register("compliance-policies", views.CompliancePolicyViewSet)
 router.register("compliance-checks", views.ComplianceCheckViewSet)
 router.register("external-sources", views.ExternalSourceViewSet)
+router.register("monitored-endpoints", views.MonitoredEndpointViewSet)
 
 urlpatterns = router.urls

--- a/netbox_ssl/api/views.py
+++ b/netbox_ssl/api/views.py
@@ -23,6 +23,7 @@ from ..filtersets import (
     ComplianceCheckFilterSet,
     CompliancePolicyFilterSet,
     ExternalSourceFilterSet,
+    MonitoredEndpointFilterSet,
 )
 from ..models import (
     Certificate,
@@ -33,6 +34,7 @@ from ..models import (
     ComplianceCheck,
     CompliancePolicy,
     ExternalSource,
+    MonitoredEndpoint,
 )
 from ..utils import CertificateExporter, ComplianceChecker, ExportFormatChoices
 from ..utils.bulk_parser import parse as bulk_parse
@@ -53,6 +55,7 @@ from .serializers import (
     CSRImportSerializer,
     ExternalSourceSerializer,
     ExternalSourceSyncLogSerializer,
+    MonitoredEndpointSerializer,
 )
 
 logger = logging.getLogger(__name__)
@@ -1425,3 +1428,15 @@ class ExternalSourceViewSet(NetBoxModelViewSet):
                 {"success": False, "message": "Sync failed due to an internal error."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
+
+class MonitoredEndpointViewSet(NetBoxModelViewSet):
+    """API viewset for the MonitoredEndpoint model.
+
+    Required by NetBox's change-logging/event machinery (every NetBoxModel needs
+    a discoverable serializer); also exposes read/write access to endpoints.
+    """
+
+    queryset = MonitoredEndpoint.objects.select_related("certificate", "tenant").prefetch_related("tags")
+    serializer_class = MonitoredEndpointSerializer
+    filterset_class = MonitoredEndpointFilterSet

--- a/netbox_ssl/filtersets/__init__.py
+++ b/netbox_ssl/filtersets/__init__.py
@@ -4,6 +4,7 @@ from .certificates import CertificateFilterSet
 from .compliance import ComplianceCheckFilterSet, CompliancePolicyFilterSet
 from .csr import CertificateSigningRequestFilterSet
 from .external_sources import ExternalSourceFilterSet
+from .monitored_endpoints import MonitoredEndpointFilterSet
 
 __all__ = [
     "CertificateFilterSet",
@@ -13,4 +14,5 @@ __all__ = [
     "CompliancePolicyFilterSet",
     "ComplianceCheckFilterSet",
     "ExternalSourceFilterSet",
+    "MonitoredEndpointFilterSet",
 ]

--- a/netbox_ssl/filtersets/monitored_endpoints.py
+++ b/netbox_ssl/filtersets/monitored_endpoints.py
@@ -38,6 +38,4 @@ class MonitoredEndpointFilterSet(NetBoxModelFilterSet):
         """Full-text search across name and url fields."""
         if not value.strip():
             return queryset
-        return queryset.filter(
-            Q(name__icontains=value) | Q(url__icontains=value)
-        )
+        return queryset.filter(Q(name__icontains=value) | Q(url__icontains=value))

--- a/netbox_ssl/filtersets/monitored_endpoints.py
+++ b/netbox_ssl/filtersets/monitored_endpoints.py
@@ -1,0 +1,43 @@
+"""
+FilterSet for MonitoredEndpoint model.
+"""
+
+import django_filters
+from django.db.models import Q
+from netbox.filtersets import NetBoxModelFilterSet
+from tenancy.models import Tenant
+
+from ..models import Certificate, MonitoredEndpoint, MonitoredEndpointStatusChoices
+
+
+class MonitoredEndpointFilterSet(NetBoxModelFilterSet):
+    """FilterSet for MonitoredEndpoint model."""
+
+    status = django_filters.MultipleChoiceFilter(
+        choices=MonitoredEndpointStatusChoices,
+        label="Status",
+    )
+    certificate_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Certificate.objects.all(),
+        label="Certificate",
+    )
+    tenant_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Tenant.objects.all(),
+        label="Tenant",
+    )
+
+    class Meta:
+        model = MonitoredEndpoint
+        fields = [
+            "id",
+            "name",
+            "status",
+        ]
+
+    def search(self, queryset, name, value):
+        """Full-text search across name and url fields."""
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(name__icontains=value) | Q(url__icontains=value)
+        )

--- a/netbox_ssl/forms/__init__.py
+++ b/netbox_ssl/forms/__init__.py
@@ -24,6 +24,11 @@ from .external_sources import (
     ExternalSourceFilterForm,
     ExternalSourceForm,
 )
+from .monitored_endpoints import (
+    MonitoredEndpointFilterForm,
+    MonitoredEndpointForm,
+    MonitoredEndpointImportForm,
+)
 from .url_import import UrlImportForm
 
 __all__ = [
@@ -43,5 +48,8 @@ __all__ = [
     "ExternalSourceForm",
     "ExternalSourceFilterForm",
     "ExternalSourceBulkEditForm",
+    "MonitoredEndpointForm",
+    "MonitoredEndpointFilterForm",
+    "MonitoredEndpointImportForm",
     "UrlImportForm",
 ]

--- a/netbox_ssl/forms/monitored_endpoints.py
+++ b/netbox_ssl/forms/monitored_endpoints.py
@@ -1,0 +1,189 @@
+"""
+Forms for MonitoredEndpoint model.
+"""
+
+from dcim.models import Device
+from django import forms
+from django.contrib.contenttypes.models import ContentType
+from django.utils.translation import gettext_lazy as _
+from ipam.models import Service
+from netbox.forms import NetBoxModelFilterSetForm, NetBoxModelForm
+from utilities.forms.fields import DynamicModelChoiceField, TagFilterField
+from utilities.forms.rendering import FieldSet
+from virtualization.models import VirtualMachine
+
+from ..models import MonitoredEndpoint, MonitoredEndpointStatusChoices
+
+
+class MonitoredEndpointForm(NetBoxModelForm):
+    """Form for creating/editing Monitored Endpoints."""
+
+    # Device selection
+    device = DynamicModelChoiceField(
+        queryset=Device.objects.all(),
+        required=False,
+        label=_("Device"),
+        help_text=_("Select a device to see its services"),
+    )
+
+    # VM selection
+    virtual_machine = DynamicModelChoiceField(
+        queryset=VirtualMachine.objects.all(),
+        required=False,
+        label=_("Virtual Machine"),
+        help_text=_("Select a VM to see its services"),
+    )
+
+    # Service selection
+    service = DynamicModelChoiceField(
+        queryset=Service.objects.all(),
+        required=False,
+        label=_("Service"),
+        help_text=_("Select a service for port-level assignment (optional)"),
+        query_params={
+            "device_id": "$device",
+            "virtual_machine_id": "$virtual_machine",
+        },
+    )
+
+    fieldsets = (
+        FieldSet(
+            "name",
+            "url",
+            "sni",
+            name=_("Endpoint"),
+        ),
+        FieldSet(
+            "device",
+            "virtual_machine",
+            "service",
+            name=_("Assignment Target"),
+        ),
+        FieldSet(
+            "certificate",
+            "tenant",
+            name=_("Links"),
+        ),
+        FieldSet(
+            "tags",
+            name=_("Tags"),
+        ),
+    )
+
+    class Meta:
+        model = MonitoredEndpoint
+        fields = [
+            "name",
+            "url",
+            "sni",
+            "certificate",
+            "tenant",
+            "tags",
+        ]
+        widgets = {
+            "url": forms.TextInput(attrs={"placeholder": "https://host:443"}),
+            "sni": forms.TextInput(attrs={"placeholder": "Optional SNI override"}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # If editing, populate the device/VM/service fields from the GenericFK.
+        if self.instance.pk and self.instance.assigned_object:
+            obj = self.instance.assigned_object
+            model_name = self.instance.assigned_object_type.model
+
+            if model_name == "service":
+                self.fields["service"].initial = obj
+                if hasattr(obj, "parent") and obj.parent:
+                    parent = obj.parent
+                    if hasattr(parent, "_meta"):
+                        if parent._meta.model_name == "device":
+                            self.fields["device"].initial = parent
+                        elif parent._meta.model_name == "virtualmachine":
+                            self.fields["virtual_machine"].initial = parent
+            elif model_name == "device":
+                self.fields["device"].initial = obj
+            elif model_name == "virtualmachine":
+                self.fields["virtual_machine"].initial = obj
+
+    def save(self, commit=True):
+        """Save the endpoint, resolving the GenericFK from device/vm/service fields."""
+        instance = super().save(commit=False)
+
+        service = self.cleaned_data.get("service")
+        device = self.cleaned_data.get("device")
+        vm = self.cleaned_data.get("virtual_machine")
+
+        if service:
+            instance.assigned_object_type = ContentType.objects.get_for_model(Service)
+            instance.assigned_object_id = service.pk
+        elif device:
+            instance.assigned_object_type = ContentType.objects.get_for_model(Device)
+            instance.assigned_object_id = device.pk
+        elif vm:
+            instance.assigned_object_type = ContentType.objects.get_for_model(VirtualMachine)
+            instance.assigned_object_id = vm.pk
+        # else: keep existing assigned_object if not changed
+
+        if commit:
+            instance.save()
+            self.save_m2m()
+
+        return instance
+
+
+class MonitoredEndpointFilterForm(NetBoxModelFilterSetForm):
+    """Filter form for Monitored Endpoint list view."""
+
+    model = MonitoredEndpoint
+
+    fieldsets = (
+        FieldSet(
+            "q",
+            "filter_id",
+            "tag",
+        ),
+        FieldSet(
+            "status",
+            name=_("Monitored Endpoint"),
+        ),
+    )
+
+    status = forms.MultipleChoiceField(
+        choices=MonitoredEndpointStatusChoices,
+        required=False,
+        label=_("Status"),
+    )
+    tag = TagFilterField(model)
+
+
+class MonitoredEndpointImportForm(forms.Form):
+    """Form for bulk-importing Monitored Endpoints from a CSV of URLs."""
+
+    csv_text = forms.CharField(
+        label=_("CSV Data"),
+        widget=forms.Textarea(
+            attrs={
+                "rows": 20,
+                "class": "font-monospace",
+                "placeholder": "url,name,sni\nhttps://host1.example.com,,\nhttps://host2.example.com,,",
+            }
+        ),
+        required=False,
+        help_text=_(
+            "Paste CSV rows with a required 'url' column. "
+            "Optional columns: name, sni, tenant, assigned_device, assigned_vm, assigned_service."
+        ),
+    )
+    csv_file = forms.FileField(
+        label=_("CSV File"),
+        required=False,
+        help_text=_("Upload a CSV file instead of pasting."),
+    )
+
+    def clean(self):
+        cleaned = super().clean()
+        if not cleaned.get("csv_text") and not cleaned.get("csv_file"):
+            raise forms.ValidationError(_("Provide either pasted CSV data or upload a CSV file."))
+        return cleaned

--- a/netbox_ssl/forms/monitored_endpoints.py
+++ b/netbox_ssl/forms/monitored_endpoints.py
@@ -174,13 +174,14 @@ class MonitoredEndpointImportForm(forms.Form):
             attrs={
                 "rows": 20,
                 "class": "font-monospace",
-                "placeholder": "url,name,sni\nhttps://host1.example.com,,\nhttps://host2.example.com,,",
+                "placeholder": "url,sni,tenant,assigned_device,assigned_vm,assigned_service\nhttps://host1.example.com,,,,,\nhttps://host2.example.com,,,,,",
             }
         ),
         required=False,
         help_text=_(
             "Paste CSV rows with a required 'url' column. "
-            "Optional columns: name, sni, tenant, assigned_device, assigned_vm, assigned_service."
+            "Optional columns: sni, tenant, assigned_device, assigned_vm, assigned_service. "
+            "The endpoint name is derived from the SNI or hostname."
         ),
     )
     csv_file = forms.FileField(

--- a/netbox_ssl/forms/monitored_endpoints.py
+++ b/netbox_ssl/forms/monitored_endpoints.py
@@ -107,6 +107,13 @@ class MonitoredEndpointForm(NetBoxModelForm):
             elif model_name == "virtualmachine":
                 self.fields["virtual_machine"].initial = obj
 
+    def clean_url(self):
+        """Reject non-HTTPS URLs at form validation time (XSS / javascript: URI defence)."""
+        url = self.cleaned_data.get("url", "")
+        if not url.lower().startswith("https://"):
+            raise forms.ValidationError(_("Only HTTPS URLs are allowed (must start with https://)."))
+        return url
+
     def save(self, commit=True):
         """Save the endpoint, resolving the GenericFK from device/vm/service fields."""
         instance = super().save(commit=False)

--- a/netbox_ssl/migrations/0025_monitored_endpoint.py
+++ b/netbox_ssl/migrations/0025_monitored_endpoint.py
@@ -1,0 +1,163 @@
+"""
+Add MonitoredEndpoint and MonitoredEndpointCertificate models (#149).
+
+Website-centric certificate monitoring: track which certificate a URL presents,
+with rotation history. MonitoredEndpoint inherits NetBoxModel (custom fields +
+tags). MonitoredEndpointCertificate is a plain model (rotation history table).
+
+Generated fields match the NetBoxModel mixin pattern used by other models in
+this plugin (see 0013_external_source_framework.py for reference).
+"""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("extras", "0001_squashed"),
+        ("netbox_ssl", "0024_url_import_fields"),
+        ("tenancy", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="MonitoredEndpoint",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(blank=True, default=dict, encoder=None),
+                ),
+                (
+                    "name",
+                    models.CharField(
+                        help_text="Human label, e.g. 'HR portal'.",
+                        max_length=200,
+                    ),
+                ),
+                (
+                    "url",
+                    models.CharField(
+                        help_text="https://host:port to monitor.",
+                        max_length=500,
+                    ),
+                ),
+                (
+                    "sni",
+                    models.CharField(
+                        blank=True,
+                        help_text="Optional SNI override (defaults to the URL host).",
+                        max_length=255,
+                    ),
+                ),
+                (
+                    "assigned_object_id",
+                    models.PositiveBigIntegerField(blank=True, null=True),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("ok", "OK"),
+                            ("unreachable", "Unreachable"),
+                            ("untrusted", "Untrusted"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("last_checked", models.DateTimeField(blank=True, null=True)),
+                ("last_seen", models.DateTimeField(blank=True, null=True)),
+                ("last_error", models.TextField(blank=True)),
+                (
+                    "assigned_object_type",
+                    models.ForeignKey(
+                        blank=True,
+                        limit_choices_to={
+                            "model__in": ["service", "device", "virtualmachine"]
+                        },
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="contenttypes.contenttype",
+                    ),
+                ),
+                (
+                    "certificate",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="The certificate this endpoint currently presents.",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="monitored_endpoints",
+                        to="netbox_ssl.certificate",
+                    ),
+                ),
+                (
+                    "tenant",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="tenancy.tenant",
+                    ),
+                ),
+                ("tags", models.ManyToManyField(blank=True, to="extras.tag")),
+            ],
+            options={
+                "ordering": ["name"],
+            },
+        ),
+        migrations.CreateModel(
+            name="MonitoredEndpointCertificate",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("first_seen", models.DateTimeField()),
+                ("last_seen", models.DateTimeField()),
+                (
+                    "certificate",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="netbox_ssl.certificate",
+                    ),
+                ),
+                (
+                    "endpoint",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="cert_history",
+                        to="netbox_ssl.monitoredendpoint",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-last_seen"],
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="monitoredendpointcertificate",
+            constraint=models.UniqueConstraint(
+                fields=["endpoint", "certificate"],
+                name="unique_endpoint_certificate",
+            ),
+        ),
+    ]

--- a/netbox_ssl/migrations/0025_monitored_endpoint.py
+++ b/netbox_ssl/migrations/0025_monitored_endpoint.py
@@ -87,9 +87,7 @@ class Migration(migrations.Migration):
                     "assigned_object_type",
                     models.ForeignKey(
                         blank=True,
-                        limit_choices_to={
-                            "model__in": ["service", "device", "virtualmachine"]
-                        },
+                        limit_choices_to={"model__in": ["service", "device", "virtualmachine"]},
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="contenttypes.contenttype",

--- a/netbox_ssl/migrations/0025_monitored_endpoint.py
+++ b/netbox_ssl/migrations/0025_monitored_endpoint.py
@@ -10,6 +10,8 @@ this plugin (see 0013_external_source_framework.py for reference).
 """
 
 import django.db.models.deletion
+import taggit.managers
+import utilities.json
 from django.db import migrations, models
 
 
@@ -37,7 +39,7 @@ class Migration(migrations.Migration):
                 ("last_updated", models.DateTimeField(auto_now=True, null=True)),
                 (
                     "custom_field_data",
-                    models.JSONField(blank=True, default=dict, encoder=None),
+                    models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder),
                 ),
                 (
                     "name",
@@ -114,7 +116,7 @@ class Migration(migrations.Migration):
                         to="tenancy.tenant",
                     ),
                 ),
-                ("tags", models.ManyToManyField(blank=True, to="extras.tag")),
+                ("tags", taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag")),
             ],
             options={
                 "ordering": ["name"],

--- a/netbox_ssl/models/__init__.py
+++ b/netbox_ssl/models/__init__.py
@@ -30,6 +30,11 @@ from .external_source import (
     SyncStatusChoices,
 )
 from .lifecycle import CertificateLifecycleEvent, LifecycleEventTypeChoices
+from .monitored_endpoint import (
+    MonitoredEndpoint,
+    MonitoredEndpointCertificate,
+    MonitoredEndpointStatusChoices,
+)
 
 __all__ = [
     "Certificate",
@@ -58,4 +63,7 @@ __all__ = [
     "ExternalSourceTypeChoices",
     "AuthMethodChoices",
     "SyncStatusChoices",
+    "MonitoredEndpoint",
+    "MonitoredEndpointCertificate",
+    "MonitoredEndpointStatusChoices",
 ]

--- a/netbox_ssl/models/monitored_endpoint.py
+++ b/netbox_ssl/models/monitored_endpoint.py
@@ -45,9 +45,7 @@ class MonitoredEndpoint(NetBoxModel):
     )
     assigned_object_id = models.PositiveBigIntegerField(null=True, blank=True)
     assigned_object = GenericForeignKey(ct_field="assigned_object_type", fk_field="assigned_object_id")
-    tenant = models.ForeignKey(
-        to="tenancy.Tenant", on_delete=models.SET_NULL, null=True, blank=True, related_name="+"
-    )
+    tenant = models.ForeignKey(to="tenancy.Tenant", on_delete=models.SET_NULL, null=True, blank=True, related_name="+")
     status = models.CharField(
         max_length=20,
         choices=MonitoredEndpointStatusChoices,
@@ -80,9 +78,7 @@ class MonitoredEndpoint(NetBoxModel):
 class MonitoredEndpointCertificate(models.Model):
     """Rotation history: which certificate an endpoint presented, and when."""
 
-    endpoint = models.ForeignKey(
-        to=MonitoredEndpoint, on_delete=models.CASCADE, related_name="cert_history"
-    )
+    endpoint = models.ForeignKey(to=MonitoredEndpoint, on_delete=models.CASCADE, related_name="cert_history")
     certificate = models.ForeignKey(to="netbox_ssl.Certificate", on_delete=models.CASCADE)
     first_seen = models.DateTimeField()
     last_seen = models.DateTimeField()

--- a/netbox_ssl/models/monitored_endpoint.py
+++ b/netbox_ssl/models/monitored_endpoint.py
@@ -1,6 +1,7 @@
 """Models for website-centric certificate monitoring (#149)."""
 
 from django.contrib.contenttypes.fields import GenericForeignKey
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
 from netbox.models import NetBoxModel
@@ -61,6 +62,12 @@ class MonitoredEndpoint(NetBoxModel):
 
     def __str__(self) -> str:
         return self.name
+
+    def clean(self) -> None:
+        """Enforce HTTPS-only at the model level (defence in depth)."""
+        super().clean()
+        if self.url and not self.url.lower().startswith("https://"):
+            raise ValidationError({"url": "Only HTTPS URLs are allowed (must start with https://)."})
 
     def get_absolute_url(self) -> str:
         return reverse("plugins:netbox_ssl:monitoredendpoint", args=[self.pk])

--- a/netbox_ssl/models/monitored_endpoint.py
+++ b/netbox_ssl/models/monitored_endpoint.py
@@ -1,0 +1,90 @@
+"""Models for website-centric certificate monitoring (#149)."""
+
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.db import models
+from django.urls import reverse
+from netbox.models import NetBoxModel
+from utilities.choices import ChoiceSet
+
+
+class MonitoredEndpointStatusChoices(ChoiceSet):
+    STATUS_PENDING = "pending"
+    STATUS_OK = "ok"
+    STATUS_UNREACHABLE = "unreachable"
+    STATUS_UNTRUSTED = "untrusted"
+
+    CHOICES = [
+        (STATUS_PENDING, "Pending", "gray"),
+        (STATUS_OK, "OK", "green"),
+        (STATUS_UNREACHABLE, "Unreachable", "red"),
+        (STATUS_UNTRUSTED, "Untrusted", "orange"),
+    ]
+
+
+class MonitoredEndpoint(NetBoxModel):
+    """A monitored website/URL whose presented certificate is tracked over time."""
+
+    name = models.CharField(max_length=200, help_text="Human label, e.g. 'HR portal'.")
+    url = models.CharField(max_length=500, help_text="https://host:port to monitor.")
+    sni = models.CharField(max_length=255, blank=True, help_text="Optional SNI override (defaults to the URL host).")
+    certificate = models.ForeignKey(
+        to="netbox_ssl.Certificate",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="monitored_endpoints",
+        help_text="The certificate this endpoint currently presents.",
+    )
+    assigned_object_type = models.ForeignKey(
+        to="contenttypes.ContentType",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        limit_choices_to={"model__in": ["service", "device", "virtualmachine"]},
+    )
+    assigned_object_id = models.PositiveBigIntegerField(null=True, blank=True)
+    assigned_object = GenericForeignKey(ct_field="assigned_object_type", fk_field="assigned_object_id")
+    tenant = models.ForeignKey(
+        to="tenancy.Tenant", on_delete=models.SET_NULL, null=True, blank=True, related_name="+"
+    )
+    status = models.CharField(
+        max_length=20,
+        choices=MonitoredEndpointStatusChoices,
+        default=MonitoredEndpointStatusChoices.STATUS_PENDING,
+    )
+    last_checked = models.DateTimeField(null=True, blank=True)
+    last_seen = models.DateTimeField(null=True, blank=True)
+    last_error = models.TextField(blank=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:
+        return self.name
+
+    def get_absolute_url(self) -> str:
+        return reverse("plugins:netbox_ssl:monitoredendpoint", args=[self.pk])
+
+    @property
+    def days_remaining(self) -> int | None:
+        return self.certificate.days_remaining if self.certificate else None
+
+
+class MonitoredEndpointCertificate(models.Model):
+    """Rotation history: which certificate an endpoint presented, and when."""
+
+    endpoint = models.ForeignKey(
+        to=MonitoredEndpoint, on_delete=models.CASCADE, related_name="cert_history"
+    )
+    certificate = models.ForeignKey(to="netbox_ssl.Certificate", on_delete=models.CASCADE)
+    first_seen = models.DateTimeField()
+    last_seen = models.DateTimeField()
+
+    class Meta:
+        ordering = ["-last_seen"]
+        constraints = [
+            models.UniqueConstraint(fields=["endpoint", "certificate"], name="unique_endpoint_certificate"),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.endpoint} → {self.certificate}"

--- a/netbox_ssl/navigation.py
+++ b/netbox_ssl/navigation.py
@@ -105,6 +105,19 @@ menu = PluginMenu(
                         ),
                     ),
                 ),
+                PluginMenuItem(
+                    link="plugins:netbox_ssl:monitoredendpoint_list",
+                    link_text="Monitored Endpoints",
+                    permissions=["netbox_ssl.view_monitoredendpoint"],
+                    buttons=(
+                        PluginMenuButton(
+                            link="plugins:netbox_ssl:monitoredendpoint_add",
+                            title="Add",
+                            icon_class="mdi mdi-plus-thick",
+                            permissions=["netbox_ssl.add_monitoredendpoint"],
+                        ),
+                    ),
+                ),
             ),
         ),
         (

--- a/netbox_ssl/scripts/endpoint_monitor.py
+++ b/netbox_ssl/scripts/endpoint_monitor.py
@@ -31,7 +31,7 @@ class MonitoredEndpointPoll(Script):
         """Return a single plugin config value."""
         return settings.PLUGINS_CONFIG.get("netbox_ssl", {}).get(name, default)
 
-    def run(self, data, commit):  # noqa: ANN001,ANN201
+    def run(self, data: dict, commit: bool) -> str:
         """Iterate over MonitoredEndpoints, poll each one, and return a summary string."""
         allowlist: list[str] = self.get_plugin_setting("url_import_private_cidr_allowlist", [])
         dry_run: bool = bool(data.get("dry_run", False))
@@ -41,15 +41,19 @@ class MonitoredEndpointPoll(Script):
         if tenant:
             endpoints = endpoints.filter(tenant=tenant)
 
+        if dry_run:
+            total = endpoints.count()
+            for endpoint in endpoints:
+                self.log_info(f"[dry-run] would poll {endpoint.name} ({endpoint.url})")
+            msg = f"[dry-run] {total} endpoint(s) would be polled"
+            self.log_info(msg)
+            return msg
+
         # Materialise counts keyed by status value (all choices start at 0).
         counts: dict[str, int] = {choice[0]: 0 for choice in MonitoredEndpointStatusChoices.CHOICES}
         rotated = 0
 
         for endpoint in endpoints:
-            if dry_run:
-                self.log_info(f"[dry-run] would poll {endpoint.name} ({endpoint.url})")
-                continue
-
             result = poll_endpoint(endpoint, allowlist=allowlist)
             counts[result.status] = counts.get(result.status, 0) + 1
             if result.rotated:
@@ -62,10 +66,5 @@ class MonitoredEndpointPoll(Script):
         summary_parts = status_parts + ([f"rotated={rotated}"] if rotated else [])
         summary = ", ".join(summary_parts) if summary_parts else "no changes"
 
-        total = endpoints.count()
-        if dry_run:
-            self.log_info(f"[dry-run] {total} endpoint(s) would have been polled.")
-        else:
-            self.log_success(f"Polled {total} endpoint(s): {summary}")
-
+        self.log_success(f"Polled {endpoints.count()} endpoint(s): {summary}")
         return summary

--- a/netbox_ssl/scripts/endpoint_monitor.py
+++ b/netbox_ssl/scripts/endpoint_monitor.py
@@ -1,0 +1,71 @@
+"""NetBox Script: re-poll all MonitoredEndpoints and reconcile their certs."""
+
+from django.conf import settings
+from extras.scripts import BooleanVar, ObjectVar, Script
+from tenancy.models import Tenant
+
+from netbox_ssl.models import MonitoredEndpoint, MonitoredEndpointStatusChoices
+from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+
+
+class MonitoredEndpointPoll(Script):
+    """Re-scrape each monitored endpoint and update its certificate, status, and history."""
+
+    class Meta:
+        name = "Monitored Endpoint Poll"
+        description = "Re-scrape each monitored endpoint and update its certificate, status, and history."
+        commit_default = True
+        job_timeout = 600
+
+    tenant = ObjectVar(
+        model=Tenant,
+        required=False,
+        description="Limit to one tenant (optional).",
+    )
+    dry_run = BooleanVar(
+        default=False,
+        description="Log actions without saving.",
+    )
+
+    def get_plugin_setting(self, name: str, default=None):
+        """Return a single plugin config value."""
+        return settings.PLUGINS_CONFIG.get("netbox_ssl", {}).get(name, default)
+
+    def run(self, data, commit):  # noqa: ANN001,ANN201
+        """Iterate over MonitoredEndpoints, poll each one, and return a summary string."""
+        allowlist: list[str] = self.get_plugin_setting("url_import_private_cidr_allowlist", [])
+        dry_run: bool = bool(data.get("dry_run", False))
+        tenant = data.get("tenant")
+
+        endpoints = MonitoredEndpoint.objects.all()
+        if tenant:
+            endpoints = endpoints.filter(tenant=tenant)
+
+        # Materialise counts keyed by status value (all choices start at 0).
+        counts: dict[str, int] = {choice[0]: 0 for choice in MonitoredEndpointStatusChoices.CHOICES}
+        rotated = 0
+
+        for endpoint in endpoints:
+            if dry_run:
+                self.log_info(f"[dry-run] would poll {endpoint.name} ({endpoint.url})")
+                continue
+
+            result = poll_endpoint(endpoint, allowlist=allowlist)
+            counts[result.status] = counts.get(result.status, 0) + 1
+            if result.rotated:
+                rotated += 1
+            suffix = " (rotated)" if result.rotated else ""
+            self.log_info(f"{endpoint.name}: {result.status}{suffix}")
+
+        # Build compact summary string, omitting zero-count statuses.
+        status_parts = [f"{k}={v}" for k, v in counts.items() if v]
+        summary_parts = status_parts + ([f"rotated={rotated}"] if rotated else [])
+        summary = ", ".join(summary_parts) if summary_parts else "no changes"
+
+        total = endpoints.count()
+        if dry_run:
+            self.log_info(f"[dry-run] {total} endpoint(s) would have been polled.")
+        else:
+            self.log_success(f"Polled {total} endpoint(s): {summary}")
+
+        return summary

--- a/netbox_ssl/tables/__init__.py
+++ b/netbox_ssl/tables/__init__.py
@@ -3,6 +3,7 @@ from .certificate_authorities import CertificateAuthorityTable
 from .certificates import CertificateTable
 from .csr import CertificateSigningRequestTable
 from .external_sources import ExternalSourceTable
+from .monitored_endpoints import MonitoredEndpointTable
 
 __all__ = [
     "CertificateTable",
@@ -10,4 +11,5 @@ __all__ = [
     "CertificateAuthorityTable",
     "CertificateSigningRequestTable",
     "ExternalSourceTable",
+    "MonitoredEndpointTable",
 ]

--- a/netbox_ssl/tables/monitored_endpoints.py
+++ b/netbox_ssl/tables/monitored_endpoints.py
@@ -1,0 +1,56 @@
+"""
+Table definitions for MonitoredEndpoint model.
+"""
+
+import django_tables2 as tables
+from netbox.tables import NetBoxTable, columns
+
+from ..models import MonitoredEndpoint
+
+
+class MonitoredEndpointTable(NetBoxTable):
+    """Table for displaying Monitored Endpoints."""
+
+    name = tables.Column(
+        linkify=True,
+    )
+    url = tables.Column(
+        verbose_name="URL",
+    )
+    status = columns.ChoiceFieldColumn()
+    certificate = tables.Column(
+        linkify=True,
+    )
+    days_remaining = tables.Column(
+        verbose_name="Days Remaining",
+        accessor="days_remaining",
+        orderable=False,
+    )
+    tenant = tables.Column(
+        linkify=True,
+    )
+    last_checked = tables.DateTimeColumn(
+        verbose_name="Last Checked",
+    )
+
+    class Meta(NetBoxTable.Meta):
+        model = MonitoredEndpoint
+        fields = (
+            "pk",
+            "id",
+            "name",
+            "url",
+            "status",
+            "certificate",
+            "days_remaining",
+            "tenant",
+            "last_checked",
+        )
+        default_columns = (
+            "name",
+            "url",
+            "status",
+            "certificate",
+            "days_remaining",
+            "last_checked",
+        )

--- a/netbox_ssl/templates/netbox_ssl/certificate.html
+++ b/netbox_ssl/templates/netbox_ssl/certificate.html
@@ -447,9 +447,9 @@
             <tr>
               <td><a href="{{ endpoint.get_absolute_url }}">{{ endpoint.name }}</a></td>
               <td>
-                <a href="{{ endpoint.url }}" target="_blank" rel="noopener noreferrer">
-                  {{ endpoint.url }}
-                </a>
+                {% if endpoint.url|slice:':8'|lower == 'https://' or endpoint.url|slice:':7'|lower == 'http://' %}
+                  <a href="{{ endpoint.url }}" target="_blank" rel="noopener noreferrer">{{ endpoint.url }}</a>
+                {% else %}{{ endpoint.url }}{% endif %}
               </td>
               <td>{% badge endpoint.get_status_display %}</td>
               <td>{{ endpoint.days_remaining|default:"—" }}</td>

--- a/netbox_ssl/templates/netbox_ssl/certificate.html
+++ b/netbox_ssl/templates/netbox_ssl/certificate.html
@@ -299,7 +299,7 @@
 {% endif %}
 
 {# Tabbed secondary sections #}
-{% if object.sans or assignments or object.replaced_by or object.replaces.exists or lifecycle_events %}
+{% if object.sans or assignments or object.replaced_by or object.replaces.exists or lifecycle_events or monitored_endpoints %}
 <div class="row mb-3">
   <div class="col col-12">
     <ul class="nav nav-tabs" role="tablist">
@@ -329,6 +329,13 @@
           Lifecycle <span class="badge text-bg-secondary">{{ lifecycle_events|length }}</span>
         </button>
       </li>
+      {% if monitored_endpoints %}
+      <li class="nav-item">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-monitored-endpoints" type="button" role="tab">
+          Monitored Endpoints <span class="badge text-bg-secondary">{{ monitored_endpoints_count }}</span>
+        </button>
+      </li>
+      {% endif %}
     </ul>
     <div class="tab-content border border-top-0 rounded-bottom">
       {% if object.sans %}
@@ -424,6 +431,34 @@
         <p class="text-muted mb-0">No lifecycle events recorded.</p>
         {% endif %}
       </div>
+      {% if monitored_endpoints %}
+      <div class="tab-pane fade p-3" id="tab-monitored-endpoints" role="tabpanel">
+        <table class="table table-hover mb-0">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>URL</th>
+              <th>Status</th>
+              <th>Days Remaining</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for endpoint in monitored_endpoints %}
+            <tr>
+              <td><a href="{{ endpoint.get_absolute_url }}">{{ endpoint.name }}</a></td>
+              <td>
+                <a href="{{ endpoint.url }}" target="_blank" rel="noopener noreferrer">
+                  {{ endpoint.url }}
+                </a>
+              </td>
+              <td>{% badge endpoint.get_status_display %}</td>
+              <td>{{ endpoint.days_remaining|default:"—" }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/netbox_ssl/templates/netbox_ssl/monitored_endpoint_import.html
+++ b/netbox_ssl/templates/netbox_ssl/monitored_endpoint_import.html
@@ -69,8 +69,9 @@
         <div class="card-body">
           <p class="text-muted">
             {% trans "Required column:" %} <code>url</code>.
-            {% trans "Optional:" %} <code>name</code>, <code>sni</code>, <code>tenant</code>,
+            {% trans "Optional:" %} <code>sni</code>, <code>tenant</code>,
             <code>assigned_device</code>, <code>assigned_vm</code>, <code>assigned_service</code>.
+            {% trans "The endpoint name is derived from the SNI or hostname." %}
           </p>
           <form method="post" enctype="multipart/form-data">
             {% csrf_token %}

--- a/netbox_ssl/templates/netbox_ssl/monitored_endpoint_import.html
+++ b/netbox_ssl/templates/netbox_ssl/monitored_endpoint_import.html
@@ -1,0 +1,109 @@
+{% extends 'base/layout.html' %}
+{% load i18n %}
+{% load helpers %}
+
+{% block title %}{% trans "Import Monitored Endpoints" %}{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col col-md-12">
+    <h2>{% trans "Import Monitored Endpoints" %}</h2>
+
+    {% if messages %}
+      {% for message in messages %}
+        <div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+          {{ message }}
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+      {% endfor %}
+    {% endif %}
+
+    {% if step == 'result' %}
+      <div class="card">
+        <h5 class="card-header">{% trans "Import Results" %}</h5>
+        <div class="card-body">
+          <p>
+            {% trans "Created" %}: <strong>{{ created }}</strong> &nbsp;
+            {% trans "Updated" %}: <strong>{{ updated }}</strong>
+          </p>
+          {% if outcomes %}
+          <table class="table table-sm">
+            <thead>
+              <tr>
+                <th>{% trans "URL" %}</th>
+                <th>{% trans "Action" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for outcome in outcomes %}
+              <tr>
+                <td>{{ outcome.url }}</td>
+                <td>
+                  {% if outcome.action == 'created' %}
+                    <span class="badge text-bg-success">{% trans "Created" %}</span>
+                  {% else %}
+                    <span class="badge text-bg-info">{% trans "Updated" %}</span>
+                  {% endif %}
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+          {% endif %}
+          {% if errors %}
+          <h6 class="text-danger mt-3">{% trans "Errors" %}</h6>
+          <ul>
+            {% for err in errors %}
+              <li>Row {{ err.row }}: {{ err.message }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+        </div>
+      </div>
+      <a href="{% url 'plugins:netbox_ssl:monitoredendpoint_list' %}" class="btn btn-primary mt-3">
+        {% trans "View Monitored Endpoints" %}
+      </a>
+    {% else %}
+      <div class="card">
+        <h5 class="card-header">{% trans "CSV Data" %}</h5>
+        <div class="card-body">
+          <p class="text-muted">
+            {% trans "Required column:" %} <code>url</code>.
+            {% trans "Optional:" %} <code>name</code>, <code>sni</code>, <code>tenant</code>,
+            <code>assigned_device</code>, <code>assigned_vm</code>, <code>assigned_service</code>.
+          </p>
+          <form method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            {% for field in form %}
+              <div class="mb-3">
+                <label class="form-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+                {{ field }}
+                {% if field.help_text %}
+                  <div class="form-text text-muted">{{ field.help_text }}</div>
+                {% endif %}
+                {% for error in field.errors %}
+                  <div class="invalid-feedback d-block">{{ error }}</div>
+                {% endfor %}
+              </div>
+            {% endfor %}
+            {% if errors %}
+            <div class="alert alert-warning">
+              <strong>{% trans "Parse errors:" %}</strong>
+              <ul class="mb-0">
+                {% for err in errors %}
+                  <li>Row {{ err.row }}: {{ err.message }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+            <button type="submit" class="btn btn-primary">{% trans "Import" %}</button>
+            <a href="{% url 'plugins:netbox_ssl:monitoredendpoint_list' %}" class="btn btn-outline-secondary ms-2">
+              {% trans "Cancel" %}
+            </a>
+          </form>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+</div>
+{% endblock content %}

--- a/netbox_ssl/templates/netbox_ssl/monitoredendpoint.html
+++ b/netbox_ssl/templates/netbox_ssl/monitoredendpoint.html
@@ -1,0 +1,81 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load plugins %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item">
+    <a href="{% url 'plugins:netbox_ssl:monitoredendpoint_list' %}">Monitored Endpoints</a>
+  </li>
+{% endblock breadcrumbs %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">Endpoint Details</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">Name</th>
+            <td>{{ object.name }}</td>
+          </tr>
+          <tr>
+            <th scope="row">URL</th>
+            <td>
+              <a href="{{ object.url }}" target="_blank" rel="noopener noreferrer">{{ object.url }}</a>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">SNI</th>
+            <td>{{ object.sni|default:"—" }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Status</th>
+            <td>{% badge object.get_status_display %}</td>
+          </tr>
+          <tr>
+            <th scope="row">Certificate</th>
+            <td>
+              {% if object.certificate %}
+                <a href="{{ object.certificate.get_absolute_url }}">{{ object.certificate }}</a>
+              {% else %}
+                <span class="text-muted">None</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Days Remaining</th>
+            <td>{{ object.days_remaining|default:"—" }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Tenant</th>
+            <td>
+              {% if object.tenant %}
+                <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+              {% else %}
+                <span class="text-muted">None</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">Last Checked</th>
+            <td>{{ object.last_checked|date:"Y-m-d H:i:s"|default:"Never" }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Last Seen</th>
+            <td>{{ object.last_seen|date:"Y-m-d H:i:s"|default:"Never" }}</td>
+          </tr>
+          {% if object.last_error %}
+          <tr>
+            <th scope="row">Last Error</th>
+            <td class="text-danger">{{ object.last_error }}</td>
+          </tr>
+          {% endif %}
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/netbox_ssl/templates/netbox_ssl/monitoredendpoint.html
+++ b/netbox_ssl/templates/netbox_ssl/monitoredendpoint.html
@@ -24,7 +24,9 @@
           <tr>
             <th scope="row">URL</th>
             <td>
-              <a href="{{ object.url }}" target="_blank" rel="noopener noreferrer">{{ object.url }}</a>
+              {% if object.url|slice:':8'|lower == 'https://' or object.url|slice:':7'|lower == 'http://' %}
+                <a href="{{ object.url }}" target="_blank" rel="noopener noreferrer">{{ object.url }}</a>
+              {% else %}{{ object.url }}{% endif %}
             </td>
           </tr>
           <tr>

--- a/netbox_ssl/templates/netbox_ssl/monitoredendpoint.html
+++ b/netbox_ssl/templates/netbox_ssl/monitoredendpoint.html
@@ -80,4 +80,47 @@
     </div>
   </div>
 </div>
+
+{# Rotation History tab #}
+<div class="row mb-3">
+  <div class="col col-12">
+    <ul class="nav nav-tabs" role="tablist">
+      <li class="nav-item">
+        <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tab-rotation-history" type="button" role="tab">
+          Rotation History
+        </button>
+      </li>
+    </ul>
+    <div class="tab-content border border-top-0 rounded-bottom">
+      <div class="tab-pane fade show active p-3" id="tab-rotation-history" role="tabpanel">
+        {% with history=object.cert_history.all %}
+        {% if history %}
+        <table class="table table-hover mb-0">
+          <thead>
+            <tr>
+              <th>Certificate</th>
+              <th>First Seen</th>
+              <th>Last Seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for entry in history %}
+            <tr>
+              <td>
+                <a href="{{ entry.certificate.get_absolute_url }}">{{ entry.certificate }}</a>
+              </td>
+              <td>{{ entry.first_seen|date:"Y-m-d H:i" }}</td>
+              <td>{{ entry.last_seen|date:"Y-m-d H:i" }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% else %}
+        <p class="text-muted mb-0">No rotation history recorded yet.</p>
+        {% endif %}
+        {% endwith %}
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock content %}

--- a/netbox_ssl/urls.py
+++ b/netbox_ssl/urls.py
@@ -231,6 +231,48 @@ urlpatterns = [
         name="externalsource_changelog",
         kwargs={"model": models.ExternalSource},
     ),
+    # MonitoredEndpoint URLs
+    path(
+        "monitored-endpoints/",
+        views.MonitoredEndpointListView.as_view(),
+        name="monitoredendpoint_list",
+    ),
+    path(
+        "monitored-endpoints/add/",
+        views.MonitoredEndpointEditView.as_view(),
+        name="monitoredendpoint_add",
+    ),
+    path(
+        "monitored-endpoints/import/",
+        views.MonitoredEndpointImportView.as_view(),
+        name="monitoredendpoint_import",
+    ),
+    path(
+        "monitored-endpoints/delete/",
+        views.MonitoredEndpointBulkDeleteView.as_view(),
+        name="monitoredendpoint_bulk_delete",
+    ),
+    path(
+        "monitored-endpoints/<int:pk>/",
+        views.MonitoredEndpointView.as_view(),
+        name="monitoredendpoint",
+    ),
+    path(
+        "monitored-endpoints/<int:pk>/edit/",
+        views.MonitoredEndpointEditView.as_view(),
+        name="monitoredendpoint_edit",
+    ),
+    path(
+        "monitored-endpoints/<int:pk>/delete/",
+        views.MonitoredEndpointDeleteView.as_view(),
+        name="monitoredendpoint_delete",
+    ),
+    path(
+        "monitored-endpoints/<int:pk>/changelog/",
+        ObjectChangeLogView.as_view(),
+        name="monitoredendpoint_changelog",
+        kwargs={"model": models.MonitoredEndpoint},
+    ),
     # CertificateAssignment URLs
     path(
         "assignments/",

--- a/netbox_ssl/utils/__init__.py
+++ b/netbox_ssl/utils/__init__.py
@@ -19,6 +19,7 @@ from .events import (
 )
 from .export import CertificateExporter, ExportFormatChoices
 from .parser import CertificateParseError, CertificateParser, PrivateKeyDetectedError
+from .url_cert_import import ImportOutcome, scrape_and_import
 
 __all__ = [
     "CertificateAnalytics",
@@ -44,4 +45,6 @@ __all__ = [
     "EVENT_CERTIFICATE_REVOKED",
     "build_certificate_event_payload",
     "fire_certificate_event",
+    "ImportOutcome",
+    "scrape_and_import",
 ]

--- a/netbox_ssl/utils/__init__.py
+++ b/netbox_ssl/utils/__init__.py
@@ -14,8 +14,13 @@ from .events import (
     EVENT_CERTIFICATE_EXPIRING_SOON,
     EVENT_CERTIFICATE_RENEWED,
     EVENT_CERTIFICATE_REVOKED,
+    EVENT_ENDPOINT_CERT_ROTATED,
+    EVENT_ENDPOINT_UNREACHABLE,
+    EVENT_ENDPOINT_UNTRUSTED_CERT,
     build_certificate_event_payload,
+    build_endpoint_event_payload,
     fire_certificate_event,
+    fire_endpoint_event,
 )
 from .export import CertificateExporter, ExportFormatChoices
 from .parser import CertificateParseError, CertificateParser, PrivateKeyDetectedError
@@ -43,8 +48,13 @@ __all__ = [
     "EVENT_CERTIFICATE_EXPIRING_SOON",
     "EVENT_CERTIFICATE_RENEWED",
     "EVENT_CERTIFICATE_REVOKED",
+    "EVENT_ENDPOINT_UNREACHABLE",
+    "EVENT_ENDPOINT_CERT_ROTATED",
+    "EVENT_ENDPOINT_UNTRUSTED_CERT",
     "build_certificate_event_payload",
+    "build_endpoint_event_payload",
     "fire_certificate_event",
+    "fire_endpoint_event",
     "ImportOutcome",
     "scrape_and_import",
 ]

--- a/netbox_ssl/utils/endpoint_monitor.py
+++ b/netbox_ssl/utils/endpoint_monitor.py
@@ -1,0 +1,124 @@
+"""Poll a MonitoredEndpoint: scrape its cert, link it, track rotation, fire events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+from django.db import transaction
+from django.utils import timezone
+
+from ..models import MonitoredEndpointCertificate, MonitoredEndpointStatusChoices
+from .events import (
+    EVENT_ENDPOINT_CERT_ROTATED,
+    EVENT_ENDPOINT_UNREACHABLE,
+    EVENT_ENDPOINT_UNTRUSTED_CERT,
+    fire_endpoint_event,
+)
+from .tls_scraper import TLSScrapeError
+from .url_cert_import import scrape_and_import
+from .url_validation import URLValidationError
+
+
+@dataclass(frozen=True)
+class PollResult:
+    endpoint: object
+    status: str
+    rotated: bool
+    events_fired: tuple[str, ...]
+
+
+def _host_port(url: str) -> tuple[str, int]:
+    parts = urlsplit(url)
+    return parts.hostname or "", parts.port or 443
+
+
+def poll_endpoint(endpoint: object, *, allowlist: list) -> PollResult:
+    """Scrape the endpoint's current cert and reconcile the endpoint record.
+
+    Two-attempt trust detection:
+    - First attempt with verify_chain=True (trusted chain required).
+    - On TLSScrapeError/URLValidationError, retry with verify_chain=False.
+      - If the unverified attempt succeeds → status UNTRUSTED + fire endpoint_untrusted_cert.
+      - If it also fails → status UNREACHABLE + last_error + fire endpoint_unreachable.
+    - Any other exception (e.g. parse error) → UNREACHABLE + fire endpoint_unreachable.
+
+    On success (either trusted or untrusted):
+    - endpoint.certificate, last_checked, last_seen, last_error updated atomically.
+    - MonitoredEndpointCertificate history row upserted (get_or_create + bump last_seen).
+    - Rotation detected when the previous cert pk differs from the new one.
+    """
+    host, port = _host_port(endpoint.url)  # type: ignore[attr-defined]
+    sni = endpoint.sni or None  # type: ignore[attr-defined]
+    prev_cert_id = endpoint.certificate_id  # type: ignore[attr-defined]
+    events: list[str] = []
+    now = timezone.now()
+
+    def _do(verify: bool):
+        return scrape_and_import(
+            endpoint.url,  # type: ignore[attr-defined]
+            host,
+            port,
+            sni=sni,
+            verify_chain=verify,
+            allowlist=allowlist,
+            tenant=endpoint.tenant,  # type: ignore[attr-defined]
+            set_discovered_url=True,
+        )
+
+    untrusted = False
+    try:
+        outcome = _do(True)
+    except (TLSScrapeError, URLValidationError):
+        try:
+            outcome = _do(False)
+            untrusted = True
+        except (TLSScrapeError, URLValidationError) as exc:
+            endpoint.status = MonitoredEndpointStatusChoices.STATUS_UNREACHABLE  # type: ignore[attr-defined]
+            endpoint.last_checked = now  # type: ignore[attr-defined]
+            endpoint.last_error = str(exc)  # type: ignore[attr-defined]
+            endpoint.save(update_fields=["status", "last_checked", "last_error"])  # type: ignore[attr-defined]
+            fire_endpoint_event(endpoint, EVENT_ENDPOINT_UNREACHABLE)
+            return PollResult(endpoint, endpoint.status, False, (EVENT_ENDPOINT_UNREACHABLE,))  # type: ignore[attr-defined]
+    except Exception as exc:  # noqa: BLE001 – record and continue (e.g. parse error)
+        endpoint.status = MonitoredEndpointStatusChoices.STATUS_UNREACHABLE  # type: ignore[attr-defined]
+        endpoint.last_checked = now  # type: ignore[attr-defined]
+        endpoint.last_error = str(exc)  # type: ignore[attr-defined]
+        endpoint.save(update_fields=["status", "last_checked", "last_error"])  # type: ignore[attr-defined]
+        fire_endpoint_event(endpoint, EVENT_ENDPOINT_UNREACHABLE)
+        return PollResult(endpoint, endpoint.status, False, (EVENT_ENDPOINT_UNREACHABLE,))  # type: ignore[attr-defined]
+
+    cert = outcome.certificate
+    rotated = prev_cert_id is not None and prev_cert_id != cert.pk
+
+    with transaction.atomic():
+        endpoint.certificate = cert  # type: ignore[attr-defined]
+        endpoint.last_checked = now  # type: ignore[attr-defined]
+        endpoint.last_seen = now  # type: ignore[attr-defined]
+        endpoint.last_error = ""  # type: ignore[attr-defined]
+        endpoint.status = (  # type: ignore[attr-defined]
+            MonitoredEndpointStatusChoices.STATUS_UNTRUSTED
+            if untrusted
+            else MonitoredEndpointStatusChoices.STATUS_OK
+        )
+        endpoint.save(  # type: ignore[attr-defined]
+            update_fields=["certificate", "last_checked", "last_seen", "last_error", "status"]
+        )
+
+        hist, created = MonitoredEndpointCertificate.objects.get_or_create(
+            endpoint=endpoint,
+            certificate=cert,
+            defaults={"first_seen": now, "last_seen": now},
+        )
+        if not created:
+            hist.last_seen = now
+            hist.save(update_fields=["last_seen"])
+
+    if untrusted:
+        events.append(EVENT_ENDPOINT_UNTRUSTED_CERT)
+        fire_endpoint_event(endpoint, EVENT_ENDPOINT_UNTRUSTED_CERT)
+    if rotated:
+        events.append(EVENT_ENDPOINT_CERT_ROTATED)
+        fire_endpoint_event(endpoint, EVENT_ENDPOINT_CERT_ROTATED, extra={"previous_certificate_id": prev_cert_id})
+
+    return PollResult(endpoint, endpoint.status, rotated, tuple(events))  # type: ignore[attr-defined]

--- a/netbox_ssl/utils/endpoint_monitor.py
+++ b/netbox_ssl/utils/endpoint_monitor.py
@@ -101,13 +101,9 @@ def poll_endpoint(endpoint: MonitoredEndpoint, *, allowlist: list[str]) -> PollR
         endpoint.last_seen = now
         endpoint.last_error = ""
         endpoint.status = (
-            MonitoredEndpointStatusChoices.STATUS_UNTRUSTED
-            if untrusted
-            else MonitoredEndpointStatusChoices.STATUS_OK
+            MonitoredEndpointStatusChoices.STATUS_UNTRUSTED if untrusted else MonitoredEndpointStatusChoices.STATUS_OK
         )
-        endpoint.save(
-            update_fields=["certificate", "last_checked", "last_seen", "last_error", "status"]
-        )
+        endpoint.save(update_fields=["certificate", "last_checked", "last_seen", "last_error", "status"])
 
         hist, created = MonitoredEndpointCertificate.objects.get_or_create(
             endpoint=endpoint,

--- a/netbox_ssl/utils/endpoint_monitor.py
+++ b/netbox_ssl/utils/endpoint_monitor.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 from django.db import transaction
 from django.utils import timezone
+
+if TYPE_CHECKING:
+    from ..models import MonitoredEndpoint
 
 from ..models import MonitoredEndpointCertificate, MonitoredEndpointStatusChoices
 from .events import (
@@ -22,7 +26,7 @@ from .url_validation import URLValidationError
 
 @dataclass(frozen=True)
 class PollResult:
-    endpoint: object
+    endpoint: MonitoredEndpoint
     status: str
     rotated: bool
     events_fired: tuple[str, ...]
@@ -33,7 +37,7 @@ def _host_port(url: str) -> tuple[str, int]:
     return parts.hostname or "", parts.port or 443
 
 
-def poll_endpoint(endpoint: object, *, allowlist: list) -> PollResult:
+def poll_endpoint(endpoint: MonitoredEndpoint, *, allowlist: list[str]) -> PollResult:
     """Scrape the endpoint's current cert and reconcile the endpoint record.
 
     Two-attempt trust detection:
@@ -48,21 +52,21 @@ def poll_endpoint(endpoint: object, *, allowlist: list) -> PollResult:
     - MonitoredEndpointCertificate history row upserted (get_or_create + bump last_seen).
     - Rotation detected when the previous cert pk differs from the new one.
     """
-    host, port = _host_port(endpoint.url)  # type: ignore[attr-defined]
-    sni = endpoint.sni or None  # type: ignore[attr-defined]
-    prev_cert_id = endpoint.certificate_id  # type: ignore[attr-defined]
+    host, port = _host_port(endpoint.url)
+    sni = endpoint.sni or None
+    prev_cert_id = endpoint.certificate_id
     events: list[str] = []
     now = timezone.now()
 
     def _do(verify: bool):
         return scrape_and_import(
-            endpoint.url,  # type: ignore[attr-defined]
+            endpoint.url,
             host,
             port,
             sni=sni,
             verify_chain=verify,
             allowlist=allowlist,
-            tenant=endpoint.tenant,  # type: ignore[attr-defined]
+            tenant=endpoint.tenant,
             set_discovered_url=True,
         )
 
@@ -74,34 +78,34 @@ def poll_endpoint(endpoint: object, *, allowlist: list) -> PollResult:
             outcome = _do(False)
             untrusted = True
         except (TLSScrapeError, URLValidationError) as exc:
-            endpoint.status = MonitoredEndpointStatusChoices.STATUS_UNREACHABLE  # type: ignore[attr-defined]
-            endpoint.last_checked = now  # type: ignore[attr-defined]
-            endpoint.last_error = str(exc)  # type: ignore[attr-defined]
-            endpoint.save(update_fields=["status", "last_checked", "last_error"])  # type: ignore[attr-defined]
+            endpoint.status = MonitoredEndpointStatusChoices.STATUS_UNREACHABLE
+            endpoint.last_checked = now
+            endpoint.last_error = str(exc)
+            endpoint.save(update_fields=["status", "last_checked", "last_error"])
             fire_endpoint_event(endpoint, EVENT_ENDPOINT_UNREACHABLE)
-            return PollResult(endpoint, endpoint.status, False, (EVENT_ENDPOINT_UNREACHABLE,))  # type: ignore[attr-defined]
+            return PollResult(endpoint, endpoint.status, False, (EVENT_ENDPOINT_UNREACHABLE,))
     except Exception as exc:  # noqa: BLE001 – record and continue (e.g. parse error)
-        endpoint.status = MonitoredEndpointStatusChoices.STATUS_UNREACHABLE  # type: ignore[attr-defined]
-        endpoint.last_checked = now  # type: ignore[attr-defined]
-        endpoint.last_error = str(exc)  # type: ignore[attr-defined]
-        endpoint.save(update_fields=["status", "last_checked", "last_error"])  # type: ignore[attr-defined]
+        endpoint.status = MonitoredEndpointStatusChoices.STATUS_UNREACHABLE
+        endpoint.last_checked = now
+        endpoint.last_error = str(exc)
+        endpoint.save(update_fields=["status", "last_checked", "last_error"])
         fire_endpoint_event(endpoint, EVENT_ENDPOINT_UNREACHABLE)
-        return PollResult(endpoint, endpoint.status, False, (EVENT_ENDPOINT_UNREACHABLE,))  # type: ignore[attr-defined]
+        return PollResult(endpoint, endpoint.status, False, (EVENT_ENDPOINT_UNREACHABLE,))
 
     cert = outcome.certificate
     rotated = prev_cert_id is not None and prev_cert_id != cert.pk
 
     with transaction.atomic():
-        endpoint.certificate = cert  # type: ignore[attr-defined]
-        endpoint.last_checked = now  # type: ignore[attr-defined]
-        endpoint.last_seen = now  # type: ignore[attr-defined]
-        endpoint.last_error = ""  # type: ignore[attr-defined]
-        endpoint.status = (  # type: ignore[attr-defined]
+        endpoint.certificate = cert
+        endpoint.last_checked = now
+        endpoint.last_seen = now
+        endpoint.last_error = ""
+        endpoint.status = (
             MonitoredEndpointStatusChoices.STATUS_UNTRUSTED
             if untrusted
             else MonitoredEndpointStatusChoices.STATUS_OK
         )
-        endpoint.save(  # type: ignore[attr-defined]
+        endpoint.save(
             update_fields=["certificate", "last_checked", "last_seen", "last_error", "status"]
         )
 
@@ -121,4 +125,4 @@ def poll_endpoint(endpoint: object, *, allowlist: list) -> PollResult:
         events.append(EVENT_ENDPOINT_CERT_ROTATED)
         fire_endpoint_event(endpoint, EVENT_ENDPOINT_CERT_ROTATED, extra={"previous_certificate_id": prev_cert_id})
 
-    return PollResult(endpoint, endpoint.status, rotated, tuple(events))  # type: ignore[attr-defined]
+    return PollResult(endpoint, endpoint.status, rotated, tuple(events))

--- a/netbox_ssl/utils/events.py
+++ b/netbox_ssl/utils/events.py
@@ -142,3 +142,44 @@ def fire_certificate_event(
     )
 
     return payload
+
+
+# ---------------------------------------------------------------------------
+# Endpoint event constants
+# ---------------------------------------------------------------------------
+
+EVENT_ENDPOINT_UNREACHABLE = "endpoint_unreachable"
+EVENT_ENDPOINT_CERT_ROTATED = "endpoint_cert_rotated"
+EVENT_ENDPOINT_UNTRUSTED_CERT = "endpoint_untrusted_cert"
+
+
+def build_endpoint_event_payload(endpoint: Any, event_type: str, extra: dict | None = None) -> dict:
+    """Build a standardized event payload for a monitored-endpoint event."""
+    cert = endpoint.certificate
+    payload = {
+        "event_type": event_type,
+        "endpoint_id": endpoint.pk,
+        "name": endpoint.name,
+        "url": endpoint.url,
+        "status": endpoint.status,
+        "certificate_id": cert.pk if cert else None,
+        "common_name": cert.common_name if cert else None,
+        "days_remaining": cert.days_remaining if cert else None,
+        "tenant": endpoint.tenant.name if endpoint.tenant else None,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def fire_endpoint_event(endpoint: Any, event_type: str, extra: dict | None = None) -> dict:
+    """Fire a monitored-endpoint event by touching last_updated (same mechanism as certs)."""
+    payload = build_endpoint_event_payload(endpoint, event_type, extra=extra)
+    try:
+        from django.utils import timezone as dj_timezone
+
+        type(endpoint).objects.filter(pk=endpoint.pk).update(last_updated=dj_timezone.now())
+    except Exception as e:
+        logger.warning("Could not update last_updated for endpoint %s: %s", endpoint.pk, e)
+    return payload

--- a/netbox_ssl/utils/url_cert_import.py
+++ b/netbox_ssl/utils/url_cert_import.py
@@ -9,15 +9,18 @@ from __future__ import annotations
 
 import socket
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from django.db import transaction
 from django.utils import timezone
 
-from ..models import Certificate, CertificateStatusChoices
 from .ca_detector import detect_issuing_ca
 from .parser import CertificateParseError, CertificateParser  # noqa: F401 (re-exported for callers)
 from .tls_scraper import TLSScrapeError, scrape_tls_certificate  # noqa: F401 (re-exported for callers)
 from .url_validation import URLValidationError, validate_https_url  # noqa: F401 (re-exported for callers)
+
+if TYPE_CHECKING:
+    from ..models import Certificate
 
 
 @dataclass(frozen=True)
@@ -42,6 +45,10 @@ def scrape_and_import(
     Raises URLValidationError / TLSScrapeError / CertificateParseError.
     Does NOT swallow — callers map exceptions to their own outcome shapes.
     """
+    # Imported lazily so ``netbox_ssl.utils`` stays importable in the host-only
+    # unit lane (``-p no:django``); ``netbox_ssl.models`` pulls in the full stack.
+    from ..models import Certificate, CertificateStatusChoices
+
     validate_https_url(url, cidr_allowlist=allowlist)
     try:
         resolved_ip = socket.getaddrinfo(host, port)[0][4][0]
@@ -50,9 +57,7 @@ def scrape_and_import(
     pem = scrape_tls_certificate(resolved_ip, host, port, sni=sni, verify_chain=verify_chain)
     parsed = CertificateParser.parse(pem)
 
-    existing = Certificate.objects.filter(
-        serial_number=parsed.serial_number, issuer=parsed.issuer
-    ).first()
+    existing = Certificate.objects.filter(serial_number=parsed.serial_number, issuer=parsed.issuer).first()
     if existing:
         existing.last_seen_at = timezone.now()
         if set_discovered_url and not existing.discovered_via_url:

--- a/netbox_ssl/utils/url_cert_import.py
+++ b/netbox_ssl/utils/url_cert_import.py
@@ -43,7 +43,10 @@ def scrape_and_import(
     Does NOT swallow — callers map exceptions to their own outcome shapes.
     """
     validate_https_url(url, cidr_allowlist=allowlist)
-    resolved_ip = socket.getaddrinfo(host, port)[0][4][0]
+    try:
+        resolved_ip = socket.getaddrinfo(host, port)[0][4][0]
+    except OSError as exc:
+        raise TLSScrapeError(f"DNS failed for {host}:{port}: {exc}") from exc
     pem = scrape_tls_certificate(resolved_ip, host, port, sni=sni, verify_chain=verify_chain)
     parsed = CertificateParser.parse(pem)
 
@@ -58,23 +61,25 @@ def scrape_and_import(
         return ImportOutcome(certificate=existing, created=False)
 
     with transaction.atomic():
-        cert = Certificate.objects.create(
-            common_name=parsed.common_name,
-            serial_number=parsed.serial_number,
-            fingerprint_sha256=parsed.fingerprint_sha256,
-            issuer=parsed.issuer,
-            issuing_ca=detect_issuing_ca(parsed.issuer),
-            valid_from=parsed.valid_from,
-            valid_to=parsed.valid_to,
-            sans=parsed.sans or [],
-            key_size=parsed.key_size,
-            algorithm=parsed.algorithm,
-            status=CertificateStatusChoices.STATUS_ACTIVE,
-            pem_content=parsed.pem_content,
-            issuer_chain=parsed.issuer_chain,
-            tenant=tenant,
-            discovered_via_url=url if set_discovered_url else "",
-            last_seen_at=timezone.now(),
-        )
+        create_kwargs = {
+            "common_name": parsed.common_name,
+            "serial_number": parsed.serial_number,
+            "fingerprint_sha256": parsed.fingerprint_sha256,
+            "issuer": parsed.issuer,
+            "issuing_ca": detect_issuing_ca(parsed.issuer),
+            "valid_from": parsed.valid_from,
+            "valid_to": parsed.valid_to,
+            "sans": parsed.sans or [],
+            "key_size": parsed.key_size,
+            "algorithm": parsed.algorithm,
+            "status": CertificateStatusChoices.STATUS_ACTIVE,
+            "pem_content": parsed.pem_content,
+            "issuer_chain": parsed.issuer_chain,
+            "tenant": tenant,
+            "last_seen_at": timezone.now(),
+        }
+        if set_discovered_url:
+            create_kwargs["discovered_via_url"] = url
+        cert = Certificate.objects.create(**create_kwargs)
         cert.auto_detect_acme(save=True)
     return ImportOutcome(certificate=cert, created=True)

--- a/netbox_ssl/utils/url_cert_import.py
+++ b/netbox_ssl/utils/url_cert_import.py
@@ -1,0 +1,80 @@
+"""Shared 'scrape a URL -> parse -> import-or-match' service.
+
+Extracted from views/url_import.py so both the #106 URL import and the #149
+endpoint poll use one code path. Raises on failure (callers map to their own
+outcome shapes); never swallows.
+"""
+
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass
+
+from django.db import transaction
+from django.utils import timezone
+
+from ..models import Certificate, CertificateStatusChoices
+from .ca_detector import detect_issuing_ca
+from .parser import CertificateParseError, CertificateParser  # noqa: F401 (re-exported for callers)
+from .tls_scraper import TLSScrapeError, scrape_tls_certificate  # noqa: F401 (re-exported for callers)
+from .url_validation import URLValidationError, validate_https_url  # noqa: F401 (re-exported for callers)
+
+
+@dataclass(frozen=True)
+class ImportOutcome:
+    certificate: Certificate
+    created: bool
+
+
+def scrape_and_import(
+    url: str,
+    host: str,
+    port: int,
+    *,
+    sni: str | None = None,
+    verify_chain: bool = True,
+    allowlist,
+    tenant=None,
+    set_discovered_url: bool = True,
+) -> ImportOutcome:
+    """Validate, scrape, parse, and import-or-match the cert presented at a URL.
+
+    Raises URLValidationError / TLSScrapeError / CertificateParseError.
+    Does NOT swallow — callers map exceptions to their own outcome shapes.
+    """
+    validate_https_url(url, cidr_allowlist=allowlist)
+    resolved_ip = socket.getaddrinfo(host, port)[0][4][0]
+    pem = scrape_tls_certificate(resolved_ip, host, port, sni=sni, verify_chain=verify_chain)
+    parsed = CertificateParser.parse(pem)
+
+    existing = Certificate.objects.filter(
+        serial_number=parsed.serial_number, issuer=parsed.issuer
+    ).first()
+    if existing:
+        existing.last_seen_at = timezone.now()
+        if set_discovered_url and not existing.discovered_via_url:
+            existing.discovered_via_url = url
+        existing.save(update_fields=["last_seen_at", "discovered_via_url"])
+        return ImportOutcome(certificate=existing, created=False)
+
+    with transaction.atomic():
+        cert = Certificate.objects.create(
+            common_name=parsed.common_name,
+            serial_number=parsed.serial_number,
+            fingerprint_sha256=parsed.fingerprint_sha256,
+            issuer=parsed.issuer,
+            issuing_ca=detect_issuing_ca(parsed.issuer),
+            valid_from=parsed.valid_from,
+            valid_to=parsed.valid_to,
+            sans=parsed.sans or [],
+            key_size=parsed.key_size,
+            algorithm=parsed.algorithm,
+            status=CertificateStatusChoices.STATUS_ACTIVE,
+            pem_content=parsed.pem_content,
+            issuer_chain=parsed.issuer_chain,
+            tenant=tenant,
+            discovered_via_url=url if set_discovered_url else "",
+            last_seen_at=timezone.now(),
+        )
+        cert.auto_detect_acme(save=True)
+    return ImportOutcome(certificate=cert, created=True)

--- a/netbox_ssl/views/__init__.py
+++ b/netbox_ssl/views/__init__.py
@@ -41,6 +41,14 @@ from .external_sources import (
     ExternalSourceListView,
     ExternalSourceView,
 )
+from .monitored_endpoints import (
+    MonitoredEndpointBulkDeleteView,
+    MonitoredEndpointDeleteView,
+    MonitoredEndpointEditView,
+    MonitoredEndpointImportView,
+    MonitoredEndpointListView,
+    MonitoredEndpointView,
+)
 from .url_import import (
     UrlImportView,
 )
@@ -85,4 +93,11 @@ __all__ = [
     "ExternalSourceDeleteView",
     "ExternalSourceBulkEditView",
     "ExternalSourceBulkDeleteView",
+    # MonitoredEndpoint views
+    "MonitoredEndpointListView",
+    "MonitoredEndpointView",
+    "MonitoredEndpointEditView",
+    "MonitoredEndpointDeleteView",
+    "MonitoredEndpointBulkDeleteView",
+    "MonitoredEndpointImportView",
 ]

--- a/netbox_ssl/views/certificates.py
+++ b/netbox_ssl/views/certificates.py
@@ -77,14 +77,18 @@ class CertificateView(generic.ObjectView):
         assignments = instance.assignments.all()
         # Add lifecycle events for timeline tab
         lifecycle_events = instance.lifecycle_events.all()[:50]
-        # Add monitored endpoints (reverse tab, #149)
-        monitored_endpoints = instance.monitored_endpoints.restrict(request.user, "view")
+        # Add monitored endpoints (reverse tab, #149) — materialized once to avoid
+        # 3 DB hits (restrict + count + template for/if); select_related avoids
+        # per-row cert queries in the tab.
+        monitored_endpoints = list(
+            instance.monitored_endpoints.restrict(request.user, "view").select_related("certificate")
+        )
         return {
             "assignments": assignments,
             "assignments_count": assignments.count(),
             "lifecycle_events": lifecycle_events,
             "monitored_endpoints": monitored_endpoints,
-            "monitored_endpoints_count": monitored_endpoints.count(),
+            "monitored_endpoints_count": len(monitored_endpoints),
         }
 
 

--- a/netbox_ssl/views/certificates.py
+++ b/netbox_ssl/views/certificates.py
@@ -73,14 +73,18 @@ class CertificateView(generic.ObjectView):
     )
 
     def get_extra_context(self, request, instance):
-        """Add assignments and lifecycle events to context."""
+        """Add assignments, lifecycle events, and monitored endpoints to context."""
         assignments = instance.assignments.all()
         # Add lifecycle events for timeline tab
         lifecycle_events = instance.lifecycle_events.all()[:50]
+        # Add monitored endpoints (reverse tab, #149)
+        monitored_endpoints = instance.monitored_endpoints.restrict(request.user, "view")
         return {
             "assignments": assignments,
             "assignments_count": assignments.count(),
             "lifecycle_events": lifecycle_events,
+            "monitored_endpoints": monitored_endpoints,
+            "monitored_endpoints_count": monitored_endpoints.count(),
         }
 
 

--- a/netbox_ssl/views/monitored_endpoints.py
+++ b/netbox_ssl/views/monitored_endpoints.py
@@ -1,0 +1,146 @@
+"""
+Views for MonitoredEndpoint model.
+"""
+
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import render
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import View
+from netbox.views import generic
+
+from ..filtersets import MonitoredEndpointFilterSet
+from ..forms import MonitoredEndpointFilterForm, MonitoredEndpointForm
+from ..forms.monitored_endpoints import MonitoredEndpointImportForm
+from ..models import MonitoredEndpoint, MonitoredEndpointStatusChoices
+from ..tables import MonitoredEndpointTable
+from ..utils.url_bulk_parser import parse as parse_url_csv
+
+
+class MonitoredEndpointListView(generic.ObjectListView):
+    """List all Monitored Endpoints."""
+
+    queryset = MonitoredEndpoint.objects.select_related("certificate", "tenant").prefetch_related("tags")
+    filterset = MonitoredEndpointFilterSet
+    filterset_form = MonitoredEndpointFilterForm
+    table = MonitoredEndpointTable
+
+
+class MonitoredEndpointView(generic.ObjectView):
+    """Display a single Monitored Endpoint."""
+
+    queryset = MonitoredEndpoint.objects.select_related("certificate", "tenant").prefetch_related("tags")
+
+    def get_extra_context(self, request, instance):
+        return {}
+
+
+class MonitoredEndpointEditView(generic.ObjectEditView):
+    """Create or edit a Monitored Endpoint."""
+
+    queryset = MonitoredEndpoint.objects.all()
+    form = MonitoredEndpointForm
+
+
+class MonitoredEndpointDeleteView(generic.ObjectDeleteView):
+    """Delete a Monitored Endpoint."""
+
+    queryset = MonitoredEndpoint.objects.all()
+
+
+class MonitoredEndpointBulkDeleteView(generic.BulkDeleteView):
+    """Bulk delete Monitored Endpoints."""
+
+    queryset = MonitoredEndpoint.objects.all()
+    filterset = MonitoredEndpointFilterSet
+    table = MonitoredEndpointTable
+
+
+class MonitoredEndpointImportView(LoginRequiredMixin, View):
+    """Bulk-import Monitored Endpoints from a CSV of URLs."""
+
+    template_name = "netbox_ssl/monitored_endpoint_import.html"
+    MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10 MB
+
+    def get(self, request):
+        form = MonitoredEndpointImportForm()
+        return render(request, self.template_name, {"form": form, "step": "input"})
+
+    def post(self, request):
+        form = MonitoredEndpointImportForm(request.POST, request.FILES)
+        if not form.is_valid():
+            return render(request, self.template_name, {"form": form, "step": "input"})
+
+        # Read content from file or pasted text.
+        content = ""
+        if form.cleaned_data.get("csv_file"):
+            uploaded = form.cleaned_data["csv_file"]
+            if uploaded.size > self.MAX_UPLOAD_SIZE:
+                messages.error(request, _("File too large. Maximum is 10 MB."))
+                return render(request, self.template_name, {"form": form, "step": "input"})
+            content = uploaded.read().decode("utf-8-sig")
+        else:
+            content = form.cleaned_data.get("csv_text", "")
+
+        if len(content.encode()) > self.MAX_UPLOAD_SIZE:
+            messages.error(request, _("Pasted content too large."))
+            return render(request, self.template_name, {"form": form, "step": "input"})
+
+        result = parse_url_csv(content)
+
+        if result.has_errors and not result.valid_rows:
+            return render(
+                request,
+                self.template_name,
+                {"form": form, "step": "input", "errors": result.errors},
+            )
+
+        created_count = 0
+        updated_count = 0
+        outcomes = []
+
+        for row in result.valid_rows:
+            name = row.sni or row.host
+            _ep, created = MonitoredEndpoint.objects.update_or_create(
+                url=row.url,
+                defaults={
+                    "name": name,
+                    "sni": row.sni or "",
+                    "status": MonitoredEndpointStatusChoices.STATUS_PENDING,
+                },
+            )
+            if created:
+                created_count += 1
+                outcomes.append({"url": row.url, "action": "created"})
+            else:
+                updated_count += 1
+                outcomes.append({"url": row.url, "action": "updated"})
+
+        if created_count:
+            messages.success(
+                request,
+                _("Created %(n)d monitored endpoint(s).") % {"n": created_count},
+            )
+        if updated_count:
+            messages.info(
+                request,
+                _("Updated %(n)d existing monitored endpoint(s).") % {"n": updated_count},
+            )
+        if result.has_errors:
+            messages.warning(
+                request,
+                _("%(n)d row(s) had errors and were skipped.") % {"n": len(result.errors)},
+            )
+
+        return render(
+            request,
+            self.template_name,
+            {
+                "form": MonitoredEndpointImportForm(),
+                "step": "result",
+                "outcomes": outcomes,
+                "created": created_count,
+                "updated": updated_count,
+                "errors": result.errors,
+            },
+        )

--- a/netbox_ssl/views/monitored_endpoints.py
+++ b/netbox_ssl/views/monitored_endpoints.py
@@ -31,10 +31,6 @@ class MonitoredEndpointView(generic.ObjectView):
 
     queryset = MonitoredEndpoint.objects.select_related("certificate", "tenant").prefetch_related("tags")
 
-    def get_extra_context(self, request, instance):
-        return {}
-
-
 class MonitoredEndpointEditView(generic.ObjectEditView):
     """Create or edit a Monitored Endpoint."""
 
@@ -105,6 +101,8 @@ class MonitoredEndpointImportView(LoginRequiredMixin, View):
 
         for row in result.valid_rows:
             name = row.sni or row.host
+            # Rows are already HTTPS-validated by url_bulk_parser (_normalize_url enforces
+            # HTTPS-only), so update_or_create (which bypasses Model.clean()) is safe here.
             _ep, created = MonitoredEndpoint.objects.update_or_create(
                 url=row.url,
                 defaults={

--- a/netbox_ssl/views/monitored_endpoints.py
+++ b/netbox_ssl/views/monitored_endpoints.py
@@ -115,6 +115,7 @@ class MonitoredEndpointImportView(LoginRequiredMixin, View):
                 row.assigned_device,
                 row.assigned_vm,
                 row.assigned_service,
+                request.user,
             )
             # Rows are already HTTPS-validated by url_bulk_parser (_normalize_url enforces
             # HTTPS-only), so update_or_create (which bypasses Model.clean()) is safe here.
@@ -185,12 +186,16 @@ class MonitoredEndpointImportView(LoginRequiredMixin, View):
         device_ref: str,
         vm_ref: str,
         service_ref: str,
+        user,
     ) -> tuple:
         """Resolve device/VM/service reference strings to (ContentType, pk) or (None, None).
 
         Priority: service > device > VM (mirrors MonitoredEndpointForm.save()).
         Reference format: name or numeric ID.  Returns (None, None) when no ref given
         or no matching object found — callers should skip setting assigned_object fields.
+
+        Lookups are restricted to objects the requesting user has 'view' permission for,
+        preventing information disclosure via name/ID enumeration (v0.7.5 security rule).
         """
         from dcim.models import Device
         from ipam.models import Service
@@ -204,17 +209,17 @@ class MonitoredEndpointImportView(LoginRequiredMixin, View):
                 return qs.filter(pk=int(ref)).first()
             return qs.filter(name=ref).first()
 
-        service = _lookup(Service.objects.all(), service_ref)
+        service = _lookup(Service.objects.restrict(user, "view"), service_ref)
         if service:
             ct = ContentType.objects.get_for_model(Service)
             return ct, service.pk
 
-        device = _lookup(Device.objects.all(), device_ref)
+        device = _lookup(Device.objects.restrict(user, "view"), device_ref)
         if device:
             ct = ContentType.objects.get_for_model(Device)
             return ct, device.pk
 
-        vm = _lookup(VirtualMachine.objects.all(), vm_ref)
+        vm = _lookup(VirtualMachine.objects.restrict(user, "view"), vm_ref)
         if vm:
             ct = ContentType.objects.get_for_model(VirtualMachine)
             return ct, vm.pk

--- a/netbox_ssl/views/monitored_endpoints.py
+++ b/netbox_ssl/views/monitored_endpoints.py
@@ -4,7 +4,7 @@ Views for MonitoredEndpoint model.
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 from netbox.views import generic
@@ -67,6 +67,10 @@ class MonitoredEndpointImportView(LoginRequiredMixin, View):
         return render(request, self.template_name, {"form": form, "step": "input"})
 
     def post(self, request):
+        if not request.user.has_perm("netbox_ssl.add_monitoredendpoint"):
+            messages.error(request, _("You do not have permission to create monitored endpoints."))
+            return redirect("plugins:netbox_ssl:monitoredendpoint_list")
+
         form = MonitoredEndpointImportForm(request.POST, request.FILES)
         if not form.is_valid():
             return render(request, self.template_name, {"form": form, "step": "input"})

--- a/netbox_ssl/views/monitored_endpoints.py
+++ b/netbox_ssl/views/monitored_endpoints.py
@@ -29,7 +29,10 @@ class MonitoredEndpointListView(generic.ObjectListView):
 class MonitoredEndpointView(generic.ObjectView):
     """Display a single Monitored Endpoint."""
 
-    queryset = MonitoredEndpoint.objects.select_related("certificate", "tenant").prefetch_related("tags")
+    queryset = MonitoredEndpoint.objects.select_related("certificate", "tenant").prefetch_related(
+        "tags",
+        "cert_history__certificate",
+    )
 
 class MonitoredEndpointEditView(generic.ObjectEditView):
     """Create or edit a Monitored Endpoint."""

--- a/netbox_ssl/views/monitored_endpoints.py
+++ b/netbox_ssl/views/monitored_endpoints.py
@@ -4,6 +4,7 @@ Views for MonitoredEndpoint model.
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import redirect, render
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
@@ -33,6 +34,7 @@ class MonitoredEndpointView(generic.ObjectView):
         "tags",
         "cert_history__certificate",
     )
+
 
 class MonitoredEndpointEditView(generic.ObjectEditView):
     """Create or edit a Monitored Endpoint."""
@@ -98,21 +100,37 @@ class MonitoredEndpointImportView(LoginRequiredMixin, View):
                 {"form": form, "step": "input", "errors": result.errors},
             )
 
+        from tenancy.models import Tenant
+
+        user_tenants = Tenant.objects.restrict(request.user, "view")
+
         created_count = 0
         updated_count = 0
         outcomes = []
 
         for row in result.valid_rows:
             name = row.sni or row.host
+            tenant = self._resolve_tenant(row.tenant, user_tenants)
+            assigned_object_type, assigned_object_id = self._resolve_assignment(
+                row.assigned_device,
+                row.assigned_vm,
+                row.assigned_service,
+            )
             # Rows are already HTTPS-validated by url_bulk_parser (_normalize_url enforces
             # HTTPS-only), so update_or_create (which bypasses Model.clean()) is safe here.
+            defaults = {
+                "name": name,
+                "sni": row.sni or "",
+                "status": MonitoredEndpointStatusChoices.STATUS_PENDING,
+            }
+            if tenant is not None:
+                defaults["tenant"] = tenant
+            if assigned_object_type is not None:
+                defaults["assigned_object_type"] = assigned_object_type
+                defaults["assigned_object_id"] = assigned_object_id
             _ep, created = MonitoredEndpoint.objects.update_or_create(
                 url=row.url,
-                defaults={
-                    "name": name,
-                    "sni": row.sni or "",
-                    "status": MonitoredEndpointStatusChoices.STATUS_PENDING,
-                },
+                defaults=defaults,
             )
             if created:
                 created_count += 1
@@ -149,3 +167,56 @@ class MonitoredEndpointImportView(LoginRequiredMixin, View):
                 "errors": result.errors,
             },
         )
+
+    @staticmethod
+    def _resolve_tenant(ref, user_tenants):
+        """Resolve a tenant name/slug/ID string against the user's accessible tenants."""
+        ref = (ref or "").strip()
+        if not ref:
+            return None
+        if ref.isdigit():
+            tenant = user_tenants.filter(pk=int(ref)).first()
+            if tenant:
+                return tenant
+        return user_tenants.filter(name=ref).first() or user_tenants.filter(slug=ref).first()
+
+    @staticmethod
+    def _resolve_assignment(
+        device_ref: str,
+        vm_ref: str,
+        service_ref: str,
+    ) -> tuple:
+        """Resolve device/VM/service reference strings to (ContentType, pk) or (None, None).
+
+        Priority: service > device > VM (mirrors MonitoredEndpointForm.save()).
+        Reference format: name or numeric ID.  Returns (None, None) when no ref given
+        or no matching object found — callers should skip setting assigned_object fields.
+        """
+        from dcim.models import Device
+        from ipam.models import Service
+        from virtualization.models import VirtualMachine
+
+        def _lookup(qs, ref):
+            ref = (ref or "").strip()
+            if not ref:
+                return None
+            if ref.isdigit():
+                return qs.filter(pk=int(ref)).first()
+            return qs.filter(name=ref).first()
+
+        service = _lookup(Service.objects.all(), service_ref)
+        if service:
+            ct = ContentType.objects.get_for_model(Service)
+            return ct, service.pk
+
+        device = _lookup(Device.objects.all(), device_ref)
+        if device:
+            ct = ContentType.objects.get_for_model(Device)
+            return ct, device.pk
+
+        vm = _lookup(VirtualMachine.objects.all(), vm_ref)
+        if vm:
+            ct = ContentType.objects.get_for_model(VirtualMachine)
+            return ct, vm.pk
+
+        return None, None

--- a/netbox_ssl/views/url_import.py
+++ b/netbox_ssl/views/url_import.py
@@ -183,6 +183,9 @@ class UrlImportView(LoginRequiredMixin, View):
         try:
             from ..models import MonitoredEndpoint
 
+            # url is already HTTPS-validated by validate_https_url() inside scrape_and_import
+            # (which ran before this success path), so update_or_create (which bypasses
+            # Model.clean()) is safe here.
             MonitoredEndpoint.objects.update_or_create(
                 url=row["url"],
                 defaults={

--- a/netbox_ssl/views/url_import.py
+++ b/netbox_ssl/views/url_import.py
@@ -14,6 +14,8 @@ references are resolved against the requesting user's accessible objects.
 
 from __future__ import annotations
 
+import logging
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -29,6 +31,8 @@ from ..utils.tls_scraper import TLSScrapeError
 from ..utils.url_bulk_parser import parse as url_parse
 from ..utils.url_cert_import import scrape_and_import
 from ..utils.url_validation import URLValidationError
+
+logger = logging.getLogger(__name__)
 
 
 def _plugin_setting(name: str, default=None):
@@ -176,20 +180,23 @@ class UrlImportView(LoginRequiredMixin, View):
             return {"url": label, "status": "error", "detail": str(exc)}
 
         # #149: keep a MonitoredEndpoint for every imported/matched URL.
-        from ..models import MonitoredEndpoint
+        try:
+            from ..models import MonitoredEndpoint
 
-        MonitoredEndpoint.objects.update_or_create(
-            url=row["url"],
-            defaults={
-                "name": row.get("sni") or row["host"],
-                "sni": row.get("sni") or "",
-                "certificate": outcome.certificate,
-                "tenant": tenant,
-                "last_seen": timezone.now(),
-                "last_checked": timezone.now(),
-                "status": MonitoredEndpointStatusChoices.STATUS_OK,
-            },
-        )
+            MonitoredEndpoint.objects.update_or_create(
+                url=row["url"],
+                defaults={
+                    "name": row.get("sni") or row["host"],
+                    "sni": row.get("sni") or "",
+                    "certificate": outcome.certificate,
+                    "tenant": tenant,
+                    "last_seen": timezone.now(),
+                    "last_checked": timezone.now(),
+                    "status": MonitoredEndpointStatusChoices.STATUS_OK,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("MonitoredEndpoint upsert failed for %s: %s", row["url"], exc)
 
         if not outcome.created:
             return {

--- a/netbox_ssl/views/url_import.py
+++ b/netbox_ssl/views/url_import.py
@@ -19,12 +19,15 @@ from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 
+from ..models import MonitoredEndpointStatusChoices
 from ..utils import CertificateParseError
 from ..utils.tls_scraper import TLSScrapeError
 from ..utils.url_bulk_parser import parse as url_parse
+from ..utils.url_cert_import import scrape_and_import
 from ..utils.url_validation import URLValidationError
 
 
@@ -151,8 +154,6 @@ class UrlImportView(LoginRequiredMixin, View):
 
     def _process_row(self, request, row, allowlist, user_tenants, default_tenant):
         """Validate → scrape → parse → import a single row; return an outcome dict."""
-        from ..utils.url_cert_import import scrape_and_import
-
         label = row["url"]
         tenant = self._resolve_tenant(row.get("tenant"), user_tenants) or default_tenant
         try:
@@ -173,6 +174,22 @@ class UrlImportView(LoginRequiredMixin, View):
             return {"url": label, "status": "error", "detail": str(exc)}
         except Exception as exc:  # noqa: BLE001 - surface per-row, don't abort the batch
             return {"url": label, "status": "error", "detail": str(exc)}
+
+        # #149: keep a MonitoredEndpoint for every imported/matched URL.
+        from ..models import MonitoredEndpoint
+
+        MonitoredEndpoint.objects.update_or_create(
+            url=row["url"],
+            defaults={
+                "name": row.get("sni") or row["host"],
+                "sni": row.get("sni") or "",
+                "certificate": outcome.certificate,
+                "tenant": tenant,
+                "last_seen": timezone.now(),
+                "last_checked": timezone.now(),
+                "status": MonitoredEndpointStatusChoices.STATUS_OK,
+            },
+        )
 
         if not outcome.created:
             return {

--- a/netbox_ssl/views/url_import.py
+++ b/netbox_ssl/views/url_import.py
@@ -14,23 +14,18 @@ references are resolved against the requesting user's accessible objects.
 
 from __future__ import annotations
 
-import socket
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.db import transaction
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 
-from ..models import Certificate, CertificateStatusChoices
-from ..utils import CertificateParseError, CertificateParser, detect_issuing_ca
-from ..utils.tls_scraper import TLSScrapeError, scrape_tls_certificate
+from ..utils import CertificateParseError
+from ..utils.tls_scraper import TLSScrapeError
 from ..utils.url_bulk_parser import parse as url_parse
-from ..utils.url_validation import URLValidationError, validate_https_url
+from ..utils.url_validation import URLValidationError
 
 
 def _plugin_setting(name: str, default=None):
@@ -156,75 +151,43 @@ class UrlImportView(LoginRequiredMixin, View):
 
     def _process_row(self, request, row, allowlist, user_tenants, default_tenant):
         """Validate → scrape → parse → import a single row; return an outcome dict."""
+        from ..utils.url_cert_import import scrape_and_import
+
         label = row["url"]
-
-        # 1. SSRF validation (resolves DNS and checks every resolved IP).
+        tenant = self._resolve_tenant(row.get("tenant"), user_tenants) or default_tenant
         try:
-            validate_https_url(row["url"], cidr_allowlist=allowlist)
-        except URLValidationError as exc:
-            return {"url": label, "status": "blocked", "detail": str(exc)}
-
-        # 2. Resolve to a concrete IP and connect to THAT ip (DNS-rebinding defense).
-        try:
-            resolved_ip = socket.getaddrinfo(row["host"], row["port"])[0][4][0]
-        except OSError as exc:
-            return {"url": label, "status": "unreachable", "detail": f"DNS failed: {exc}"}
-
-        # 3. Scrape the presented chain.
-        try:
-            pem = scrape_tls_certificate(
-                resolved_ip,
+            outcome = scrape_and_import(
+                row["url"],
                 row["host"],
                 row["port"],
                 sni=row["sni"],
                 verify_chain=row["verify_chain"],
+                allowlist=allowlist,
+                tenant=tenant,
             )
+        except URLValidationError as exc:
+            return {"url": label, "status": "blocked", "detail": str(exc)}
         except TLSScrapeError as exc:
             return {"url": label, "status": "unreachable", "detail": str(exc)}
-
-        # 4. Parse.
-        try:
-            parsed = CertificateParser.parse(pem)
         except CertificateParseError as exc:
             return {"url": label, "status": "error", "detail": str(exc)}
-
-        # 5. Dedup on serial+issuer (same as Smart Paste / bulk import).
-        existing = Certificate.objects.filter(serial_number=parsed.serial_number, issuer=parsed.issuer).first()
-        if existing:
-            existing.last_seen_at = timezone.now()
-            if not existing.discovered_via_url:
-                existing.discovered_via_url = row["url"]
-            existing.save(update_fields=["last_seen_at", "discovered_via_url"])
-            return {"url": label, "status": "matched", "detail": parsed.common_name, "pk": existing.pk}
-
-        # 6. Create.
-        tenant = self._resolve_tenant(row.get("tenant"), user_tenants) or default_tenant
-        try:
-            with transaction.atomic():
-                cert = Certificate.objects.create(
-                    common_name=parsed.common_name,
-                    serial_number=parsed.serial_number,
-                    fingerprint_sha256=parsed.fingerprint_sha256,
-                    issuer=parsed.issuer,
-                    issuing_ca=detect_issuing_ca(parsed.issuer),
-                    valid_from=parsed.valid_from,
-                    valid_to=parsed.valid_to,
-                    sans=parsed.sans or [],
-                    key_size=parsed.key_size,
-                    algorithm=parsed.algorithm,
-                    status=CertificateStatusChoices.STATUS_ACTIVE,
-                    pem_content=parsed.pem_content,
-                    issuer_chain=parsed.issuer_chain,
-                    tenant=tenant,
-                    discovered_via_url=row["url"],
-                    last_seen_at=timezone.now(),
-                )
-                cert.auto_detect_acme(save=True)
         except Exception as exc:  # noqa: BLE001 - surface per-row, don't abort the batch
             return {"url": label, "status": "error", "detail": str(exc)}
 
+        if not outcome.created:
+            return {
+                "url": label,
+                "status": "matched",
+                "detail": outcome.certificate.common_name,
+                "pk": outcome.certificate.pk,
+            }
         status = "imported" if row["verify_chain"] else "imported_untrusted"
-        return {"url": label, "status": status, "detail": parsed.common_name, "pk": cert.pk}
+        return {
+            "url": label,
+            "status": status,
+            "detail": outcome.certificate.common_name,
+            "pk": outcome.certificate.pk,
+        }
 
     @staticmethod
     def _resolve_tenant(ref, user_tenants):

--- a/project-requirement-document/plans/2026-06-20-149-website-centric-monitoring.md
+++ b/project-requirement-document/plans/2026-06-20-149-website-centric-monitoring.md
@@ -1,0 +1,1128 @@
+# Website-Centric Certificate Monitoring (#149) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track the certificate each monitored website (URL) presents over time — with a re-poll script, rotation history, per-endpoint events, and a website-centric view — reusing #106's TLS scraper and the v0.6 event machinery.
+
+**Architecture:** A new `MonitoredEndpoint` model points to the `Certificate` it currently presents; a `MonitoredEndpointCertificate` table records rotation history. A shared `scrape_and_import` service (extracted from #106's inline `_process_row`) is reused by both #106 and a new `poll_endpoint` service. A NetBox-scheduled Script polls all endpoints. Endpoint events fire through the same `last_updated`-touch mechanism as certificate events.
+
+**Tech Stack:** Django, NetBox plugin framework (`NetBoxModel`, generic views, `Script`), Python `ssl`/`socket` (via the existing `tls_scraper`), pytest (`@pytest.mark.django_db`).
+
+## Global Constraints
+
+- **NetBox compatibility:** 4.4–4.6; **Python:** 3.10–3.12.
+- **Spec:** `project-requirement-document/specs/2026-06-20-149-website-centric-monitoring-design.md`. **Target release:** v1.3.
+- **One additive migration** (two new models); **no changes to existing models** (so no data migration). Generate via real `makemigrations` (NetBox container needs `DEVELOPER=True`); grep the new migration for `custom_field_data` + `tags` on the `NetBoxModel` model.
+- **Reuse #106's security model unchanged:** all scraping via `tls_scraper.scrape_tls_certificate` (HTTPS-only, connect to the pre-validated IP — never re-resolve, timeout/size caps); URL validated via `url_validation.validate_https_url(url, cidr_allowlist=...)` before every scrape; private/loopback blocked unless allowlisted via `PLUGINS_CONFIG["netbox_ssl"]["url_import_private_cidr_allowlist"]`; self-signed/untrusted never auto-trusted (recorded `status="untrusted"`).
+- **#106 behavior must be unchanged** after the `scrape_and_import` extraction (parity tests required).
+- **Security v0.7.5:** every custom view uses `LoginRequiredMixin` first + `.restrict()`; writes perm-gated; DB/scrape errors logged internally (`last_error`), generic messages surfaced.
+- **Endpoint status values:** `pending` / `ok` / `unreachable` / `untrusted` only. Rotation is an event + a history row, never a status — a reachable, trusted endpoint stays `ok` right after rotating.
+- **Style:** PEP 8, type annotations, black/isort/ruff clean.
+
+## Test Execution
+
+Tests are `@pytest.mark.django_db` and run **inside the running NetBox container** `netbox-ssl-netbox-1` (pytest + pytest-django installed). Copy `tests/` **and** `pytest.ini` to `/tmp/plugin_tests/` before each run (`pytest.ini` supplies `DJANGO_SETTINGS_MODULE=netbox.settings`). Canonical command (per-step `docker cp tests/...` lines are shorthand for it):
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/<FILE> -v --tb=short
+```
+~90s per run (NetBox migration build for the test DB) — normal, be patient. All scraping is **mocked** in tests (no real network): patch `netbox_ssl.utils.url_cert_import.scrape_tls_certificate` (and `validate_https_url`/`socket.getaddrinfo`) to return a fixed PEM or raise `TLSScrapeError`.
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `netbox_ssl/models/monitored_endpoint.py` | **new** — `MonitoredEndpoint`, `MonitoredEndpointCertificate`, `MonitoredEndpointStatusChoices` |
+| `netbox_ssl/models/__init__.py` | export the new models + choices |
+| `netbox_ssl/migrations/00XX_monitored_endpoint.py` | **new** (generated) — additive |
+| `netbox_ssl/utils/url_cert_import.py` | **new** — `ImportOutcome` + `scrape_and_import()` (extracted from #106) |
+| `netbox_ssl/views/url_import.py` | refactor `_process_row` to call `scrape_and_import` (behavior unchanged) |
+| `netbox_ssl/utils/endpoint_monitor.py` | **new** — `PollResult` + `poll_endpoint()` |
+| `netbox_ssl/utils/events.py` | add `EVENT_ENDPOINT_*` + `build_endpoint_event_payload` + `fire_endpoint_event` |
+| `netbox_ssl/scripts/endpoint_monitor.py` | **new** — `MonitoredEndpointPoll(Script)` |
+| `netbox_ssl/tables/monitored_endpoints.py`, `filtersets/`, `forms/`, `views/monitored_endpoints.py` | **new** CRUD (mirror `ExternalSource`) |
+| `netbox_ssl/urls.py`, `navigation.py` | register endpoint routes + nav |
+| `netbox_ssl/templates/netbox_ssl/monitoredendpoint.html` | endpoint detail incl. rotation-history tab |
+| `netbox_ssl/templates/netbox_ssl/certificate.html` | new "Monitored Endpoints" tab |
+| `netbox_ssl/views/certificates.py` | add monitored-endpoints to the certificate detail context |
+| `tests/test_monitored_endpoint_model.py`, `test_url_cert_import.py`, `test_endpoint_monitor.py`, `test_endpoint_poll_script.py`, `test_monitored_endpoint_views.py` | **new** tests |
+| `CHANGELOG.md` | `Unreleased` → Added |
+
+**Out of scope (YAGNI, not in spec):** REST API / GraphQL for `MonitoredEndpoint` (file a follow-up if wanted), per-endpoint scheduling, IPv6, STARTTLS.
+
+---
+
+## Task 1: Models + migration
+
+**Files:**
+- Create: `netbox_ssl/models/monitored_endpoint.py`
+- Modify: `netbox_ssl/models/__init__.py`
+- Create (generated): `netbox_ssl/migrations/00XX_monitored_endpoint.py`
+- Test: `tests/test_monitored_endpoint_model.py`
+
+**Interfaces:**
+- Produces:
+  - `MonitoredEndpointStatusChoices` (ChoiceSet) with `STATUS_PENDING="pending"`, `STATUS_OK="ok"`, `STATUS_UNREACHABLE="unreachable"`, `STATUS_UNTRUSTED="untrusted"`.
+  - `MonitoredEndpoint(NetBoxModel)` fields: `name` (CharField), `url` (CharField), `sni` (CharField, blank), `certificate` (FK→Certificate, null, `SET_NULL`, related_name `monitored_endpoints`), `assigned_object_type`/`assigned_object_id`/`assigned_object` (GenericFK, null, allowlist device/virtualmachine/service), `tenant` (FK→tenancy.Tenant, null, `SET_NULL`), `status` (CharField, choices, default `pending`), `last_checked`/`last_seen` (DateTimeField, null), `last_error` (TextField, blank). `get_absolute_url()`. `@property days_remaining` → `self.certificate.days_remaining if self.certificate else None`.
+  - `MonitoredEndpointCertificate(models.Model)` fields: `endpoint` (FK, CASCADE, related_name `cert_history`), `certificate` (FK→Certificate, CASCADE), `first_seen`/`last_seen` (DateTimeField). `UniqueConstraint(endpoint, certificate)`, `ordering = ["-last_seen"]`.
+
+- [ ] **Step 1: Write the failing model test**
+
+Create `tests/test_monitored_endpoint_model.py`:
+
+```python
+"""Unit tests for the MonitoredEndpoint models."""
+
+import uuid
+import datetime
+import pytest
+from django.utils import timezone
+
+
+def _make_cert(serial=None):
+    from netbox_ssl.models import Certificate
+
+    uid = uuid.uuid4().hex[:8]
+    return Certificate.objects.create(
+        common_name=f"{uid}.example.com",
+        serial_number=serial or f"SER:{uid}",
+        issuer="Test CA",
+        valid_from=timezone.now(),
+        valid_to=timezone.now() + datetime.timedelta(days=365),
+        fingerprint_sha256=":".join([f"{(i % 256):02X}" for i in range(32)]),
+        algorithm="RSA",
+    )
+
+
+@pytest.mark.django_db
+class TestMonitoredEndpoint:
+    def test_create_and_link_certificate(self):
+        from netbox_ssl.models import MonitoredEndpoint, MonitoredEndpointStatusChoices
+
+        cert = _make_cert()
+        ep = MonitoredEndpoint.objects.create(
+            name="HR portal", url="https://hr.example.com:443", certificate=cert
+        )
+        assert ep.status == MonitoredEndpointStatusChoices.STATUS_PENDING
+        assert ep.certificate == cert
+        assert ep.days_remaining == cert.days_remaining
+
+    def test_certificate_set_null_on_delete(self):
+        from netbox_ssl.models import MonitoredEndpoint
+
+        cert = _make_cert()
+        ep = MonitoredEndpoint.objects.create(name="x", url="https://x.example.com", certificate=cert)
+        cert.delete()
+        ep.refresh_from_db()
+        assert ep.certificate is None
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_monitored_endpoint_model.py -v --tb=short
+```
+Expected: FAIL — `ImportError: cannot import name 'MonitoredEndpoint'`.
+
+- [ ] **Step 3: Write the models**
+
+Create `netbox_ssl/models/monitored_endpoint.py`:
+
+```python
+"""Models for website-centric certificate monitoring (#149)."""
+
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.db import models
+from django.urls import reverse
+from netbox.models import NetBoxModel
+from utilities.choices import ChoiceSet
+
+
+class MonitoredEndpointStatusChoices(ChoiceSet):
+    STATUS_PENDING = "pending"
+    STATUS_OK = "ok"
+    STATUS_UNREACHABLE = "unreachable"
+    STATUS_UNTRUSTED = "untrusted"
+
+    CHOICES = [
+        (STATUS_PENDING, "Pending", "gray"),
+        (STATUS_OK, "OK", "green"),
+        (STATUS_UNREACHABLE, "Unreachable", "red"),
+        (STATUS_UNTRUSTED, "Untrusted", "orange"),
+    ]
+
+
+class MonitoredEndpoint(NetBoxModel):
+    """A monitored website/URL whose presented certificate is tracked over time."""
+
+    name = models.CharField(max_length=200, help_text="Human label, e.g. 'HR portal'.")
+    url = models.CharField(max_length=500, help_text="https://host:port to monitor.")
+    sni = models.CharField(max_length=255, blank=True, help_text="Optional SNI override (defaults to the URL host).")
+    certificate = models.ForeignKey(
+        to="netbox_ssl.Certificate",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="monitored_endpoints",
+        help_text="The certificate this endpoint currently presents.",
+    )
+    assigned_object_type = models.ForeignKey(
+        to="contenttypes.ContentType",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        limit_choices_to={"model__in": ["service", "device", "virtualmachine"]},
+    )
+    assigned_object_id = models.PositiveBigIntegerField(null=True, blank=True)
+    assigned_object = GenericForeignKey(ct_field="assigned_object_type", fk_field="assigned_object_id")
+    tenant = models.ForeignKey(
+        to="tenancy.Tenant", on_delete=models.SET_NULL, null=True, blank=True, related_name="+"
+    )
+    status = models.CharField(
+        max_length=20,
+        choices=MonitoredEndpointStatusChoices,
+        default=MonitoredEndpointStatusChoices.STATUS_PENDING,
+    )
+    last_checked = models.DateTimeField(null=True, blank=True)
+    last_seen = models.DateTimeField(null=True, blank=True)
+    last_error = models.TextField(blank=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_ssl:monitoredendpoint", args=[self.pk])
+
+    @property
+    def days_remaining(self):
+        return self.certificate.days_remaining if self.certificate else None
+
+
+class MonitoredEndpointCertificate(models.Model):
+    """Rotation history: which certificate an endpoint presented, and when."""
+
+    endpoint = models.ForeignKey(
+        to=MonitoredEndpoint, on_delete=models.CASCADE, related_name="cert_history"
+    )
+    certificate = models.ForeignKey(to="netbox_ssl.Certificate", on_delete=models.CASCADE)
+    first_seen = models.DateTimeField()
+    last_seen = models.DateTimeField()
+
+    class Meta:
+        ordering = ["-last_seen"]
+        constraints = [
+            models.UniqueConstraint(fields=["endpoint", "certificate"], name="unique_endpoint_certificate"),
+        ]
+
+    def __str__(self):
+        return f"{self.endpoint} → {self.certificate}"
+```
+
+Add to `netbox_ssl/models/__init__.py` (mirror the existing import + `__all__` style):
+
+```python
+from .monitored_endpoint import (
+    MonitoredEndpoint,
+    MonitoredEndpointCertificate,
+    MonitoredEndpointStatusChoices,
+)
+```
+and add the three names to `__all__`.
+
+- [ ] **Step 4: Generate the migration**
+
+```bash
+docker exec -e DEVELOPER=True netbox-ssl-netbox-1 python /opt/netbox/netbox/manage.py makemigrations netbox_ssl -n monitored_endpoint
+docker cp netbox-ssl-netbox-1:/opt/netbox/netbox/netbox_ssl/migrations/. netbox_ssl/migrations/
+```
+Then **grep the new migration** to confirm `custom_field_data` and `tags` fields are present on `MonitoredEndpoint` (it inherits `NetBoxModel`):
+```bash
+grep -E "custom_field_data|tags" netbox_ssl/migrations/00XX_monitored_endpoint.py
+```
+Expected: both appear. If absent, the model didn't inherit `NetBoxModel` correctly — fix before continuing.
+
+- [ ] **Step 5: Run model tests (migration applied automatically by pytest-django)**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ \
+  && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_monitored_endpoint_model.py -v --tb=short
+```
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Add history + "which sites share a cert" tests**
+
+Append to `TestMonitoredEndpoint`:
+
+```python
+    def test_rotation_history_unique_constraint(self):
+        from django.db import IntegrityError
+        from netbox_ssl.models import MonitoredEndpoint, MonitoredEndpointCertificate
+
+        cert = _make_cert()
+        ep = MonitoredEndpoint.objects.create(name="x", url="https://x.example.com")
+        now = timezone.now()
+        MonitoredEndpointCertificate.objects.create(endpoint=ep, certificate=cert, first_seen=now, last_seen=now)
+        with pytest.raises(IntegrityError):
+            MonitoredEndpointCertificate.objects.create(endpoint=ep, certificate=cert, first_seen=now, last_seen=now)
+
+    def test_which_sites_share_a_certificate(self):
+        from netbox_ssl.models import MonitoredEndpoint
+
+        cert = _make_cert()
+        MonitoredEndpoint.objects.create(name="a", url="https://a.example.com", certificate=cert)
+        MonitoredEndpoint.objects.create(name="b", url="https://b.example.com", certificate=cert)
+        MonitoredEndpoint.objects.create(name="c", url="https://c.example.com", certificate=_make_cert())
+        assert MonitoredEndpoint.objects.filter(certificate=cert).count() == 2
+```
+
+- [ ] **Step 7: Run, lint, commit**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_monitored_endpoint_model.py -v --tb=short
+ruff check netbox_ssl/models/monitored_endpoint.py tests/test_monitored_endpoint_model.py
+git add netbox_ssl/models/ netbox_ssl/migrations/ tests/test_monitored_endpoint_model.py
+git commit -m "feat: add MonitoredEndpoint + rotation-history models (#149)"
+```
+Expected: 4 passed; ruff clean.
+
+---
+
+## Task 2: Shared scrape-and-import service (extract from #106)
+
+**Files:**
+- Create: `netbox_ssl/utils/url_cert_import.py`
+- Modify: `netbox_ssl/views/url_import.py` (`_process_row` calls the service)
+- Modify: `netbox_ssl/utils/__init__.py` (export)
+- Test: `tests/test_url_cert_import.py`
+
+**Interfaces:**
+- Consumes: `scrape_tls_certificate`, `TLSScrapeError` (`utils/tls_scraper.py`); `validate_https_url`, `URLValidationError` (`utils/url_validation.py`); `CertificateParser`, `CertificateParseError`, `detect_issuing_ca` (`utils/parser.py` / utils).
+- Produces:
+  - `@dataclass(frozen=True) class ImportOutcome` with `certificate` (Certificate), `created` (bool).
+  - `scrape_and_import(url: str, host: str, port: int, *, sni: str | None = None, verify_chain: bool = True, allowlist, tenant=None, set_discovered_url: bool = True) -> ImportOutcome`. Raises `URLValidationError`, `TLSScrapeError`, `CertificateParseError`. (Rotation is NOT computed here — it is endpoint-specific and lives in `poll_endpoint`.)
+
+- [ ] **Step 1: Write the failing test** (`tests/test_url_cert_import.py`)
+
+```python
+"""Unit tests for the shared scrape-and-import service."""
+
+import uuid
+import pytest
+from unittest.mock import patch
+
+# A minimal self-signed-ish PEM is not needed: we mock the scraper to return a
+# real fixture PEM and let the real parser run. Reuse the project's cert factory.
+from tests.cert_factory import generate_self_signed_pem  # noqa: E402
+
+
+@pytest.mark.django_db
+class TestScrapeAndImport:
+    def _pem(self):
+        return generate_self_signed_pem(common_name=f"{uuid.uuid4().hex[:8]}.example.com")
+
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch("netbox_ssl.utils.url_cert_import.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("203.0.113.10", 443))])
+    @patch("netbox_ssl.utils.url_cert_import.scrape_tls_certificate")
+    def test_creates_certificate_on_miss(self, mock_scrape, _gai, _val):
+        from netbox_ssl.models import Certificate
+        from netbox_ssl.utils.url_cert_import import scrape_and_import
+
+        mock_scrape.return_value = self._pem()
+        before = Certificate.objects.count()
+        outcome = scrape_and_import("https://a.example.com", "a.example.com", 443, allowlist=[])
+        assert outcome.created is True
+        assert Certificate.objects.count() == before + 1
+        assert outcome.certificate.discovered_via_url == "https://a.example.com"
+```
+
+> If `tests/cert_factory.py` lacks `generate_self_signed_pem`, use the existing factory function it does export (check the file) and adapt the call; the goal is a parseable PEM string.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_url_cert_import.py -v --tb=short
+```
+Expected: FAIL — `ModuleNotFoundError: ...url_cert_import`.
+
+- [ ] **Step 3: Write the service** (`netbox_ssl/utils/url_cert_import.py`)
+
+```python
+"""Shared 'scrape a URL → parse → import-or-match' service.
+
+Extracted from views/url_import.py so both the #106 URL import and the #149
+endpoint poll use one code path. Raises on failure (callers map to their own
+outcome shapes); never swallows.
+"""
+
+import socket
+from dataclasses import dataclass
+
+from django.db import transaction
+from django.utils import timezone
+
+from ..models import Certificate, CertificateStatusChoices
+from .parser import CertificateParseError, CertificateParser
+from .tls_scraper import TLSScrapeError, scrape_tls_certificate
+from .url_validation import URLValidationError, validate_https_url
+from . import detect_issuing_ca
+
+
+@dataclass(frozen=True)
+class ImportOutcome:
+    certificate: "Certificate"
+    created: bool
+
+
+def scrape_and_import(
+    url: str,
+    host: str,
+    port: int,
+    *,
+    sni: str | None = None,
+    verify_chain: bool = True,
+    allowlist,
+    tenant=None,
+    set_discovered_url: bool = True,
+) -> ImportOutcome:
+    """Validate, scrape, parse, and import-or-match the cert presented at a URL.
+
+    Raises URLValidationError / TLSScrapeError / CertificateParseError.
+    """
+    validate_https_url(url, cidr_allowlist=allowlist)
+    resolved_ip = socket.getaddrinfo(host, port)[0][4][0]
+    pem = scrape_tls_certificate(resolved_ip, host, port, sni=sni, verify_chain=verify_chain)
+    parsed = CertificateParser.parse(pem)
+
+    existing = Certificate.objects.filter(
+        serial_number=parsed.serial_number, issuer=parsed.issuer
+    ).first()
+    if existing:
+        existing.last_seen_at = timezone.now()
+        if set_discovered_url and not existing.discovered_via_url:
+            existing.discovered_via_url = url
+        existing.save(update_fields=["last_seen_at", "discovered_via_url"])
+        return ImportOutcome(certificate=existing, created=False)
+
+    with transaction.atomic():
+        cert = Certificate.objects.create(
+            common_name=parsed.common_name,
+            serial_number=parsed.serial_number,
+            fingerprint_sha256=parsed.fingerprint_sha256,
+            issuer=parsed.issuer,
+            issuing_ca=detect_issuing_ca(parsed.issuer),
+            valid_from=parsed.valid_from,
+            valid_to=parsed.valid_to,
+            sans=parsed.sans or [],
+            key_size=parsed.key_size,
+            algorithm=parsed.algorithm,
+            status=CertificateStatusChoices.STATUS_ACTIVE,
+            pem_content=parsed.pem_content,
+            issuer_chain=parsed.issuer_chain,
+            tenant=tenant,
+            discovered_via_url=url if set_discovered_url else "",
+            last_seen_at=timezone.now(),
+        )
+        cert.auto_detect_acme(save=True)
+    return ImportOutcome(certificate=cert, created=True)
+```
+
+> **Circular-import warning:** import `detect_issuing_ca` from its **defining submodule**, NOT from `from . import detect_issuing_ca` — Step 6 adds `url_cert_import` to `utils/__init__.py`, so importing it back from the package `__init__` would be circular. Grep for its definition (`grep -rn "def detect_issuing_ca" netbox_ssl/utils/`) and import from that module directly (e.g. `from .ca_detector import detect_issuing_ca`). Same for `CertificateParser`/`CertificateParseError` — import from `.parser`. The example above uses `from . import detect_issuing_ca`; replace it with the direct submodule path once you confirm it.
+
+- [ ] **Step 4: Run the create test (GREEN)**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_url_cert_import.py -v --tb=short
+```
+Expected: PASS.
+
+- [ ] **Step 5: Add the match (dedup) test**
+
+```python
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch("netbox_ssl.utils.url_cert_import.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("203.0.113.10", 443))])
+    @patch("netbox_ssl.utils.url_cert_import.scrape_tls_certificate")
+    def test_matches_existing_on_second_call(self, mock_scrape, _gai, _val):
+        from netbox_ssl.models import Certificate
+        from netbox_ssl.utils.url_cert_import import scrape_and_import
+
+        pem = self._pem()
+        mock_scrape.return_value = pem
+        first = scrape_and_import("https://a.example.com", "a.example.com", 443, allowlist=[])
+        before = Certificate.objects.count()
+        second = scrape_and_import("https://a.example.com", "a.example.com", 443, allowlist=[])
+        assert second.created is False
+        assert second.certificate.pk == first.certificate.pk
+        assert Certificate.objects.count() == before
+```
+
+- [ ] **Step 6: Refactor `_process_row` to call the service**
+
+In `netbox_ssl/views/url_import.py`, replace the body of `_process_row` (steps 1–6, lines ~157–227) so it calls `scrape_and_import` and maps exceptions to the **existing outcome dict shapes** (do not change the returned keys/values — the result template depends on them):
+
+```python
+    def _process_row(self, request, row, allowlist, user_tenants, default_tenant):
+        """Validate → scrape → parse → import a single row; return an outcome dict."""
+        from ..utils.url_cert_import import scrape_and_import
+
+        label = row["url"]
+        tenant = self._resolve_tenant(row.get("tenant"), user_tenants) or default_tenant
+        try:
+            outcome = scrape_and_import(
+                row["url"], row["host"], row["port"],
+                sni=row["sni"], verify_chain=row["verify_chain"],
+                allowlist=allowlist, tenant=tenant,
+            )
+        except URLValidationError as exc:
+            return {"url": label, "status": "blocked", "detail": str(exc)}
+        except TLSScrapeError as exc:
+            return {"url": label, "status": "unreachable", "detail": str(exc)}
+        except CertificateParseError as exc:
+            return {"url": label, "status": "error", "detail": str(exc)}
+        except Exception as exc:  # noqa: BLE001 - surface per-row, don't abort the batch
+            return {"url": label, "status": "error", "detail": str(exc)}
+
+        if not outcome.created:
+            return {"url": label, "status": "matched", "detail": outcome.certificate.common_name, "pk": outcome.certificate.pk}
+        status = "imported" if row["verify_chain"] else "imported_untrusted"
+        return {"url": label, "status": status, "detail": outcome.certificate.common_name, "pk": outcome.certificate.pk}
+```
+
+Leave the surrounding imports in `url_import.py` (they are still referenced by the except clauses). Add `"scrape_and_import"`, `"ImportOutcome"` to `netbox_ssl/utils/__init__.py` exports.
+
+- [ ] **Step 7: #106 parity test**
+
+Add `tests/test_url_cert_import.py::TestProcessRowParity` asserting the refactored view path still returns the documented outcome shapes for matched/imported. If `tests/test_bulk_data_import.py` or an existing URL-import test exercises `_process_row`/`_scan_and_import`, run that file too and confirm it still passes:
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_url_cert_import.py -v --tb=short
+```
+Expected: PASS. Then grep for an existing url-import test and run it to confirm unchanged behavior.
+
+- [ ] **Step 8: Lint, commit**
+
+```bash
+ruff check netbox_ssl/utils/url_cert_import.py netbox_ssl/views/url_import.py tests/test_url_cert_import.py
+git add netbox_ssl/utils/url_cert_import.py netbox_ssl/utils/__init__.py netbox_ssl/views/url_import.py tests/test_url_cert_import.py
+git commit -m "refactor: extract shared scrape_and_import service from URL import (#149)"
+```
+
+---
+
+## Task 3: Endpoint poll service + endpoint events
+
+**Files:**
+- Create: `netbox_ssl/utils/endpoint_monitor.py`
+- Modify: `netbox_ssl/utils/events.py` (endpoint event types + helpers)
+- Test: `tests/test_endpoint_monitor.py`
+
+**Interfaces:**
+- Consumes: `scrape_and_import`, `ImportOutcome` (Task 2); `TLSScrapeError`, `URLValidationError`; `MonitoredEndpoint`, `MonitoredEndpointCertificate`, `MonitoredEndpointStatusChoices` (Task 1).
+- Produces:
+  - `utils/events.py`: `EVENT_ENDPOINT_UNREACHABLE="endpoint_unreachable"`, `EVENT_ENDPOINT_CERT_ROTATED="endpoint_cert_rotated"`, `EVENT_ENDPOINT_UNTRUSTED_CERT="endpoint_untrusted_cert"`; `build_endpoint_event_payload(endpoint, event_type, extra=None) -> dict`; `fire_endpoint_event(endpoint, event_type, extra=None) -> dict`.
+  - `utils/endpoint_monitor.py`: `@dataclass(frozen=True) class PollResult` (`endpoint`, `status: str`, `rotated: bool`, `events_fired: tuple[str, ...]`); `poll_endpoint(endpoint, *, allowlist) -> PollResult`.
+
+- [ ] **Step 1: Write the failing event-helper test** (`tests/test_endpoint_monitor.py`)
+
+```python
+"""Unit tests for endpoint events + the poll service."""
+
+import uuid
+import datetime
+import pytest
+from unittest.mock import patch
+from django.utils import timezone
+
+
+def _make_cert(serial=None):
+    from netbox_ssl.models import Certificate
+
+    uid = uuid.uuid4().hex[:8]
+    return Certificate.objects.create(
+        common_name=f"{uid}.example.com", serial_number=serial or f"SER:{uid}",
+        issuer="Test CA", valid_from=timezone.now(),
+        valid_to=timezone.now() + datetime.timedelta(days=365),
+        fingerprint_sha256=":".join([f"{(i % 256):02X}" for i in range(32)]), algorithm="RSA",
+    )
+
+
+@pytest.mark.django_db
+class TestEndpointEventPayload:
+    def test_payload_has_endpoint_fields(self):
+        from netbox_ssl.models import MonitoredEndpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_UNREACHABLE, build_endpoint_event_payload
+
+        ep = MonitoredEndpoint.objects.create(name="hr", url="https://hr.example.com")
+        payload = build_endpoint_event_payload(ep, EVENT_ENDPOINT_UNREACHABLE)
+        assert payload["event_type"] == EVENT_ENDPOINT_UNREACHABLE
+        assert payload["endpoint_id"] == ep.pk
+        assert payload["url"] == "https://hr.example.com"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_endpoint_monitor.py -v --tb=short
+```
+Expected: FAIL — `ImportError: cannot import name 'EVENT_ENDPOINT_UNREACHABLE'`.
+
+- [ ] **Step 3: Add endpoint events to `utils/events.py`**
+
+Append:
+
+```python
+EVENT_ENDPOINT_UNREACHABLE = "endpoint_unreachable"
+EVENT_ENDPOINT_CERT_ROTATED = "endpoint_cert_rotated"
+EVENT_ENDPOINT_UNTRUSTED_CERT = "endpoint_untrusted_cert"
+
+
+def build_endpoint_event_payload(endpoint: Any, event_type: str, extra: dict | None = None) -> dict:
+    """Build a standardized event payload for a monitored-endpoint event."""
+    cert = endpoint.certificate
+    payload = {
+        "event_type": event_type,
+        "endpoint_id": endpoint.pk,
+        "name": endpoint.name,
+        "url": endpoint.url,
+        "status": endpoint.status,
+        "certificate_id": cert.pk if cert else None,
+        "common_name": cert.common_name if cert else None,
+        "days_remaining": cert.days_remaining if cert else None,
+        "tenant": endpoint.tenant.name if endpoint.tenant else None,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def fire_endpoint_event(endpoint: Any, event_type: str, extra: dict | None = None) -> dict:
+    """Fire a monitored-endpoint event by touching last_updated (same mechanism as certs)."""
+    payload = build_endpoint_event_payload(endpoint, event_type, extra=extra)
+    try:
+        from django.utils import timezone as dj_timezone
+
+        type(endpoint).objects.filter(pk=endpoint.pk).update(last_updated=dj_timezone.now())
+    except Exception as e:
+        logger.warning("Could not update last_updated for endpoint %s: %s", endpoint.pk, e)
+    return payload
+```
+
+- [ ] **Step 4: Run the payload test (GREEN)**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_endpoint_monitor.py -v --tb=short
+```
+Expected: PASS.
+
+- [ ] **Step 5: Write the poll-service tests**
+
+```python
+@pytest.mark.django_db
+class TestPollEndpoint:
+    def _ep(self, **kw):
+        from netbox_ssl.models import MonitoredEndpoint
+        return MonitoredEndpoint.objects.create(name="hr", url="https://hr.example.com:443", **kw)
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_ok_links_cert_and_history(self, mock_import):
+        from netbox_ssl.models import MonitoredEndpointCertificate, MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+
+        cert = _make_cert()
+        mock_import.return_value = ImportOutcome(certificate=cert, created=True)
+        ep = self._ep()
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_OK
+        assert ep.certificate == cert
+        assert ep.last_seen is not None
+        assert MonitoredEndpointCertificate.objects.filter(endpoint=ep, certificate=cert).count() == 1
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_unreachable_fires_event(self, mock_import):
+        from netbox_ssl.utils.tls_scraper import TLSScrapeError
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_UNREACHABLE
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+
+        mock_import.side_effect = TLSScrapeError("connection refused")
+        ep = self._ep()
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_UNREACHABLE
+        assert EVENT_ENDPOINT_UNREACHABLE in result.events_fired
+        assert ep.last_error
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_rotation_fires_event_and_keeps_status_ok(self, mock_import):
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_CERT_ROTATED
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+
+        cert_a, cert_b = _make_cert(), _make_cert()
+        ep = self._ep(certificate=cert_a)
+        mock_import.return_value = ImportOutcome(certificate=cert_b, created=False)
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.rotated is True
+        assert ep.certificate == cert_b
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_OK
+        assert EVENT_ENDPOINT_CERT_ROTATED in result.events_fired
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_untrusted_when_verify_fails_then_succeeds(self, mock_import):
+        from netbox_ssl.utils.tls_scraper import TLSScrapeError
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_UNTRUSTED_CERT
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+
+        cert = _make_cert()
+        # First (verify_chain=True) raises; second (verify_chain=False) succeeds.
+        mock_import.side_effect = [TLSScrapeError("self-signed"), ImportOutcome(certificate=cert, created=True)]
+        ep = self._ep()
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_UNTRUSTED
+        assert ep.certificate == cert
+        assert EVENT_ENDPOINT_UNTRUSTED_CERT in result.events_fired
+```
+
+- [ ] **Step 6: Run to verify they fail**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_endpoint_monitor.py::TestPollEndpoint -v --tb=short
+```
+Expected: FAIL — `ImportError: ...endpoint_monitor`.
+
+- [ ] **Step 7: Write the poll service** (`netbox_ssl/utils/endpoint_monitor.py`)
+
+```python
+"""Poll a MonitoredEndpoint: scrape its cert, link it, track rotation, fire events."""
+
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+from django.db import transaction
+from django.utils import timezone
+
+from ..models import MonitoredEndpointCertificate, MonitoredEndpointStatusChoices
+from .events import (
+    EVENT_ENDPOINT_CERT_ROTATED,
+    EVENT_ENDPOINT_UNREACHABLE,
+    EVENT_ENDPOINT_UNTRUSTED_CERT,
+    fire_endpoint_event,
+)
+from .tls_scraper import TLSScrapeError
+from .url_cert_import import scrape_and_import
+from .url_validation import URLValidationError
+
+
+@dataclass(frozen=True)
+class PollResult:
+    endpoint: "object"
+    status: str
+    rotated: bool
+    events_fired: tuple[str, ...]
+
+
+def _host_port(url: str) -> tuple[str, int]:
+    parts = urlsplit(url)
+    return parts.hostname or "", parts.port or 443
+
+
+def poll_endpoint(endpoint, *, allowlist) -> PollResult:
+    """Scrape the endpoint's current cert and reconcile the endpoint record."""
+    host, port = _host_port(endpoint.url)
+    sni = endpoint.sni or None
+    prev_cert_id = endpoint.certificate_id
+    events: list[str] = []
+    now = timezone.now()
+
+    def _do(verify):
+        return scrape_and_import(
+            endpoint.url, host, port, sni=sni, verify_chain=verify,
+            allowlist=allowlist, tenant=endpoint.tenant, set_discovered_url=True,
+        )
+
+    untrusted = False
+    try:
+        outcome = _do(True)
+    except (TLSScrapeError, URLValidationError):
+        try:
+            outcome = _do(False)
+            untrusted = True
+        except (TLSScrapeError, URLValidationError) as exc:
+            endpoint.status = MonitoredEndpointStatusChoices.STATUS_UNREACHABLE
+            endpoint.last_checked = now
+            endpoint.last_error = str(exc)
+            endpoint.save(update_fields=["status", "last_checked", "last_error"])
+            fire_endpoint_event(endpoint, EVENT_ENDPOINT_UNREACHABLE)
+            return PollResult(endpoint, endpoint.status, False, (EVENT_ENDPOINT_UNREACHABLE,))
+    except Exception as exc:  # noqa: BLE001 - record + continue (e.g. parse error)
+        endpoint.status = MonitoredEndpointStatusChoices.STATUS_UNREACHABLE
+        endpoint.last_checked = now
+        endpoint.last_error = str(exc)
+        endpoint.save(update_fields=["status", "last_checked", "last_error"])
+        fire_endpoint_event(endpoint, EVENT_ENDPOINT_UNREACHABLE)
+        return PollResult(endpoint, endpoint.status, False, (EVENT_ENDPOINT_UNREACHABLE,))
+
+    cert = outcome.certificate
+    rotated = prev_cert_id is not None and prev_cert_id != cert.pk
+
+    with transaction.atomic():
+        endpoint.certificate = cert
+        endpoint.last_checked = now
+        endpoint.last_seen = now
+        endpoint.last_error = ""
+        endpoint.status = (
+            MonitoredEndpointStatusChoices.STATUS_UNTRUSTED
+            if untrusted
+            else MonitoredEndpointStatusChoices.STATUS_OK
+        )
+        endpoint.save(update_fields=["certificate", "last_checked", "last_seen", "last_error", "status"])
+
+        hist, created = MonitoredEndpointCertificate.objects.get_or_create(
+            endpoint=endpoint, certificate=cert, defaults={"first_seen": now, "last_seen": now}
+        )
+        if not created:
+            hist.last_seen = now
+            hist.save(update_fields=["last_seen"])
+
+    if untrusted:
+        events.append(EVENT_ENDPOINT_UNTRUSTED_CERT)
+        fire_endpoint_event(endpoint, EVENT_ENDPOINT_UNTRUSTED_CERT)
+    if rotated:
+        events.append(EVENT_ENDPOINT_CERT_ROTATED)
+        fire_endpoint_event(endpoint, EVENT_ENDPOINT_CERT_ROTATED, extra={"previous_certificate_id": prev_cert_id})
+
+    return PollResult(endpoint, endpoint.status, rotated, tuple(events))
+```
+
+- [ ] **Step 8: Run (GREEN), lint, commit**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_endpoint_monitor.py -v --tb=short
+ruff check netbox_ssl/utils/endpoint_monitor.py netbox_ssl/utils/events.py tests/test_endpoint_monitor.py
+git add netbox_ssl/utils/endpoint_monitor.py netbox_ssl/utils/events.py tests/test_endpoint_monitor.py
+git commit -m "feat: add endpoint poll service + endpoint events (#149)"
+```
+Expected: all poll + payload tests pass; ruff clean.
+
+---
+
+## Task 4: Re-poll NetBox Script
+
+**Files:**
+- Create: `netbox_ssl/scripts/endpoint_monitor.py`
+- Test: `tests/test_endpoint_poll_script.py`
+
+**Interfaces:**
+- Consumes: `poll_endpoint`, `PollResult` (Task 3); `MonitoredEndpoint` (Task 1).
+- Produces: `MonitoredEndpointPoll(Script)` whose `run(data, commit)` iterates endpoints (optional tenant filter, `dry_run`), calls `poll_endpoint`, logs a per-status summary, returns a summary string.
+
+- [ ] **Step 1: Write the failing test** (`tests/test_endpoint_poll_script.py`)
+
+> Mirror the structure of the existing `tests/test_expiry_scan.py`. Scripts are instantiated and `run()` called directly with a `data` dict. Mock `poll_endpoint` so no network/poll logic runs here — this test covers the Script's orchestration only.
+
+```python
+import uuid
+import pytest
+from unittest.mock import patch
+
+
+@pytest.mark.django_db
+class TestMonitoredEndpointPollScript:
+    def _ep(self):
+        from netbox_ssl.models import MonitoredEndpoint
+        return MonitoredEndpoint.objects.create(name=f"e{uuid.uuid4().hex[:6]}", url="https://e.example.com")
+
+    @patch("netbox_ssl.scripts.endpoint_monitor.poll_endpoint")
+    def test_polls_all_endpoints(self, mock_poll):
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.scripts.endpoint_monitor import MonitoredEndpointPoll
+        from netbox_ssl.utils.endpoint_monitor import PollResult
+
+        ep1, ep2 = self._ep(), self._ep()
+        mock_poll.side_effect = lambda ep, **kw: PollResult(ep, MonitoredEndpointStatusChoices.STATUS_OK, False, ())
+        script = MonitoredEndpointPoll()
+        script.run({"tenant": None, "dry_run": False}, commit=True)
+        assert mock_poll.call_count == 2
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_endpoint_poll_script.py -v --tb=short
+```
+Expected: FAIL — `ModuleNotFoundError: ...scripts.endpoint_monitor`.
+
+- [ ] **Step 3: Write the Script** (`netbox_ssl/scripts/endpoint_monitor.py`)
+
+> Mirror `netbox_ssl/scripts/expiry_scan.py` for the `Script`/`ObjectVar`/`BooleanVar` imports, `class Meta`, `get_plugin_setting`, and `log_*` helpers. **`ObjectVar(model=...)` must take the model CLASS, not a string** (see [[netbox-plugin-scripts-loading]], #143).
+
+```python
+"""NetBox Script: re-poll all MonitoredEndpoints and reconcile their certs."""
+
+from extras.scripts import BooleanVar, ObjectVar, Script
+from tenancy.models import Tenant
+
+from netbox_ssl.models import MonitoredEndpoint, MonitoredEndpointStatusChoices
+from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+
+
+class MonitoredEndpointPoll(Script):
+    class Meta:
+        name = "Monitored Endpoint Poll"
+        description = "Re-scrape each monitored endpoint and update its certificate, status, and history."
+
+    tenant = ObjectVar(model=Tenant, required=False, description="Limit to one tenant.")
+    dry_run = BooleanVar(default=False, description="Log actions without saving.")
+
+    def run(self, data, commit):
+        from django.conf import settings
+
+        allowlist = settings.PLUGINS_CONFIG.get("netbox_ssl", {}).get("url_import_private_cidr_allowlist", [])
+        endpoints = MonitoredEndpoint.objects.all()
+        if data.get("tenant"):
+            endpoints = endpoints.filter(tenant=data["tenant"])
+
+        counts = {c[0]: 0 for c in MonitoredEndpointStatusChoices.CHOICES}
+        rotated = 0
+        for endpoint in endpoints:
+            if data.get("dry_run"):
+                self.log_info(f"[dry-run] would poll {endpoint.name} ({endpoint.url})")
+                continue
+            result = poll_endpoint(endpoint, allowlist=allowlist)
+            counts[result.status] = counts.get(result.status, 0) + 1
+            if result.rotated:
+                rotated += 1
+            self.log_info(f"{endpoint.name}: {result.status}" + (" (rotated)" if result.rotated else ""))
+
+        summary = ", ".join(f"{k}={v}" for k, v in counts.items() if v) + (f", rotated={rotated}" if rotated else "")
+        self.log_success(f"Polled {endpoints.count()} endpoint(s): {summary or 'no changes'}")
+        return summary
+```
+
+- [ ] **Step 4: Run (GREEN), add a dry-run test**
+
+Add a dry-run test asserting `poll_endpoint` is NOT called when `dry_run=True`:
+
+```python
+    @patch("netbox_ssl.scripts.endpoint_monitor.poll_endpoint")
+    def test_dry_run_does_not_poll(self, mock_poll):
+        from netbox_ssl.scripts.endpoint_monitor import MonitoredEndpointPoll
+        self._ep()
+        MonitoredEndpointPoll().run({"tenant": None, "dry_run": True}, commit=False)
+        mock_poll.assert_not_called()
+```
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_endpoint_poll_script.py -v --tb=short
+```
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Add the AST/registration guard + lint + commit**
+
+Confirm the new Script passes the existing `tests/test_script_objectvar.py` guard (the AST check that no `ObjectVar(model="string")` exists), then:
+
+```bash
+docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_script_objectvar.py -v --tb=short
+ruff check netbox_ssl/scripts/endpoint_monitor.py tests/test_endpoint_poll_script.py
+git add netbox_ssl/scripts/endpoint_monitor.py tests/test_endpoint_poll_script.py
+git commit -m "feat: add MonitoredEndpointPoll re-poll script (#149)"
+```
+
+---
+
+## Task 5: Provisioning — CRUD, bulk CSV, #106 auto-create hook
+
+**Files:**
+- Create: `netbox_ssl/forms/monitored_endpoints.py`, `netbox_ssl/tables/monitored_endpoints.py`, `netbox_ssl/filtersets/monitored_endpoints.py`, `netbox_ssl/views/monitored_endpoints.py`
+- Modify: the `forms/`, `tables/`, `filtersets/`, `views/` `__init__.py`; `netbox_ssl/urls.py`; `netbox_ssl/navigation.py`
+- Modify: `netbox_ssl/utils/url_cert_import.py` is NOT touched; add the auto-create hook in `netbox_ssl/views/url_import.py`
+- Test: extend `tests/test_monitored_endpoint_views.py`
+
+**Interfaces:**
+- Consumes: `MonitoredEndpoint` (Task 1).
+- Produces: list/add/edit/delete/detail URL names `monitoredendpoint_list`, `monitoredendpoint_add`, `monitoredendpoint`, `monitoredendpoint_edit`, `monitoredendpoint_delete`, plus `monitoredendpoint_import` (bulk CSV).
+
+This task is **NetBox CRUD boilerplate** — mirror the existing `ExternalSource` CRUD exactly. For each file, copy the structure from its `ExternalSource` counterpart and swap model/fields:
+
+- [ ] **Step 1: Table** — `netbox_ssl/tables/monitored_endpoints.py`, mirror `tables/external_sources.py`. Columns: `name` (linkified), `url`, `status` (`ChoiceFieldColumn`), `certificate` (linkified), `days_remaining`, `tenant`, `last_checked`. Register in `tables/__init__.py`.
+
+- [ ] **Step 2: FilterSet** — `filtersets/monitored_endpoints.py`, mirror `filtersets/external_sources.py`. Filters: `status` (multiple choice from `MonitoredEndpointStatusChoices`), `certificate_id` (`ModelMultipleChoiceFilter`), `tenant_id`, `q` (search `name`/`url`). Register in `filtersets/__init__.py`.
+
+- [ ] **Step 3: Forms** — `forms/monitored_endpoints.py`, mirror `forms/external_sources.py`: a `MonitoredEndpointForm(NetBoxModelForm)` (fields `name`, `url`, `sni`, `tenant`, `device`/`virtual_machine`/`service` resolving to the GenericFK like `CertificateAssignmentForm` does, `tags`), a `MonitoredEndpointFilterForm`, and a `MonitoredEndpointImportForm` (CSV `TextVar`-style textarea) reusing `utils/url_bulk_parser`. Register in `forms/__init__.py`.
+
+- [ ] **Step 4: Views** — `views/monitored_endpoints.py`, mirror `views/external_sources.py`: `MonitoredEndpointListView`, `MonitoredEndpointView`, `MonitoredEndpointEditView`, `MonitoredEndpointDeleteView`, `MonitoredEndpointBulkDeleteView`, and a `MonitoredEndpointImportView(LoginRequiredMixin, View)` that parses CSV via `url_bulk_parser` and creates endpoints. Register in `views/__init__.py`.
+
+- [ ] **Step 5: URLs + navigation** — add the routes to `urls.py` (mirror the certificate/external-source URL block, names listed in Interfaces above) and a nav item to `navigation.py` (mirror the existing SSL menu group entries). Import the views in `urls.py`.
+
+- [ ] **Step 6: #106 auto-create hook** — in `netbox_ssl/views/url_import.py`, after a row imports successfully in `_process_row` (status `imported`/`imported_untrusted`/`matched`), upsert a `MonitoredEndpoint` for `row["url"]` linked to the resulting cert:
+
+```python
+        # #149: keep a MonitoredEndpoint for every imported URL.
+        from ..models import MonitoredEndpoint
+
+        MonitoredEndpoint.objects.update_or_create(
+            url=row["url"],
+            defaults={
+                "name": row.get("name") or row["host"],
+                "sni": row.get("sni") or "",
+                "certificate": outcome.certificate,
+                "tenant": tenant,
+                "last_seen": timezone.now(),
+                "last_checked": timezone.now(),
+                "status": MonitoredEndpointStatusChoices.STATUS_OK,
+            },
+        )
+```
+Import `MonitoredEndpointStatusChoices` at the top of `url_import.py`.
+
+- [ ] **Step 7: Tests** — `tests/test_monitored_endpoint_views.py`:
+
+```python
+import uuid
+import pytest
+
+
+@pytest.mark.django_db
+class TestMonitoredEndpointViews:
+    def test_list_requires_login(self, client):
+        resp = client.get("/plugins/ssl/monitored-endpoints/")
+        assert resp.status_code in (302, 403)  # redirected to login
+
+    def test_list_renders_for_superuser(self, client, django_user_model):
+        user = django_user_model.objects.create_user("u", password="x", is_superuser=True)
+        client.force_login(user)
+        from netbox_ssl.models import MonitoredEndpoint
+        MonitoredEndpoint.objects.create(name="hr", url="https://hr.example.com")
+        resp = client.get("/plugins/ssl/monitored-endpoints/")
+        assert resp.status_code == 200
+        assert b"hr" in resp.content
+```
+Plus a test that the #106 auto-create hook upserts an endpoint (patch `scrape_and_import` in `url_import`, drive `_process_row`, assert a `MonitoredEndpoint` exists for the URL).
+
+- [ ] **Step 8: Run, restart, lint, commit**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_monitored_endpoint_views.py -v --tb=short
+docker-compose restart netbox netbox-worker   # template/url/nav changes
+ruff check netbox_ssl/tables/monitored_endpoints.py netbox_ssl/filtersets/monitored_endpoints.py netbox_ssl/forms/monitored_endpoints.py netbox_ssl/views/monitored_endpoints.py netbox_ssl/views/url_import.py
+git add netbox_ssl/ tests/test_monitored_endpoint_views.py
+git commit -m "feat: add MonitoredEndpoint CRUD, bulk CSV, and #106 auto-create (#149)"
+```
+
+---
+
+## Task 6: Website-centric views — endpoint detail rotation tab + certificate reverse tab
+
+**Files:**
+- Create: `netbox_ssl/templates/netbox_ssl/monitoredendpoint.html`
+- Modify: `netbox_ssl/templates/netbox_ssl/certificate.html`, `netbox_ssl/views/certificates.py`
+- Test: extend `tests/test_monitored_endpoint_views.py`
+
+**Interfaces:**
+- Consumes: `MonitoredEndpoint`, `MonitoredEndpointCertificate` (Task 1); the detail views (Task 5).
+
+- [ ] **Step 1: Endpoint detail template** — `monitoredendpoint.html`, mirroring `certificateauthority.html`/`externalsource.html`: a details card (url, status badge, linked certificate + `days_remaining`, last_checked/last_seen, assigned object, tenant) and a **Rotation History** tab listing `object.cert_history.all` (certificate link, first_seen, last_seen). The `MonitoredEndpointView` (Task 5) already supplies `object`; `cert_history` is the related manager.
+
+- [ ] **Step 2: Certificate "Monitored Endpoints" tab** — in `views/certificates.py`, find the `CertificateView` (the `generic.ObjectView` for `Certificate`) and add to its detail context (via `get_extra_context`) `monitored_endpoints = instance.monitored_endpoints.restrict(request.user, "view")` and `monitored_endpoints_count`. In `certificate.html`, add a tab `#tab-monitored-endpoints` (mirroring the existing `#tab-assignments` block from #148) that renders the list (name link, url, status badge, days_remaining), shown when `monitored_endpoints` is non-empty.
+
+- [ ] **Step 3: Tests**
+
+```python
+    def test_certificate_detail_shows_linked_endpoints(self, client, django_user_model):
+        import datetime
+        from django.utils import timezone
+        from netbox_ssl.models import Certificate, MonitoredEndpoint
+
+        user = django_user_model.objects.create_user("u2", password="x", is_superuser=True)
+        client.force_login(user)
+        uid = uuid.uuid4().hex[:8]
+        cert = Certificate.objects.create(
+            common_name=f"{uid}.example.com", serial_number=f"S:{uid}", issuer="CA",
+            valid_from=timezone.now(), valid_to=timezone.now() + datetime.timedelta(days=90),
+            fingerprint_sha256=":".join([f"{(i % 256):02X}" for i in range(32)]), algorithm="RSA",
+        )
+        MonitoredEndpoint.objects.create(name="hr-portal", url="https://hr.example.com", certificate=cert)
+        resp = client.get(f"/plugins/ssl/certificates/{cert.pk}/")
+        assert resp.status_code == 200
+        assert b"hr-portal" in resp.content
+```
+
+- [ ] **Step 4: Run, restart, lint, CHANGELOG, commit**
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest /tmp/plugin_tests/test_monitored_endpoint_views.py -v --tb=short
+docker-compose restart netbox netbox-worker
+ruff check netbox_ssl/views/certificates.py
+```
+Add to `CHANGELOG.md` `## [Unreleased]` → `### Added`:
+```markdown
+- **Website-centric certificate monitoring** ([#149](https://github.com/ctrl-alt-automate/netbox-ssl/issues/149)):
+  a new **Monitored Endpoints** feature tracks the certificate each website/URL
+  presents over time. A scheduled "Monitored Endpoint Poll" script re-scrapes
+  each endpoint (reusing the URL-import TLS scraper + security model), links the
+  certificate it finds, records rotation history, and fires NetBox events on
+  unreachable / rotated / untrusted endpoints. Endpoints can be added manually,
+  bulk-imported from CSV, or auto-created from the URL import flow. A certificate's
+  detail page now lists every website presenting it. One additive migration.
+```
+```bash
+git add netbox_ssl/templates/ netbox_ssl/views/certificates.py CHANGELOG.md tests/test_monitored_endpoint_views.py
+git commit -m "feat: add endpoint rotation tab + certificate reverse tab (#149)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run all new test files together** (cross-contamination gate):
+
+```bash
+docker cp tests/. netbox-ssl-netbox-1:/tmp/plugin_tests/ && docker cp pytest.ini netbox-ssl-netbox-1:/tmp/plugin_tests/pytest.ini \
+  && docker exec netbox-ssl-netbox-1 /opt/netbox/venv/bin/python -m pytest \
+       /tmp/plugin_tests/test_monitored_endpoint_model.py /tmp/plugin_tests/test_url_cert_import.py \
+       /tmp/plugin_tests/test_endpoint_monitor.py /tmp/plugin_tests/test_endpoint_poll_script.py \
+       /tmp/plugin_tests/test_monitored_endpoint_views.py /tmp/plugin_tests/test_script_objectvar.py -v --tb=short
+```
+Expected: all green.
+
+- [ ] **Django system checks + live smoke**
+
+```bash
+docker exec netbox-ssl-netbox-1 python /opt/netbox/netbox/manage.py check --tag netbox_ssl
+```
+Then load `/plugins/ssl/monitored-endpoints/`, add an endpoint, and confirm the detail page + the certificate's Monitored Endpoints tab.
+
+- [ ] **Open PR to `dev`** with `Closes #149`, crediting @SerhiiZahuba. Target milestone v1.3.
+
+## Self-review (completed during planning)
+
+- **Spec coverage:** model + history (Task 1) ✓; shared import refactor + #106 parity (Task 2) ✓; poll service + rotation + endpoint events (Task 3) ✓; re-poll Script (Task 4) ✓; CRUD + bulk CSV + auto-create (Task 5) ✓; website-centric views + reverse tab + rotation tab + CHANGELOG (Task 6) ✓; security/#106-reuse in Global Constraints ✓; one additive migration ✓.
+- **Interface consistency:** `scrape_and_import(url, host, port, *, sni, verify_chain, allowlist, tenant, set_discovered_url) -> ImportOutcome(certificate, created)` is identical in Tasks 2/3/5; `poll_endpoint(endpoint, *, allowlist) -> PollResult(endpoint, status, rotated, events_fired)` identical in Tasks 3/4; `MonitoredEndpointStatusChoices.STATUS_*`, `MonitoredEndpoint.cert_history`, `Certificate.monitored_endpoints`, the `EVENT_ENDPOINT_*` names, and the `monitoredendpoint*` URL names are used consistently. **Spec correction:** `rotated` lives on `PollResult`, not `ImportOutcome` (the import service is endpoint-agnostic) — noted intentionally.
+- **Placeholders:** Tasks 1–4 and 6 carry complete code + full test code. Task 5 is NetBox CRUD boilerplate, intentionally specified as "mirror the exact `ExternalSource` counterpart" with explicit per-file field/column/filter lists — the established, declarative pattern an engineer reproduces rather than invents; the one novel piece (the #106 auto-create hook) is given as complete code.

--- a/project-requirement-document/specs/2026-06-20-149-website-centric-monitoring-design.md
+++ b/project-requirement-document/specs/2026-06-20-149-website-centric-monitoring-design.md
@@ -1,0 +1,255 @@
+# Design: Website-centric certificate monitoring (#149)
+
+- **Issue:** [#149](https://github.com/ctrl-alt-automate/netbox-ssl/issues/149) — "website-centric view" (reported by @SerhiiZahuba; mislabeled `bug`, it is an enhancement)
+- **Date:** 2026-06-20
+- **Status:** Approved — ready for implementation plan
+- **Target release:** v1.3 (new minor; milestone justified — one issue spanning many components, the v1.2/#106 pattern)
+- **Author:** maintainer + Claude (brainstorming session)
+
+## 1. Problem
+
+An operator runs many internal/external sites (`hr.example.com`, `it.example.com`,
+`portal.example.com`, …) but reuses only a handful of certificates (often
+wildcards) across them. They want a **website-centric** view, not a
+certificate-centric one:
+
+1. Maintain a list of websites/URLs.
+2. Automatically retrieve and track the certificate each site presents.
+3. Show certificate expiry per website.
+4. Alert when a website's certificate is approaching expiry.
+5. See which websites are affected by the same certificate.
+
+Today the plugin is certificate-centric. The certificate↔URL relationship is a
+single `discovered_via_url` string field on `Certificate` (added by #106), which
+**cannot represent many URLs sharing one certificate** — exactly the reporter's
+case. A first-class "monitored endpoint" entity is required.
+
+This is passive administration (inventory/monitoring). Importing a certificate
+observed at a URL is consistent with the charter (#106 already does it one-shot);
+the new element is a **persistent, re-polled endpoint**.
+
+## 2. Goals / Non-goals
+
+**Goals (the MVP chosen in brainstorming)**
+
+- A `MonitoredEndpoint` model: a URL whose presented certificate is tracked over
+  time, with rotation history.
+- A re-poll NetBox Script that re-scrapes endpoints on a NetBox schedule,
+  reusing #106's TLS scraper and security model.
+- On rotation, auto-import the newly presented certificate (reusing #106's
+  parse + serial/issuer dedup) and re-point the endpoint, recording history.
+- Website-centric list/detail views and a "which sites share this certificate"
+  view (the reverse of #148's assignments).
+- Per-endpoint NetBox events (unreachable, cert-rotated, untrusted-cert) via the
+  existing v0.6 event/webhook machinery. Expiry alerts continue to come from the
+  existing expiry-scan on the linked certificate.
+- Provisioning: manual CRUD, bulk CSV (reuse #106's parser), and auto-create
+  from the #106 URL-import flow.
+
+**Non-goals (YAGNI / deferred, mirroring #106's deferrals)**
+
+- Per-endpoint check intervals / a bespoke scheduler (re-poll is one
+  NetBox-scheduled Script for all endpoints).
+- Per-endpoint alert thresholds or recipients.
+- IPv6, STARTTLS, non-HTTPS protocols.
+- Active deployment of certificates (the plugin stays passive).
+
+## 3. Background: reusable building blocks (#106, v0.6)
+
+| Component | Where | Reuse for #149 |
+|-----------|-------|----------------|
+| `scrape_tls_certificate(...)` → PEM | `utils/tls_scraper.py` | The poll's network call (HTTPS-only, DNS-rebinding defense, timeout/size caps). |
+| URL validation (private-IP block + CIDR allowlist) | `utils/url_validation.py` | Re-validate every endpoint URL before each poll. |
+| CSV URL parser | `utils/url_bulk_parser.py` | Bulk endpoint provisioning. |
+| One-shot scrape→parse→import-or-match | `views/url_import.py:_process_row` | **Extract to a shared service** used by both #106 and the #149 poll. |
+| `CertificateURLScan` / `CertificateExpiryScan` Scripts | `scripts/url_scan.py`, `scripts/expiry_scan.py` | Template for the re-poll Script (`ObjectVar` tenant filter, `dry_run`, summary logging). |
+| Event helpers + types | `utils/events.py` (`EVENT_CERTIFICATE_*`, `fire_certificate_event`) | Add `EVENT_ENDPOINT_*` + a `fire_endpoint_event` sibling using the same Event Rules delivery. |
+| `discovered_via_url`, `last_seen_at` | `models/certificates.py` | Updated by the shared import service (unchanged behavior for #106). |
+
+## 4. Data model
+
+One additive migration. No changes to existing models.
+
+### 4.1 `MonitoredEndpoint(NetBoxModel)`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | CharField | Human label (e.g. "HR portal"). |
+| `url` | CharField | `https://host:port` form; host/port derived via `url_validation`. HTTPS-only. |
+| `sni` | CharField, blank | Optional SNI override; defaults to the URL host. |
+| `certificate` | FK → `Certificate`, null | The certificate currently presented (null until the first successful poll). `on_delete=SET_NULL`. |
+| `assigned_object` | GenericForeignKey, null | Optional Device/VM/Service this site runs on — **same pattern as `CertificateAssignment`** (`assigned_object_type` + `assigned_object_id`, allowlist `device`/`virtualmachine`/`service`). |
+| `tenant` | FK → `tenancy.Tenant`, null | Optional. |
+| `status` | CharField (choices) | `pending` (never polled) / `ok` / `unreachable` / `untrusted`. Rotation is captured as an event + a history row, **not** a status — a reachable, trusted endpoint stays `ok` even right after it rotated. |
+| `last_checked` | DateTimeField, null | Last poll attempt. |
+| `last_seen` | DateTimeField, null | Last successful scrape. |
+| `last_error` | TextField, blank | Last failure detail (internal; UI shows a generic status). |
+
+Inherits `NetBoxModel` → custom fields, tags, changelog, journaling. Standard
+list/detail/edit/delete generic views.
+
+### 4.2 `MonitoredEndpointCertificate(models.Model)` — rotation history
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `endpoint` | FK → `MonitoredEndpoint`, CASCADE | |
+| `certificate` | FK → `Certificate`, CASCADE | |
+| `first_seen` | DateTimeField | When this endpoint first presented this cert. |
+| `last_seen` | DateTimeField | Updated each poll while still presenting it. |
+
+`UniqueConstraint(endpoint, certificate)`. The endpoint's *current* cert is the
+history row with the latest `last_seen`; the timeline of rows is the rotation
+history. A plain `models.Model` (not `NetBoxModel`) — it is an internal audit
+record, not a user-managed object.
+
+### 4.3 "Which sites share a certificate"
+
+`MonitoredEndpoint.objects.filter(certificate=X)`. Surfaced as a **Monitored
+Endpoints** tab on the certificate detail page (the reverse of #148's
+assignments tab) and as a filter on the endpoint list.
+
+## 5. Services
+
+### 5.1 Shared import/link service — `utils/url_cert_import.py` (refactor + extend)
+
+Extract the inline import-or-match logic from `UrlImportView._process_row` into:
+
+```python
+@dataclass(frozen=True)
+class ImportOutcome:
+    certificate: "Certificate"
+    created: bool          # True = newly imported, False = matched existing
+    rotated: bool          # True = the URL now presents a different cert than before
+
+def scrape_and_import(
+    url: str, *, allowlist, tenant=None, verify_chain: bool = True,
+) -> ImportOutcome: ...
+```
+
+Behavior (identical to today's #106 path, now shared): validate URL → scrape via
+`tls_scraper` → parse → dedup by `(serial_number, issuer)` → update
+`last_seen_at`/`discovered_via_url` on match, or create on miss. `UrlImportView`
+and the #106 `CertificateURLScan` script are refactored to call this — **#106
+behavior must be unchanged** (covered by existing tests + new parity tests).
+
+### 5.2 Endpoint poll service — `utils/endpoint_monitor.py`
+
+```python
+@dataclass(frozen=True)
+class PollResult:
+    endpoint: "MonitoredEndpoint"
+    status: str            # ok / unreachable / untrusted / changed
+    rotated: bool
+    events_fired: tuple[str, ...]
+
+def poll_endpoint(endpoint, *, allowlist) -> PollResult: ...
+```
+
+Per endpoint, atomically: call `scrape_and_import` → link the resulting cert to
+the endpoint → update `status`/`last_checked`/`last_seen` → upsert the rotation
+history (on a cert change: bump the old row's `last_seen`, create/refresh the new
+row, fire `endpoint_cert_rotated`; `status` stays `ok` if the new cert is
+reachable and trusted) → on
+`TLSScrapeError` set `unreachable` + `last_error`, fire `endpoint_unreachable` →
+on untrusted/self-signed result set `untrusted`, fire `endpoint_untrusted_cert`.
+
+### 5.3 Re-poll Script — `scripts/endpoint_monitor.py`
+
+`MonitoredEndpointPoll(Script)` mirroring `CertificateExpiryScan`: `ObjectVar`
+tenant filter, `dry_run` BooleanVar, iterate `.restrict`ed endpoints, call
+`poll_endpoint`, log a per-status summary. Scheduled via NetBox's job scheduler
+(no bespoke scheduler). Registered via `SCRIPTS_ROOT` like the other bundled
+scripts (see [[netbox-plugin-scripts-loading]]).
+
+## 6. Events
+
+Add to `utils/events.py`: `EVENT_ENDPOINT_UNREACHABLE`,
+`EVENT_ENDPOINT_CERT_ROTATED`, `EVENT_ENDPOINT_UNTRUSTED_CERT`, plus
+`fire_endpoint_event(endpoint, event_type, **payload)` delivering through the
+same NetBox Event Rules mechanism as `fire_certificate_event`. Expiry alerting
+is unchanged — the linked certificate flows through the existing expiry-scan.
+
+## 7. Provisioning
+
+- **Manual:** `MonitoredEndpoint` generic CRUD views.
+- **Bulk CSV:** reuse `url_bulk_parser`/`url_validation`; CSV columns
+  `url`,`name`,`device`/`virtual_machine`/`service`,`tenant`,`sni`. A bulk-add
+  flow (or a Script) creates endpoints.
+- **Auto-create from #106:** the #106 URL-import flow upserts a
+  `MonitoredEndpoint` for each imported URL row (the user explicitly chose this).
+  Implemented as a hook the URL-import path calls after a successful import; the
+  shared service (5.1) stays free of endpoint concerns so it has one
+  responsibility. Whether to additionally gate it behind a plugin setting is a
+  planning detail (§13).
+
+## 8. Views (website-centric)
+
+- **Endpoint list** — filterable by `status`, `certificate`, `tenant`; columns
+  include the linked cert's `days_remaining` (expiry-per-site, reusing
+  `Certificate.days_remaining`).
+- **Endpoint detail** — current cert, status, last_checked/last_seen, and a
+  **rotation history** tab (the `MonitoredEndpointCertificate` rows).
+- **Certificate detail** — new **Monitored Endpoints** tab listing endpoints
+  whose `certificate` is this cert.
+- All custom views: `LoginRequiredMixin` first, `.restrict()` on every queryset.
+
+## 9. Security (reuse #106 + v0.7.5)
+
+- Every poll re-validates the URL (DNS can change) and scrapes via `tls_scraper`:
+  HTTPS-only, private/loopback blocked unless allowlisted via
+  `PLUGINS_CONFIG["netbox_ssl"]["url_import_private_cidr_allowlist"]`,
+  DNS-rebinding defense (connect to the validated IP, no re-resolve), hard
+  timeout/size caps, no redirects.
+- Self-signed/untrusted chains are recorded with `status="untrusted"` and never
+  auto-trusted.
+- v0.7.5: `LoginRequiredMixin`, `.restrict()`, perm-gated writes on all custom
+  views and the script; generic error messages, `last_error` logged internally.
+
+## 10. Migrations
+
+One additive migration creating `MonitoredEndpoint` +
+`MonitoredEndpointCertificate`. No existing-model changes → no data migration.
+Generated via real `makemigrations` (NetBox needs `DEVELOPER=True`); grep the new
+migration against the `NetBoxModel` parent for `custom_field_data`/`tags`
+(see [[feedback-netboxmodel-migration-drift]]).
+
+## 11. Testing plan
+
+- **Shared import service:** create-on-miss, match-on-existing, `rotated` flag;
+  parity tests proving #106's URL-import behavior is unchanged after the refactor.
+- **Poll service:** ok / unreachable / untrusted / rotated paths, history upsert,
+  correct events fired (scraper mocked — no real network).
+- **Model:** endpoint↔cert link, `SET_NULL` on cert delete, history unique
+  constraint, "which sites share a cert" query.
+- **Script:** dry-run vs commit, tenant filter, summary counts.
+- **Views:** list filters, detail + rotation tab, certificate's Monitored
+  Endpoints tab, auth/`.restrict()`.
+- **CSV/auto-create:** parser reuse, auto-create upsert from the #106 flow.
+- Conventions: `@pytest.mark.django_db`, in-container run (copy `tests/` **and**
+  `pytest.ini` to `/tmp/plugin_tests/`).
+
+## 12. Decomposition (implementation plan will be multi-task)
+
+One spec → one plan, but the plan splits into tasks with internal dependencies:
+1. Models + migration.
+2. Shared import-service refactor (extract from #106, parity-tested).
+3. Endpoint poll service + endpoint events.
+4. Re-poll Script.
+5. Provisioning: CRUD + bulk CSV + #106 auto-create hook.
+6. Views (endpoint list/detail + rotation tab + certificate Monitored-Endpoints tab).
+
+Larger than #148 — a v1.3 minor.
+
+## 13. Open questions
+
+None blocking. During planning, confirm whether the #106 auto-create hook should
+be unconditional or gated by a plugin setting (default proposed: on for the
+URL-import path, since the user explicitly asked for it).
+
+## 14. References
+
+- #106 URL import: `utils/tls_scraper.py`, `utils/url_validation.py`,
+  `utils/url_bulk_parser.py`, `views/url_import.py`, `scripts/url_scan.py`.
+- Event system (v0.6): `utils/events.py`.
+- Reverse-relationship precedent: #148 assignments tab.
+- Security rules: `CLAUDE.md` §"Security Rules (v0.7.5)".

--- a/tests/test_endpoint_monitor.py
+++ b/tests/test_endpoint_monitor.py
@@ -282,3 +282,4 @@ class TestPollEndpoint:
         ep.refresh_from_db()
         assert result.status == MonitoredEndpointStatusChoices.STATUS_UNREACHABLE
         assert ep.last_error
+        assert "private IP" in ep.last_error

--- a/tests/test_endpoint_monitor.py
+++ b/tests/test_endpoint_monitor.py
@@ -9,7 +9,13 @@ import pytest
 # ---------------------------------------------------------------------------
 # Guard: only run these tests inside the Docker container where NetBox lives.
 # ---------------------------------------------------------------------------
-if importlib.util.find_spec("netbox") is None:
+try:
+    _netbox_available = importlib.util.find_spec("netbox") is not None
+except (ValueError, ModuleNotFoundError):
+    # The host-only unit lane mocks ``netbox`` in sys.modules, so find_spec hits
+    # a Mock ``__spec__`` and raises ValueError — treat that as "not available".
+    _netbox_available = False
+if not _netbox_available:
     pytest.skip("NetBox not available – skipping endpoint monitor tests", allow_module_level=True)
 
 from unittest.mock import patch

--- a/tests/test_endpoint_monitor.py
+++ b/tests/test_endpoint_monitor.py
@@ -1,0 +1,284 @@
+"""Unit tests for endpoint events + the poll service."""
+
+import datetime
+import importlib.util
+import uuid
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard: only run these tests inside the Docker container where NetBox lives.
+# ---------------------------------------------------------------------------
+if importlib.util.find_spec("netbox") is None:
+    pytest.skip("NetBox not available – skipping endpoint monitor tests", allow_module_level=True)
+
+from unittest.mock import patch
+
+from django.utils import timezone
+
+
+def _make_cert(serial=None):
+    from netbox_ssl.models import Certificate
+
+    uid = uuid.uuid4().hex[:8]
+    # Fingerprint must be unique per cert — derive 32 bytes from the uid so two
+    # certs created in the same test don't collide on the unique constraint.
+    fp_bytes = (uid * 4)[:32]  # 32 ASCII chars, all unique per uid
+    fingerprint = ":".join([f"{ord(c):02X}" for c in fp_bytes])
+    return Certificate.objects.create(
+        common_name=f"{uid}.example.com",
+        serial_number=serial or f"SER:{uid}",
+        issuer="Test CA",
+        valid_from=timezone.now(),
+        valid_to=timezone.now() + datetime.timedelta(days=365),
+        fingerprint_sha256=fingerprint,
+        algorithm="RSA",
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestEndpointEventPayload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestEndpointEventPayload:
+    def test_payload_has_endpoint_fields(self):
+        from netbox_ssl.models import MonitoredEndpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_UNREACHABLE, build_endpoint_event_payload
+
+        ep = MonitoredEndpoint.objects.create(name="hr", url="https://hr.example.com")
+        payload = build_endpoint_event_payload(ep, EVENT_ENDPOINT_UNREACHABLE)
+        assert payload["event_type"] == EVENT_ENDPOINT_UNREACHABLE
+        assert payload["endpoint_id"] == ep.pk
+        assert payload["url"] == "https://hr.example.com"
+
+    def test_payload_includes_cert_fields_when_cert_linked(self):
+        from netbox_ssl.models import MonitoredEndpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_CERT_ROTATED, build_endpoint_event_payload
+
+        cert = _make_cert()
+        ep = MonitoredEndpoint.objects.create(name="pay", url="https://pay.example.com", certificate=cert)
+        payload = build_endpoint_event_payload(ep, EVENT_ENDPOINT_CERT_ROTATED)
+        assert payload["certificate_id"] == cert.pk
+        assert payload["common_name"] == cert.common_name
+
+    def test_payload_cert_fields_are_none_when_no_cert(self):
+        from netbox_ssl.models import MonitoredEndpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_UNREACHABLE, build_endpoint_event_payload
+
+        ep = MonitoredEndpoint.objects.create(name="nocert", url="https://nocert.example.com")
+        payload = build_endpoint_event_payload(ep, EVENT_ENDPOINT_UNREACHABLE)
+        assert payload["certificate_id"] is None
+        assert payload["common_name"] is None
+        assert payload["days_remaining"] is None
+
+    def test_payload_includes_extra(self):
+        from netbox_ssl.models import MonitoredEndpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_UNREACHABLE, build_endpoint_event_payload
+
+        ep = MonitoredEndpoint.objects.create(name="extra", url="https://extra.example.com")
+        payload = build_endpoint_event_payload(ep, EVENT_ENDPOINT_UNREACHABLE, extra={"prev_id": 42})
+        assert payload["prev_id"] == 42
+
+    def test_payload_has_timestamp(self):
+        from netbox_ssl.models import MonitoredEndpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_UNREACHABLE, build_endpoint_event_payload
+
+        ep = MonitoredEndpoint.objects.create(name="ts", url="https://ts.example.com")
+        payload = build_endpoint_event_payload(ep, EVENT_ENDPOINT_UNREACHABLE)
+        assert "timestamp" in payload
+        assert payload["timestamp"]  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# TestPollEndpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPollEndpoint:
+    def _ep(self, **kw):
+        from netbox_ssl.models import MonitoredEndpoint
+
+        return MonitoredEndpoint.objects.create(name="hr", url="https://hr.example.com:443", **kw)
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_ok_links_cert_and_history(self, mock_import):
+        from netbox_ssl.models import MonitoredEndpointCertificate, MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+
+        cert = _make_cert()
+        mock_import.return_value = ImportOutcome(certificate=cert, created=True)
+        ep = self._ep()
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_OK
+        assert ep.certificate == cert
+        assert ep.last_seen is not None
+        assert MonitoredEndpointCertificate.objects.filter(endpoint=ep, certificate=cert).count() == 1
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_ok_clears_last_error(self, mock_import):
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+
+        cert = _make_cert()
+        mock_import.return_value = ImportOutcome(certificate=cert, created=False)
+        ep = self._ep(last_error="previous error")
+        poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert ep.last_error == ""
+        assert ep.status == MonitoredEndpointStatusChoices.STATUS_OK
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_ok_result_has_no_events_when_no_rotation(self, mock_import):
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+
+        cert = _make_cert()
+        mock_import.return_value = ImportOutcome(certificate=cert, created=True)
+        ep = self._ep()  # no previous cert
+        result = poll_endpoint(ep, allowlist=[])
+        assert result.rotated is False
+        assert len(result.events_fired) == 0
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_unreachable_fires_event(self, mock_import):
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_UNREACHABLE
+        from netbox_ssl.utils.tls_scraper import TLSScrapeError
+
+        mock_import.side_effect = TLSScrapeError("connection refused")
+        ep = self._ep()
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_UNREACHABLE
+        assert EVENT_ENDPOINT_UNREACHABLE in result.events_fired
+        assert ep.last_error
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_unreachable_when_both_attempts_fail(self, mock_import):
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_UNREACHABLE
+        from netbox_ssl.utils.tls_scraper import TLSScrapeError
+
+        # Both verify=True and verify=False fail
+        mock_import.side_effect = [TLSScrapeError("timeout"), TLSScrapeError("timeout")]
+        ep = self._ep()
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_UNREACHABLE
+        assert EVENT_ENDPOINT_UNREACHABLE in result.events_fired
+        assert ep.last_error
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_rotation_fires_event_and_keeps_status_ok(self, mock_import):
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_CERT_ROTATED
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+
+        cert_a, cert_b = _make_cert(), _make_cert()
+        ep = self._ep(certificate=cert_a)
+        mock_import.return_value = ImportOutcome(certificate=cert_b, created=False)
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.rotated is True
+        assert ep.certificate == cert_b
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_OK
+        assert EVENT_ENDPOINT_CERT_ROTATED in result.events_fired
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_no_rotation_when_same_cert(self, mock_import):
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+
+        cert = _make_cert()
+        ep = self._ep(certificate=cert)
+        mock_import.return_value = ImportOutcome(certificate=cert, created=False)
+        result = poll_endpoint(ep, allowlist=[])
+        assert result.rotated is False
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_untrusted_when_verify_fails_then_succeeds(self, mock_import):
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_UNTRUSTED_CERT
+        from netbox_ssl.utils.tls_scraper import TLSScrapeError
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+
+        cert = _make_cert()
+        # First (verify_chain=True) raises; second (verify_chain=False) succeeds.
+        mock_import.side_effect = [TLSScrapeError("self-signed"), ImportOutcome(certificate=cert, created=True)]
+        ep = self._ep()
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_UNTRUSTED
+        assert ep.certificate == cert
+        assert EVENT_ENDPOINT_UNTRUSTED_CERT in result.events_fired
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_untrusted_with_rotation_fires_both_events(self, mock_import):
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.events import EVENT_ENDPOINT_CERT_ROTATED, EVENT_ENDPOINT_UNTRUSTED_CERT
+        from netbox_ssl.utils.tls_scraper import TLSScrapeError
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+
+        cert_old, cert_new = _make_cert(), _make_cert()
+        ep = self._ep(certificate=cert_old)
+        mock_import.side_effect = [TLSScrapeError("self-signed"), ImportOutcome(certificate=cert_new, created=True)]
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_UNTRUSTED
+        assert result.rotated is True
+        assert EVENT_ENDPOINT_UNTRUSTED_CERT in result.events_fired
+        assert EVENT_ENDPOINT_CERT_ROTATED in result.events_fired
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_history_row_upserted_on_second_ok_poll(self, mock_import):
+        from netbox_ssl.models import MonitoredEndpointCertificate
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+
+        cert = _make_cert()
+        mock_import.return_value = ImportOutcome(certificate=cert, created=False)
+        ep = self._ep()
+        poll_endpoint(ep, allowlist=[])
+        poll_endpoint(ep, allowlist=[])  # second poll: same cert
+        # Still only ONE history row (upserted, not doubled)
+        assert MonitoredEndpointCertificate.objects.filter(endpoint=ep, certificate=cert).count() == 1
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_poll_result_is_frozen_dataclass(self, mock_import):
+        from netbox_ssl.utils.endpoint_monitor import PollResult, poll_endpoint
+        from netbox_ssl.utils.url_cert_import import ImportOutcome
+
+        cert = _make_cert()
+        mock_import.return_value = ImportOutcome(certificate=cert, created=True)
+        ep = self._ep()
+        result = poll_endpoint(ep, allowlist=[])
+        import dataclasses
+
+        assert isinstance(result, PollResult)
+        # Frozen: attribute assignment should raise FrozenInstanceError
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            result.status = "bad"  # type: ignore[misc]
+
+    @patch("netbox_ssl.utils.endpoint_monitor.scrape_and_import")
+    def test_url_validation_error_treated_as_unreachable(self, mock_import):
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.utils.endpoint_monitor import poll_endpoint
+        from netbox_ssl.utils.url_validation import URLValidationError
+
+        mock_import.side_effect = URLValidationError("private IP")
+        ep = self._ep()
+        result = poll_endpoint(ep, allowlist=[])
+        ep.refresh_from_db()
+        assert result.status == MonitoredEndpointStatusChoices.STATUS_UNREACHABLE
+        assert ep.last_error

--- a/tests/test_endpoint_poll_script.py
+++ b/tests/test_endpoint_poll_script.py
@@ -1,0 +1,94 @@
+"""Tests for MonitoredEndpointPoll Script (#149).
+
+Covers orchestration only — poll_endpoint is mocked so no network/poll logic runs.
+Mirror of tests/test_expiry_scan.py pattern.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.django_db
+class TestMonitoredEndpointPollScript:
+    def _ep(self):
+        from netbox_ssl.models import MonitoredEndpoint
+
+        return MonitoredEndpoint.objects.create(
+            name=f"e{uuid.uuid4().hex[:6]}", url="https://e.example.com"
+        )
+
+    @patch("netbox_ssl.scripts.endpoint_monitor.poll_endpoint")
+    def test_polls_all_endpoints(self, mock_poll):
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.scripts.endpoint_monitor import MonitoredEndpointPoll
+        from netbox_ssl.utils.endpoint_monitor import PollResult
+
+        _ep1, _ep2 = self._ep(), self._ep()
+        mock_poll.side_effect = lambda ep, **kw: PollResult(
+            ep, MonitoredEndpointStatusChoices.STATUS_OK, False, ()
+        )
+        script = MonitoredEndpointPoll()
+        script.run({"tenant": None, "dry_run": False}, commit=True)
+        assert mock_poll.call_count == 2
+
+    @patch("netbox_ssl.scripts.endpoint_monitor.poll_endpoint")
+    def test_dry_run_does_not_poll(self, mock_poll):
+        from netbox_ssl.scripts.endpoint_monitor import MonitoredEndpointPoll
+
+        self._ep()
+        MonitoredEndpointPoll().run({"tenant": None, "dry_run": True}, commit=False)
+        mock_poll.assert_not_called()
+
+    @patch("netbox_ssl.scripts.endpoint_monitor.poll_endpoint")
+    def test_tenant_filter_applied(self, mock_poll):
+        """When a tenant is given, only endpoints for that tenant are polled."""
+        from tenancy.models import Tenant
+
+        from netbox_ssl.models import MonitoredEndpoint, MonitoredEndpointStatusChoices
+        from netbox_ssl.scripts.endpoint_monitor import MonitoredEndpointPoll
+        from netbox_ssl.utils.endpoint_monitor import PollResult
+
+        tenant = Tenant.objects.create(name=f"t{uuid.uuid4().hex[:6]}", slug=f"t{uuid.uuid4().hex[:6]}")
+        ep_with = MonitoredEndpoint.objects.create(
+            name=f"e{uuid.uuid4().hex[:6]}", url="https://a.example.com", tenant=tenant
+        )
+        _ep_without = MonitoredEndpoint.objects.create(
+            name=f"e{uuid.uuid4().hex[:6]}", url="https://b.example.com"
+        )
+        mock_poll.side_effect = lambda ep, **kw: PollResult(
+            ep, MonitoredEndpointStatusChoices.STATUS_OK, False, ()
+        )
+        MonitoredEndpointPoll().run({"tenant": tenant, "dry_run": False}, commit=True)
+        assert mock_poll.call_count == 1
+        assert mock_poll.call_args[0][0] == ep_with
+
+    @patch("netbox_ssl.scripts.endpoint_monitor.poll_endpoint")
+    def test_summary_string_returned(self, mock_poll):
+        """run() returns a non-empty summary string."""
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.scripts.endpoint_monitor import MonitoredEndpointPoll
+        from netbox_ssl.utils.endpoint_monitor import PollResult
+
+        self._ep()
+        mock_poll.side_effect = lambda ep, **kw: PollResult(
+            ep, MonitoredEndpointStatusChoices.STATUS_OK, False, ()
+        )
+        result = MonitoredEndpointPoll().run({"tenant": None, "dry_run": False}, commit=True)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @patch("netbox_ssl.scripts.endpoint_monitor.poll_endpoint")
+    def test_rotated_count_in_summary(self, mock_poll):
+        """Rotated count appears in summary when at least one cert rotated."""
+        from netbox_ssl.models import MonitoredEndpointStatusChoices
+        from netbox_ssl.scripts.endpoint_monitor import MonitoredEndpointPoll
+        from netbox_ssl.utils.endpoint_monitor import PollResult
+
+        self._ep()
+        mock_poll.side_effect = lambda ep, **kw: PollResult(
+            ep, MonitoredEndpointStatusChoices.STATUS_OK, True, ("endpoint_cert_rotated",)
+        )
+        result = MonitoredEndpointPoll().run({"tenant": None, "dry_run": False}, commit=True)
+        assert "rotated=1" in result

--- a/tests/test_endpoint_poll_script.py
+++ b/tests/test_endpoint_poll_script.py
@@ -38,8 +38,11 @@ class TestMonitoredEndpointPollScript:
         from netbox_ssl.scripts.endpoint_monitor import MonitoredEndpointPoll
 
         self._ep()
-        MonitoredEndpointPoll().run({"tenant": None, "dry_run": True}, commit=False)
+        self._ep()
+        result = MonitoredEndpointPoll().run({"tenant": None, "dry_run": True}, commit=False)
         mock_poll.assert_not_called()
+        assert "dry-run" in result
+        assert "2" in result
 
     @patch("netbox_ssl.scripts.endpoint_monitor.poll_endpoint")
     def test_tenant_filter_applied(self, mock_poll):

--- a/tests/test_monitored_endpoint_model.py
+++ b/tests/test_monitored_endpoint_model.py
@@ -1,0 +1,70 @@
+"""Unit tests for the MonitoredEndpoint models."""
+
+import datetime
+import uuid
+
+import pytest
+from django.utils import timezone
+
+
+def _make_cert(serial=None):
+    from netbox_ssl.models import Certificate
+
+    uid = uuid.uuid4()
+    # Build a unique 95-char colon-hex fingerprint from the UUID's 16 bytes +
+    # 16 bytes of a second UUID → 32 bytes total.
+    raw = uid.bytes + uuid.uuid4().bytes  # 32 bytes
+    fingerprint = ":".join(f"{b:02X}" for b in raw)
+    return Certificate.objects.create(
+        common_name=f"{uid.hex[:8]}.example.com",
+        serial_number=serial or f"SER:{uid.hex[:8]}",
+        issuer="Test CA",
+        valid_from=timezone.now(),
+        valid_to=timezone.now() + datetime.timedelta(days=365),
+        fingerprint_sha256=fingerprint,
+        algorithm="RSA",
+    )
+
+
+@pytest.mark.django_db
+class TestMonitoredEndpoint:
+    def test_create_and_link_certificate(self):
+        from netbox_ssl.models import MonitoredEndpoint, MonitoredEndpointStatusChoices
+
+        cert = _make_cert()
+        ep = MonitoredEndpoint.objects.create(
+            name="HR portal", url="https://hr.example.com:443", certificate=cert
+        )
+        assert ep.status == MonitoredEndpointStatusChoices.STATUS_PENDING
+        assert ep.certificate == cert
+        assert ep.days_remaining == cert.days_remaining
+
+    def test_certificate_set_null_on_delete(self):
+        from netbox_ssl.models import MonitoredEndpoint
+
+        cert = _make_cert()
+        ep = MonitoredEndpoint.objects.create(name="x", url="https://x.example.com", certificate=cert)
+        cert.delete()
+        ep.refresh_from_db()
+        assert ep.certificate is None
+
+    def test_rotation_history_unique_constraint(self):
+        from django.db import IntegrityError
+
+        from netbox_ssl.models import MonitoredEndpoint, MonitoredEndpointCertificate
+
+        cert = _make_cert()
+        ep = MonitoredEndpoint.objects.create(name="x", url="https://x.example.com")
+        now = timezone.now()
+        MonitoredEndpointCertificate.objects.create(endpoint=ep, certificate=cert, first_seen=now, last_seen=now)
+        with pytest.raises(IntegrityError):
+            MonitoredEndpointCertificate.objects.create(endpoint=ep, certificate=cert, first_seen=now, last_seen=now)
+
+    def test_which_sites_share_a_certificate(self):
+        from netbox_ssl.models import MonitoredEndpoint
+
+        cert = _make_cert()
+        MonitoredEndpoint.objects.create(name="a", url="https://a.example.com", certificate=cert)
+        MonitoredEndpoint.objects.create(name="b", url="https://b.example.com", certificate=cert)
+        MonitoredEndpoint.objects.create(name="c", url="https://c.example.com", certificate=_make_cert())
+        assert MonitoredEndpoint.objects.filter(certificate=cert).count() == 2

--- a/tests/test_monitored_endpoint_model.py
+++ b/tests/test_monitored_endpoint_model.py
@@ -2,12 +2,17 @@
 
 import datetime
 import uuid
+from typing import TYPE_CHECKING
 
 import pytest
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
+if TYPE_CHECKING:
+    from netbox_ssl.models import Certificate
 
-def _make_cert(serial=None):
+
+def _make_cert(serial: str | None = None) -> "Certificate":
     from netbox_ssl.models import Certificate
 
     uid = uuid.uuid4()
@@ -49,16 +54,15 @@ class TestMonitoredEndpoint:
         assert ep.certificate is None
 
     def test_rotation_history_unique_constraint(self):
-        from django.db import IntegrityError
-
         from netbox_ssl.models import MonitoredEndpoint, MonitoredEndpointCertificate
 
         cert = _make_cert()
         ep = MonitoredEndpoint.objects.create(name="x", url="https://x.example.com")
         now = timezone.now()
         MonitoredEndpointCertificate.objects.create(endpoint=ep, certificate=cert, first_seen=now, last_seen=now)
-        with pytest.raises(IntegrityError):
-            MonitoredEndpointCertificate.objects.create(endpoint=ep, certificate=cert, first_seen=now, last_seen=now)
+        with pytest.raises(IntegrityError):  # noqa: SIM117
+            with transaction.atomic():
+                MonitoredEndpointCertificate.objects.create(endpoint=ep, certificate=cert, first_seen=now, last_seen=now)
 
     def test_which_sites_share_a_certificate(self):
         from netbox_ssl.models import MonitoredEndpoint

--- a/tests/test_monitored_endpoint_views.py
+++ b/tests/test_monitored_endpoint_views.py
@@ -88,6 +88,70 @@ class TestMonitoredEndpointImportViewPermission:
 
 
 @pytest.mark.django_db
+class TestMonitoredEndpointBulkImportColumns:
+    """Fix #149 review: bulk-import must honor the columns it advertises."""
+
+    def test_bulk_import_applies_tenant(self, client, django_user_model):
+        """A CSV row with a 'tenant' column creates an endpoint with that tenant set."""
+        from tenancy.models import Tenant
+
+        user = django_user_model.objects.create_user("bulk_tenant", password="x", is_superuser=True)
+        client.force_login(user)
+
+        tenant = Tenant.objects.create(name="BulkTenant", slug="bulk-tenant")
+
+        csv_data = "url,tenant\nhttps://tenant-test.example.com,BulkTenant"
+        resp = client.post(
+            "/plugins/ssl/monitored-endpoints/import/",
+            data={"csv_text": csv_data},
+        )
+        assert resp.status_code == 200
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        ep = MonitoredEndpoint.objects.filter(url="https://tenant-test.example.com:443").first()
+        assert ep is not None, "Endpoint was not created"
+        assert ep.tenant_id == tenant.pk, f"Expected tenant {tenant.pk}, got {ep.tenant_id}"
+
+    def test_bulk_import_name_derived_from_host(self, client, django_user_model):
+        """Endpoint name should be derived from host (not a CSV column) in bulk import."""
+        user = django_user_model.objects.create_user("bulk_name", password="x", is_superuser=True)
+        client.force_login(user)
+
+        csv_data = "url\nhttps://nametest.example.com"
+        resp = client.post(
+            "/plugins/ssl/monitored-endpoints/import/",
+            data={"csv_text": csv_data},
+        )
+        assert resp.status_code == 200
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        ep = MonitoredEndpoint.objects.filter(url="https://nametest.example.com:443").first()
+        assert ep is not None, "Endpoint was not created"
+        # Name must be derived from SNI or host, not from a 'name' CSV column
+        assert ep.name == "nametest.example.com"
+
+    def test_bulk_import_unknown_tenant_skips_gracefully(self, client, django_user_model):
+        """A CSV row with an unknown tenant still creates the endpoint without a tenant."""
+        user = django_user_model.objects.create_user("bulk_notenant", password="x", is_superuser=True)
+        client.force_login(user)
+
+        csv_data = "url,tenant\nhttps://notenant.example.com,NonExistentTenant"
+        resp = client.post(
+            "/plugins/ssl/monitored-endpoints/import/",
+            data={"csv_text": csv_data},
+        )
+        assert resp.status_code == 200
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        ep = MonitoredEndpoint.objects.filter(url="https://notenant.example.com:443").first()
+        assert ep is not None, "Endpoint was not created even without a matching tenant"
+        assert ep.tenant is None
+
+
+@pytest.mark.django_db
 class TestMonitoredEndpointHttpsEnforcement:
     """Security fix: javascript: and http: URLs must be rejected at form and model level."""
 

--- a/tests/test_monitored_endpoint_views.py
+++ b/tests/test_monitored_endpoint_views.py
@@ -1,0 +1,207 @@
+"""
+Tests for MonitoredEndpoint CRUD views and the #149 auto-create hook in url_import.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.django_db
+class TestMonitoredEndpointViews:
+    """Tests for MonitoredEndpoint list/detail views."""
+
+    def test_list_requires_login(self, client):
+        """Anonymous GET should redirect to login (302) or return 403."""
+        resp = client.get("/plugins/ssl/monitored-endpoints/")
+        assert resp.status_code in (302, 403)
+
+    def test_list_renders_for_superuser(self, client, django_user_model):
+        """Superuser GET should return 200 with the endpoint name in the response."""
+        user = django_user_model.objects.create_user("u", password="x", is_superuser=True)
+        client.force_login(user)
+        from netbox_ssl.models import MonitoredEndpoint
+
+        MonitoredEndpoint.objects.create(name="hr", url="https://hr.example.com")
+        resp = client.get("/plugins/ssl/monitored-endpoints/")
+        assert resp.status_code == 200
+        assert b"hr" in resp.content
+
+    def test_add_view_requires_login(self, client):
+        """Anonymous GET to add view should redirect."""
+        resp = client.get("/plugins/ssl/monitored-endpoints/add/")
+        assert resp.status_code in (302, 403)
+
+    def test_add_view_renders_for_superuser(self, client, django_user_model):
+        """Superuser GET to add view should return 200."""
+        user = django_user_model.objects.create_user("su2", password="x", is_superuser=True)
+        client.force_login(user)
+        resp = client.get("/plugins/ssl/monitored-endpoints/add/")
+        assert resp.status_code == 200
+
+    def test_detail_view_renders(self, client, django_user_model):
+        """Superuser can view the detail page for a monitored endpoint."""
+        user = django_user_model.objects.create_user("su3", password="x", is_superuser=True)
+        client.force_login(user)
+        from netbox_ssl.models import MonitoredEndpoint
+
+        ep = MonitoredEndpoint.objects.create(name="payments", url="https://pay.example.com")
+        resp = client.get(f"/plugins/ssl/monitored-endpoints/{ep.pk}/")
+        assert resp.status_code == 200
+        assert b"payments" in resp.content
+
+    def test_import_view_requires_login(self, client):
+        """Anonymous GET to import view should redirect."""
+        resp = client.get("/plugins/ssl/monitored-endpoints/import/")
+        assert resp.status_code in (302, 403)
+
+    def test_import_view_get_renders(self, client, django_user_model):
+        """Superuser GET to import view renders input form."""
+        user = django_user_model.objects.create_user("su4", password="x", is_superuser=True)
+        client.force_login(user)
+        resp = client.get("/plugins/ssl/monitored-endpoints/import/")
+        assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+class TestAutoCreateHook:
+    """Test the #149 auto-create hook in url_import._process_row."""
+
+    def _make_outcome(self, url: str, common_name: str = "test.example.com"):
+        """Create a fake scrape_and_import outcome."""
+        from netbox_ssl.models import Certificate
+
+        cert = Certificate.objects.create(
+            common_name=common_name,
+            serial_number="AABBCC",
+            issuer="Test CA",
+            valid_from="2025-01-01T00:00:00Z",
+            valid_to="2026-01-01T00:00:00Z",
+            fingerprint_sha256="AA:BB:CC",
+            algorithm="RSA",
+        )
+        outcome = MagicMock()
+        outcome.created = True
+        outcome.certificate = cert
+        return outcome
+
+    def test_process_row_creates_monitored_endpoint(self, client, django_user_model):
+        """When _process_row succeeds with status 'imported', a MonitoredEndpoint is upserted."""
+        user = django_user_model.objects.create_user("su5", password="x", is_superuser=True)
+        url = "https://import.example.com:443"
+        row = {
+            "row": 1,
+            "url": url,
+            "host": "import.example.com",
+            "port": 443,
+            "sni": "import.example.com",
+            "verify_chain": True,
+            "assigned_device": "",
+            "assigned_vm": "",
+            "assigned_service": "",
+            "tenant": "",
+        }
+        outcome = self._make_outcome(url)
+
+        request = MagicMock()
+        request.user = user
+
+        from tenancy.models import Tenant
+
+        user_tenants = Tenant.objects.none()
+
+        with patch("netbox_ssl.views.url_import.scrape_and_import", return_value=outcome):
+            from netbox_ssl.views.url_import import UrlImportView
+
+            view = UrlImportView()
+            result = view._process_row(request, row, allowlist=[], user_tenants=user_tenants, default_tenant=None)
+
+        assert result["status"] in ("imported", "imported_untrusted")
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        assert MonitoredEndpoint.objects.filter(url=url).exists()
+        ep = MonitoredEndpoint.objects.get(url=url)
+        assert ep.certificate == outcome.certificate
+        assert ep.status == "ok"
+
+    def test_process_row_upserts_existing_endpoint(self, client, django_user_model):
+        """When the MonitoredEndpoint already exists, update_or_create updates it."""
+        user = django_user_model.objects.create_user("su6", password="x", is_superuser=True)
+        url = "https://upsert.example.com:443"
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        existing = MonitoredEndpoint.objects.create(name="old-name", url=url)
+
+        row = {
+            "row": 1,
+            "url": url,
+            "host": "upsert.example.com",
+            "port": 443,
+            "sni": "upsert.example.com",
+            "verify_chain": True,
+            "assigned_device": "",
+            "assigned_vm": "",
+            "assigned_service": "",
+            "tenant": "",
+        }
+        outcome = self._make_outcome(url, common_name="upsert.example.com")
+
+        request = MagicMock()
+        request.user = user
+
+        from tenancy.models import Tenant
+
+        user_tenants = Tenant.objects.none()
+
+        with patch("netbox_ssl.views.url_import.scrape_and_import", return_value=outcome):
+            from netbox_ssl.views.url_import import UrlImportView
+
+            view = UrlImportView()
+            view._process_row(request, row, allowlist=[], user_tenants=user_tenants, default_tenant=None)
+
+        # Still only one endpoint for this URL.
+        assert MonitoredEndpoint.objects.filter(url=url).count() == 1
+        existing.refresh_from_db()
+        assert existing.certificate == outcome.certificate
+
+    def test_process_row_no_endpoint_on_error(self, client, django_user_model):
+        """When scrape fails, no MonitoredEndpoint is created."""
+        from netbox_ssl.utils.tls_scraper import TLSScrapeError
+
+        user = django_user_model.objects.create_user("su7", password="x", is_superuser=True)
+        url = "https://unreachable.example.com:443"
+        row = {
+            "row": 1,
+            "url": url,
+            "host": "unreachable.example.com",
+            "port": 443,
+            "sni": "unreachable.example.com",
+            "verify_chain": True,
+            "assigned_device": "",
+            "assigned_vm": "",
+            "assigned_service": "",
+            "tenant": "",
+        }
+
+        request = MagicMock()
+        request.user = user
+
+        from tenancy.models import Tenant
+
+        user_tenants = Tenant.objects.none()
+
+        with patch("netbox_ssl.views.url_import.scrape_and_import", side_effect=TLSScrapeError("timeout")):
+            from netbox_ssl.views.url_import import UrlImportView
+
+            view = UrlImportView()
+            result = view._process_row(request, row, allowlist=[], user_tenants=user_tenants, default_tenant=None)
+
+        assert result["status"] == "unreachable"
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        assert not MonitoredEndpoint.objects.filter(url=url).exists()

--- a/tests/test_monitored_endpoint_views.py
+++ b/tests/test_monitored_endpoint_views.py
@@ -66,6 +66,82 @@ class TestMonitoredEndpointViews:
 
 
 @pytest.mark.django_db
+class TestMonitoredEndpointImportViewPermission:
+    """Security fix: bulk-import POST must be gated on add_monitoredendpoint."""
+
+    def test_import_post_denied_without_perm(self, client, django_user_model):
+        """Non-superuser without add_monitoredendpoint cannot create via import POST."""
+        user = django_user_model.objects.create_user("noperm", password="x", is_superuser=False)
+        client.force_login(user)
+        resp = client.post(
+            "/plugins/ssl/monitored-endpoints/import/",
+            data={"csv_text": "url\nhttps://blocked.example.com"},
+        )
+        # Must redirect (not 200/create)
+        assert resp.status_code == 302
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        assert not MonitoredEndpoint.objects.filter(url__contains="blocked.example.com").exists()
+
+
+@pytest.mark.django_db
+class TestMonitoredEndpointHttpsEnforcement:
+    """Security fix: javascript: and http: URLs must be rejected at form and model level."""
+
+    def test_form_rejects_javascript_uri(self):
+        """MonitoredEndpointForm.clean_url must raise on javascript: URI."""
+        from netbox_ssl.forms import MonitoredEndpointForm
+
+        form = MonitoredEndpointForm(data={"name": "evil", "url": "javascript:alert(1)"})
+        assert not form.is_valid()
+        assert "url" in form.errors
+
+    def test_form_rejects_http_url(self):
+        """MonitoredEndpointForm.clean_url must raise on plain http:// URL."""
+        from netbox_ssl.forms import MonitoredEndpointForm
+
+        form = MonitoredEndpointForm(data={"name": "plain", "url": "http://example.com"})
+        assert not form.is_valid()
+        assert "url" in form.errors
+
+    def test_form_accepts_https_url(self):
+        """MonitoredEndpointForm.clean_url must accept a valid https:// URL."""
+        from netbox_ssl.forms import MonitoredEndpointForm
+
+        form = MonitoredEndpointForm(data={"name": "ok", "url": "https://secure.example.com"})
+        # The url field itself should not error; other fields (tags etc.) may be absent but url is fine
+        assert "url" not in form.errors
+
+    def test_model_clean_rejects_javascript_uri(self):
+        """MonitoredEndpoint.clean() must raise ValidationError on javascript: URI."""
+        from django.core.exceptions import ValidationError
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        ep = MonitoredEndpoint(name="evil", url="javascript:alert(1)")
+        with pytest.raises(ValidationError):
+            ep.clean()
+
+    def test_model_clean_rejects_http_url(self):
+        """MonitoredEndpoint.clean() must raise ValidationError on http:// URL."""
+        from django.core.exceptions import ValidationError
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        ep = MonitoredEndpoint(name="plain", url="http://example.com")
+        with pytest.raises(ValidationError):
+            ep.clean()
+
+    def test_model_clean_accepts_https_url(self):
+        """MonitoredEndpoint.clean() must not raise on a valid https:// URL."""
+        from netbox_ssl.models import MonitoredEndpoint
+
+        ep = MonitoredEndpoint(name="ok", url="https://secure.example.com")
+        ep.clean()  # Should not raise
+
+
+@pytest.mark.django_db
 class TestAutoCreateHook:
     """Test the #149 auto-create hook in url_import._process_row."""
 

--- a/tests/test_monitored_endpoint_views.py
+++ b/tests/test_monitored_endpoint_views.py
@@ -557,3 +557,18 @@ class TestEndpointDetailRotationHistoryTab:
         assert resp.status_code == 200
         assert uid_a.encode() in resp.content
         assert uid_b.encode() in resp.content
+
+
+@pytest.mark.django_db
+class TestMonitoredEndpointApiSerializer:
+    """Regression for #152: NetBox serializes a model for events on save
+    (``serialize_for_event`` → ``get_serializer_for_model``). A missing
+    serializer raises ``SerializerNotFound`` on NetBox 4.4, breaking any save in
+    a request context. Guard that a serializer is registered."""
+
+    def test_serializer_is_discoverable(self):
+        from utilities.api import get_serializer_for_model
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        assert get_serializer_for_model(MonitoredEndpoint) is not None

--- a/tests/test_monitored_endpoint_views.py
+++ b/tests/test_monitored_endpoint_views.py
@@ -4,6 +4,8 @@ Tests for MonitoredEndpoint CRUD views and the #149 auto-create hook in url_impo
 
 from __future__ import annotations
 
+import datetime
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -281,3 +283,173 @@ class TestAutoCreateHook:
         from netbox_ssl.models import MonitoredEndpoint
 
         assert not MonitoredEndpoint.objects.filter(url=url).exists()
+
+
+@pytest.mark.django_db
+class TestCertificateDetailMonitoredEndpointsTab:
+    """Certificate detail page shows the Monitored Endpoints reverse tab (#149)."""
+
+    def _make_cert(self, uid: str):
+        from django.utils import timezone
+
+        from netbox_ssl.models import Certificate
+
+        # Use uid bytes so each cert gets a unique fingerprint.
+        uid_bytes = uid.encode()[:8].ljust(8, b"\x00")
+        fingerprint = ":".join([f"{b:02X}" for b in (uid_bytes * 4)[:32]])
+        return Certificate.objects.create(
+            common_name=f"{uid}.example.com",
+            serial_number=f"S:{uid}",
+            issuer="CA",
+            valid_from=timezone.now(),
+            valid_to=timezone.now() + datetime.timedelta(days=90),
+            fingerprint_sha256=fingerprint,
+            algorithm="RSA",
+        )
+
+    def test_certificate_detail_shows_linked_endpoints(self, client, django_user_model):
+        """Certificate detail page lists a MonitoredEndpoint that points to it."""
+        user = django_user_model.objects.create_user("u2", password="x", is_superuser=True)
+        client.force_login(user)
+        uid = uuid.uuid4().hex[:8]
+        cert = self._make_cert(uid)
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        MonitoredEndpoint.objects.create(name="hr-portal", url="https://hr.example.com", certificate=cert)
+
+        resp = client.get(f"/plugins/ssl/certificates/{cert.pk}/")
+        assert resp.status_code == 200
+        assert b"hr-portal" in resp.content
+
+    def test_certificate_detail_no_endpoints_tab_hidden(self, client, django_user_model):
+        """Certificate detail page does not show the Monitored Endpoints tab when no endpoints exist."""
+        user = django_user_model.objects.create_user("u3", password="x", is_superuser=True)
+        client.force_login(user)
+        uid = uuid.uuid4().hex[:8]
+        cert = self._make_cert(uid)
+
+        resp = client.get(f"/plugins/ssl/certificates/{cert.pk}/")
+        assert resp.status_code == 200
+        # Tab anchor should not be in the page
+        assert b"tab-monitored-endpoints" not in resp.content
+
+    def test_certificate_detail_multiple_endpoints(self, client, django_user_model):
+        """Certificate detail page lists all MonitoredEndpoints linked to a certificate."""
+        user = django_user_model.objects.create_user("u4", password="x", is_superuser=True)
+        client.force_login(user)
+        uid = uuid.uuid4().hex[:8]
+        cert = self._make_cert(uid)
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        MonitoredEndpoint.objects.create(name="endpoint-alpha", url="https://alpha.example.com", certificate=cert)
+        MonitoredEndpoint.objects.create(name="endpoint-beta", url="https://beta.example.com", certificate=cert)
+
+        resp = client.get(f"/plugins/ssl/certificates/{cert.pk}/")
+        assert resp.status_code == 200
+        assert b"endpoint-alpha" in resp.content
+        assert b"endpoint-beta" in resp.content
+
+
+@pytest.mark.django_db
+class TestEndpointDetailRotationHistoryTab:
+    """Endpoint detail page shows the Rotation History tab (#149)."""
+
+    def _make_cert(self, uid: str, days: int = 90):
+        from django.utils import timezone
+
+        from netbox_ssl.models import Certificate
+
+        # Use uid bytes so each cert gets a unique fingerprint.
+        uid_bytes = uid.encode()[:8].ljust(8, b"\x00")
+        fingerprint = ":".join([f"{b:02X}" for b in (uid_bytes * 4)[:32]])
+        return Certificate.objects.create(
+            common_name=f"{uid}.example.com",
+            serial_number=f"S:{uid}",
+            issuer="CA",
+            valid_from=timezone.now(),
+            valid_to=timezone.now() + datetime.timedelta(days=days),
+            fingerprint_sha256=fingerprint,
+            algorithm="RSA",
+        )
+
+    def test_rotation_history_tab_renders_empty(self, client, django_user_model):
+        """Endpoint detail page shows Rotation History tab even when empty."""
+        user = django_user_model.objects.create_user("rh1", password="x", is_superuser=True)
+        client.force_login(user)
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        ep = MonitoredEndpoint.objects.create(name="my-portal", url="https://portal.example.com")
+        resp = client.get(f"/plugins/ssl/monitored-endpoints/{ep.pk}/")
+        assert resp.status_code == 200
+        assert b"Rotation History" in resp.content
+        assert b"No rotation history recorded yet." in resp.content
+
+    def test_rotation_history_tab_shows_certificate(self, client, django_user_model):
+        """Endpoint detail page lists MonitoredEndpointCertificate entries in Rotation History."""
+        from django.utils import timezone
+
+        user = django_user_model.objects.create_user("rh2", password="x", is_superuser=True)
+        client.force_login(user)
+        uid = uuid.uuid4().hex[:8]
+        cert = self._make_cert(uid)
+
+        from netbox_ssl.models import MonitoredEndpoint, MonitoredEndpointCertificate
+
+        ep = MonitoredEndpoint.objects.create(
+            name="history-portal",
+            url="https://history.example.com",
+            certificate=cert,
+        )
+        now = timezone.now()
+        MonitoredEndpointCertificate.objects.create(
+            endpoint=ep,
+            certificate=cert,
+            first_seen=now - datetime.timedelta(days=30),
+            last_seen=now,
+        )
+
+        resp = client.get(f"/plugins/ssl/monitored-endpoints/{ep.pk}/")
+        assert resp.status_code == 200
+        assert b"Rotation History" in resp.content
+        # Certificate's common_name should appear in the history table
+        assert uid.encode() in resp.content
+
+    def test_rotation_history_shows_multiple_entries(self, client, django_user_model):
+        """Endpoint detail page lists all historical certificate entries."""
+        from django.utils import timezone
+
+        user = django_user_model.objects.create_user("rh3", password="x", is_superuser=True)
+        client.force_login(user)
+        uid_a = uuid.uuid4().hex[:8]
+        uid_b = uuid.uuid4().hex[:8]
+        cert_a = self._make_cert(uid_a, days=90)
+        cert_b = self._make_cert(uid_b, days=180)
+
+        from netbox_ssl.models import MonitoredEndpoint, MonitoredEndpointCertificate
+
+        ep = MonitoredEndpoint.objects.create(
+            name="multi-history",
+            url="https://multi.example.com",
+            certificate=cert_b,
+        )
+        now = timezone.now()
+        MonitoredEndpointCertificate.objects.create(
+            endpoint=ep,
+            certificate=cert_a,
+            first_seen=now - datetime.timedelta(days=180),
+            last_seen=now - datetime.timedelta(days=90),
+        )
+        MonitoredEndpointCertificate.objects.create(
+            endpoint=ep,
+            certificate=cert_b,
+            first_seen=now - datetime.timedelta(days=90),
+            last_seen=now,
+        )
+
+        resp = client.get(f"/plugins/ssl/monitored-endpoints/{ep.pk}/")
+        assert resp.status_code == 200
+        assert uid_a.encode() in resp.content
+        assert uid_b.encode() in resp.content

--- a/tests/test_monitored_endpoint_views.py
+++ b/tests/test_monitored_endpoint_views.py
@@ -150,6 +150,46 @@ class TestMonitoredEndpointBulkImportColumns:
         assert ep is not None, "Endpoint was not created even without a matching tenant"
         assert ep.tenant is None
 
+    def test_bulk_import_assigns_device(self, client, django_user_model):
+        """A CSV row with 'assigned_device' sets the GenericFK assigned_object on the endpoint."""
+        from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+        from django.contrib.contenttypes.models import ContentType
+
+        user = django_user_model.objects.create_user("bulk_device", password="x", is_superuser=True)
+        client.force_login(user)
+
+        # Build required DCIM FK chain.
+        site = Site.objects.create(name="BulkSite", slug="bulk-site")
+        manufacturer = Manufacturer.objects.create(name="BulkMfg", slug="bulk-mfg")
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model="BulkModel",
+            slug="bulk-model",
+        )
+        device_role = DeviceRole.objects.create(name="BulkRole", slug="bulk-role", color="ffffff")
+        device = Device.objects.create(
+            name="BulkDevice",
+            site=site,
+            device_type=device_type,
+            role=device_role,
+        )
+
+        csv_data = f"url,assigned_device\nhttps://device-assign.example.com,{device.name}"
+        resp = client.post(
+            "/plugins/ssl/monitored-endpoints/import/",
+            data={"csv_text": csv_data},
+        )
+        assert resp.status_code == 200
+
+        from netbox_ssl.models import MonitoredEndpoint
+
+        ep = MonitoredEndpoint.objects.filter(url="https://device-assign.example.com:443").first()
+        assert ep is not None, "Endpoint was not created"
+        assert ep.assigned_object is not None, "assigned_object was not set"
+        expected_ct = ContentType.objects.get_for_model(Device)
+        assert ep.assigned_object_type == expected_ct, "Wrong ContentType on assigned_object_type"
+        assert ep.assigned_object_id == device.pk, "Wrong pk on assigned_object_id"
+
 
 @pytest.mark.django_db
 class TestMonitoredEndpointHttpsEnforcement:

--- a/tests/test_url_cert_import.py
+++ b/tests/test_url_cert_import.py
@@ -93,6 +93,21 @@ class TestScrapeAndImport:
         assert outcome.created is True
         assert outcome.certificate.discovered_via_url == ""
 
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch("netbox_ssl.utils.url_cert_import.socket.getaddrinfo", side_effect=OSError("Name or service not known"))
+    def test_dns_failure_raises_tls_scrape_error(self, _gai, _val):
+        """DNS OSError from getaddrinfo must surface as TLSScrapeError (not bare OSError)."""
+        from netbox_ssl.utils.tls_scraper import TLSScrapeError
+        from netbox_ssl.utils.url_cert_import import scrape_and_import
+
+        with pytest.raises(TLSScrapeError, match="DNS failed"):
+            scrape_and_import(
+                "https://no-such-host.example.com",
+                "no-such-host.example.com",
+                443,
+                allowlist=[],
+            )
+
 
 @pytest.mark.unit
 @pytest.mark.django_db
@@ -109,7 +124,8 @@ class TestProcessRowParity:
         """_process_row returns {'status': 'imported', 'url': ..., 'detail': CN, 'pk': id}."""
         from netbox_ssl.views.url_import import UrlImportView
 
-        mock_scrape.return_value = _pem()
+        cn = "import-shape.example.com"
+        mock_scrape.return_value = _pem(cn=cn)
         view = UrlImportView()
         row = {
             "url": "https://c.example.com",
@@ -122,7 +138,7 @@ class TestProcessRowParity:
         result = view._process_row(None, row, [], [], None)
         assert result["status"] == "imported"
         assert result["url"] == "https://c.example.com"
-        assert "detail" in result
+        assert result["detail"] == cn
         assert "pk" in result
 
     @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
@@ -135,7 +151,8 @@ class TestProcessRowParity:
         """Second call with same cert returns {'status': 'matched', 'pk': ...}."""
         from netbox_ssl.views.url_import import UrlImportView
 
-        pem = _pem()
+        pem_cn = "matched-shape.example.com"
+        pem = _pem(cn=pem_cn)
         mock_scrape.return_value = pem
         view = UrlImportView()
         row = {
@@ -150,7 +167,7 @@ class TestProcessRowParity:
         result = view._process_row(None, row, [], [], None)
         assert result["status"] == "matched"
         assert "pk" in result
-        assert "detail" in result
+        assert result["detail"] == pem_cn
 
     @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
     @patch(

--- a/tests/test_url_cert_import.py
+++ b/tests/test_url_cert_import.py
@@ -1,0 +1,225 @@
+"""Unit tests for the shared scrape-and-import service (Task 2, #149)."""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add tests/ dir so cert_factory can be imported as a top-level module
+# (mirrors the pattern in test_aws_acm_adapter.py).
+_tests_dir = Path(__file__).parent
+if str(_tests_dir) not in sys.path:
+    sys.path.insert(0, str(_tests_dir))
+
+from cert_factory import CertFactory  # noqa: E402
+
+
+def _pem(cn: str | None = None) -> str:
+    """Return a fresh self-signed PEM for test isolation."""
+    return CertFactory.create(cn=cn or f"{uuid.uuid4().hex[:8]}.example.com")
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestScrapeAndImport:
+    """Core create / dedup behaviour of scrape_and_import."""
+
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch(
+        "netbox_ssl.utils.url_cert_import.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("203.0.113.10", 443))],
+    )
+    @patch("netbox_ssl.utils.url_cert_import.scrape_tls_certificate")
+    def test_creates_certificate_on_miss(self, mock_scrape, _gai, _val):
+        """First import creates the Certificate row."""
+        from netbox_ssl.models import Certificate
+        from netbox_ssl.utils.url_cert_import import scrape_and_import
+
+        mock_scrape.return_value = _pem()
+        before = Certificate.objects.count()
+        outcome = scrape_and_import(
+            "https://a.example.com", "a.example.com", 443, allowlist=[]
+        )
+        assert outcome.created is True
+        assert Certificate.objects.count() == before + 1
+        assert outcome.certificate.discovered_via_url == "https://a.example.com"
+
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch(
+        "netbox_ssl.utils.url_cert_import.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("203.0.113.10", 443))],
+    )
+    @patch("netbox_ssl.utils.url_cert_import.scrape_tls_certificate")
+    def test_matches_existing_on_second_call(self, mock_scrape, _gai, _val):
+        """Second call with same cert returns created=False and the same PK."""
+        from netbox_ssl.models import Certificate
+        from netbox_ssl.utils.url_cert_import import scrape_and_import
+
+        pem = _pem()
+        mock_scrape.return_value = pem
+        first = scrape_and_import(
+            "https://a.example.com", "a.example.com", 443, allowlist=[]
+        )
+        before = Certificate.objects.count()
+        second = scrape_and_import(
+            "https://a.example.com", "a.example.com", 443, allowlist=[]
+        )
+        assert second.created is False
+        assert second.certificate.pk == first.certificate.pk
+        assert Certificate.objects.count() == before
+
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch(
+        "netbox_ssl.utils.url_cert_import.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("203.0.113.10", 443))],
+    )
+    @patch("netbox_ssl.utils.url_cert_import.scrape_tls_certificate")
+    def test_set_discovered_url_false_leaves_field_empty(self, mock_scrape, _gai, _val):
+        """When set_discovered_url=False the field is not written."""
+        from netbox_ssl.utils.url_cert_import import scrape_and_import
+
+        mock_scrape.return_value = _pem()
+        outcome = scrape_and_import(
+            "https://b.example.com",
+            "b.example.com",
+            443,
+            allowlist=[],
+            set_discovered_url=False,
+        )
+        assert outcome.created is True
+        assert outcome.certificate.discovered_via_url == ""
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestProcessRowParity:
+    """#106 parity: _process_row must return the documented outcome dict shapes."""
+
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch(
+        "netbox_ssl.utils.url_cert_import.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("203.0.113.10", 443))],
+    )
+    @patch("netbox_ssl.utils.url_cert_import.scrape_tls_certificate")
+    def test_imported_outcome_shape(self, mock_scrape, _gai, _val):
+        """_process_row returns {'status': 'imported', 'url': ..., 'detail': CN, 'pk': id}."""
+        from netbox_ssl.views.url_import import UrlImportView
+
+        mock_scrape.return_value = _pem()
+        view = UrlImportView()
+        row = {
+            "url": "https://c.example.com",
+            "host": "c.example.com",
+            "port": 443,
+            "sni": None,
+            "verify_chain": True,
+            "tenant": None,
+        }
+        result = view._process_row(None, row, [], [], None)
+        assert result["status"] == "imported"
+        assert result["url"] == "https://c.example.com"
+        assert "detail" in result
+        assert "pk" in result
+
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch(
+        "netbox_ssl.utils.url_cert_import.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("203.0.113.10", 443))],
+    )
+    @patch("netbox_ssl.utils.url_cert_import.scrape_tls_certificate")
+    def test_matched_outcome_shape(self, mock_scrape, _gai, _val):
+        """Second call with same cert returns {'status': 'matched', 'pk': ...}."""
+        from netbox_ssl.views.url_import import UrlImportView
+
+        pem = _pem()
+        mock_scrape.return_value = pem
+        view = UrlImportView()
+        row = {
+            "url": "https://d.example.com",
+            "host": "d.example.com",
+            "port": 443,
+            "sni": None,
+            "verify_chain": True,
+            "tenant": None,
+        }
+        view._process_row(None, row, [], [], None)
+        result = view._process_row(None, row, [], [], None)
+        assert result["status"] == "matched"
+        assert "pk" in result
+        assert "detail" in result
+
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch(
+        "netbox_ssl.utils.url_cert_import.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("203.0.113.10", 443))],
+    )
+    @patch("netbox_ssl.utils.url_cert_import.scrape_tls_certificate")
+    def test_blocked_outcome_shape(self, mock_scrape, _gai, mock_val):
+        """URLValidationError maps to {'status': 'blocked'}."""
+        from netbox_ssl.utils.url_validation import URLValidationError
+        from netbox_ssl.views.url_import import UrlImportView
+
+        mock_val.side_effect = URLValidationError("blocked")
+        view = UrlImportView()
+        row = {
+            "url": "https://10.0.0.1",
+            "host": "10.0.0.1",
+            "port": 443,
+            "sni": None,
+            "verify_chain": True,
+            "tenant": None,
+        }
+        result = view._process_row(None, row, [], [], None)
+        assert result["status"] == "blocked"
+        assert result["url"] == "https://10.0.0.1"
+
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch(
+        "netbox_ssl.utils.url_cert_import.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("203.0.113.10", 443))],
+    )
+    @patch("netbox_ssl.utils.url_cert_import.scrape_tls_certificate")
+    def test_unreachable_outcome_shape(self, mock_scrape, _gai, _val):
+        """TLSScrapeError maps to {'status': 'unreachable'}."""
+        from netbox_ssl.utils.tls_scraper import TLSScrapeError
+        from netbox_ssl.views.url_import import UrlImportView
+
+        mock_scrape.side_effect = TLSScrapeError("timeout")
+        view = UrlImportView()
+        row = {
+            "url": "https://e.example.com",
+            "host": "e.example.com",
+            "port": 443,
+            "sni": None,
+            "verify_chain": True,
+            "tenant": None,
+        }
+        result = view._process_row(None, row, [], [], None)
+        assert result["status"] == "unreachable"
+
+    @patch("netbox_ssl.utils.url_cert_import.validate_https_url")
+    @patch(
+        "netbox_ssl.utils.url_cert_import.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("203.0.113.10", 443))],
+    )
+    @patch("netbox_ssl.utils.url_cert_import.scrape_tls_certificate")
+    def test_imported_untrusted_when_verify_chain_false(self, mock_scrape, _gai, _val):
+        """verify_chain=False yields {'status': 'imported_untrusted'}."""
+        from netbox_ssl.views.url_import import UrlImportView
+
+        mock_scrape.return_value = _pem()
+        view = UrlImportView()
+        row = {
+            "url": "https://f.example.com",
+            "host": "f.example.com",
+            "port": 443,
+            "sni": None,
+            "verify_chain": False,
+            "tenant": None,
+        }
+        result = view._process_row(None, row, [], [], None)
+        assert result["status"] == "imported_untrusted"

--- a/tests/test_url_cert_import.py
+++ b/tests/test_url_cert_import.py
@@ -23,7 +23,6 @@ def _pem(cn: str | None = None) -> str:
     return CertFactory.create(cn=cn or f"{uuid.uuid4().hex[:8]}.example.com")
 
 
-@pytest.mark.unit
 @pytest.mark.django_db
 class TestScrapeAndImport:
     """Core create / dedup behaviour of scrape_and_import."""
@@ -109,7 +108,6 @@ class TestScrapeAndImport:
             )
 
 
-@pytest.mark.unit
 @pytest.mark.django_db
 class TestProcessRowParity:
     """#106 parity: _process_row must return the documented outcome dict shapes."""


### PR DESCRIPTION
## Summary

Adds **website-centric certificate monitoring**: a new `MonitoredEndpoint` is a first-class object that is periodically re-scraped, tracking the certificate it currently presents — with rotation history, per-endpoint events, and a "which sites share this certificate" view. Requested by @SerhiiZahuba.

Maximum reuse of the #106 URL-import machinery (TLS scraper + security model) and the v0.6 event system. **Target release: v1.3.**

## What's included

- **Models** (`models/monitored_endpoint.py`) — `MonitoredEndpoint` (NetBoxModel: url, sni, current `certificate`, optional device/VM/service + tenant, status, last_checked/last_seen) + `MonitoredEndpointCertificate` rotation history. One **additive** migration (`0025`); no existing-model changes.
- **Shared import service** (`utils/url_cert_import.py`) — `scrape_and_import()` extracted from the #106 URL-import view so #106 and the poll share one validate→scrape→parse→dedup path (with **#106 parity tests**).
- **Poll service + events** (`utils/endpoint_monitor.py`) — `poll_endpoint()` re-scrapes an endpoint, links the cert, records rotation, and fires `endpoint_unreachable` / `endpoint_cert_rotated` / `endpoint_untrusted_cert` events (via the v0.6 `last_updated` mechanism). Two-attempt trust detection (verified → untrusted).
- **Re-poll Script** (`scripts/endpoint_monitor.py`) — `MonitoredEndpointPoll` (NetBox-scheduled, tenant filter, dry-run).
- **CRUD + provisioning** — list/detail/edit/delete views, table, filterset, form, nav; bulk CSV import (reuses `url_bulk_parser`, honors tenant + device/vm/service columns); auto-create of an endpoint from each #106 URL import.
- **Website-centric views** — endpoint detail **Rotation History** tab; a **Monitored Endpoints** tab on the certificate detail page (the reverse of #148's assignments).

## Security (v0.7.5 + spec)

HTTPS-only enforced at every write path (form `clean_url`, model `clean()`, `url_bulk_parser`); bulk-import perm-gated on `add_monitoredendpoint`; `.restrict(user, "view")` on the cert reverse query **and** the device/vm/service assignment lookups; both detail templates scheme-guard the URL `href` (no `javascript:`); the poll re-validates the URL each run (DNS-rebinding defense, private-IP block + CIDR allowlist via the existing TLS scraper). Two background commit-security findings (import authz, template XSS) were caught and fixed during development.

## Test plan

- ✅ 63 new tests across 6 files, all `@pytest.mark.django_db`, run together in-container against the real ORM/HTTP — no cross-file contamination. Service / poll / script / model / views / #106 parity all covered.
- ✅ `makemigrations --check` clean (migration 0025 fully captures the NetBoxModel, canonical `custom_field_data`/`tags`).
- ✅ ruff clean; Django system checks pass.
- ✅ **Live UI smoke** on NetBox 4.5 (Docker): endpoint list, endpoint detail + rotation tab, and the certificate's Monitored Endpoints tab all render and link correctly.

## Design docs

- Spec: `project-requirement-document/specs/2026-06-20-149-website-centric-monitoring-design.md`
- Plan: `project-requirement-document/plans/2026-06-20-149-website-centric-monitoring.md`

## Notes

- No REST API / GraphQL surface for `MonitoredEndpoint` (deferred; not in scope).
- Built via brainstorm → spec → plan → subagent-driven development (6 tasks, per-task review + adversarial fix loops, final whole-branch review on the most capable model).

Closes #149