### PR TITLE
chore: pre-cut release-rehearsal preflight (release_preflight.py)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://pypi.org/project/netbox-ssl/"><img src="https://img.shields.io/pypi/pyversions/netbox-ssl" alt="Python"></a>
   <a href="https://github.com/ctrl-alt-automate/netbox-ssl/actions/workflows/ci.yml"><img src="https://github.com/ctrl-alt-automate/netbox-ssl/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
-  <a href="https://github.com/netbox-community/netbox"><img src="https://img.shields.io/badge/NetBox-4.4%20%7C%204.5-blue.svg" alt="NetBox"></a>
+  <a href="https://github.com/netbox-community/netbox"><img src="https://img.shields.io/badge/NetBox-4.4%20%7C%204.5%20%7C%204.6-blue.svg" alt="NetBox"></a>
   <img src="https://img.shields.io/badge/Status-Stable-brightgreen.svg" alt="Stable">
 </p>
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -153,6 +153,20 @@ days. For urgent security issues, see [SECURITY.md](https://github.com/ctrl-alt-
 
 ## Release process (for maintainers)
 
+Before cutting, run the **pre-cut rehearsal** and fix anything it flags:
+
+```bash
+python scripts/release_preflight.py X.Y.Z
+```
+
+It inspects files only (no container, no network) and asserts the
+release-critical invariants that have each broken a past release: version sync
+(`pyproject.toml` ↔ `netbox_ssl/__init__.py`), a dated `CHANGELOG` section for
+the target version, the NetBox support matrix (PluginConfig `min`/`max_version`
+↔ README badge + table ↔ `COMPATIBILITY.md`), the publish-gate poll budget
+(#141/#142), and the gh-pages serialization guard (#110). Exit code is non-zero
+if any check fails.
+
 1. Create `release/vX.Y.Z` branch from `dev`
 2. Bump version in `pyproject.toml` and `netbox_ssl/__init__.py`
 3. Add CHANGELOG `[X.Y.Z]` section with Added/Changed/Deprecated/Security

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Pre-cut release rehearsal for the NetBox SSL plugin.
+
+Run this BEFORE tagging a release. It asserts the release-critical invariants
+that have each broken a past release, by *inspecting files only* — no network,
+no container, no ``netbox_ssl`` import — so it runs anywhere in well under a
+second:
+
+  - **version drift** between ``pyproject.toml`` and ``netbox_ssl/__init__.py``
+  - **CHANGELOG** missing a dated ``## [X.Y.Z] - YYYY-MM-DD`` section for the
+    release you are about to cut
+  - **NetBox support matrix** stale across the PluginConfig ``min_version`` /
+    ``max_version``, the README badge + table, and ``COMPATIBILITY.md``
+    (a stale README badge shipped in v1.2.x)
+  - **publish gate budget** — the ``verify-ci`` poll loop in ``publish.yml`` must
+    outlast the integration matrix, or the tag-push Publish run times out before
+    CI goes green (#141 / #142)
+  - **gh-pages serialization guard** — ``docs.yml`` must keep its ``concurrency``
+    group with ``cancel-in-progress: false`` or the release docs deploy races
+    the main-push deploy (#110)
+
+Usage::
+
+    python scripts/release_preflight.py 1.3.0
+    python scripts/release_preflight.py 1.3.0 --repo-root /path/to/repo
+
+Exits 0 if every check passes, 1 if any fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+
+# The publish.yml verify-ci gate must poll for at least this long. The slowest
+# integration job (NetBox 4.4) has been observed at ~16.5 min; 25 min leaves
+# margin without waiting absurdly long. See #141 / #142.
+MIN_GATE_SECONDS = 1500
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Outcome of a single preflight check."""
+
+    name: str
+    passed: bool
+    detail: str
+
+
+# --------------------------------------------------------------------------- #
+# Pure parsers — text in, data out, no I/O                                     #
+# --------------------------------------------------------------------------- #
+
+
+def extract_pyproject_version(text: str) -> str | None:
+    """Return the ``[project] version`` string from pyproject.toml, or None."""
+    match = re.search(r"""(?m)^version\s*=\s*["']([^"']+)["']""", text)
+    return match.group(1) if match else None
+
+
+def extract_init_version(text: str) -> str | None:
+    """Return ``__version__`` from netbox_ssl/__init__.py, or None."""
+    match = re.search(r"""(?m)^__version__\s*=\s*["']([^"']+)["']""", text)
+    return match.group(1) if match else None
+
+
+def changelog_release_versions(text: str) -> set[str]:
+    """Return every dated ``## [X.Y.Z] - YYYY-MM-DD`` version (excludes Unreleased)."""
+    return set(re.findall(r"(?m)^##\s*\[(\d+\.\d+\.\d+)\]\s*-\s*\d{4}-\d{2}-\d{2}", text))
+
+
+def supported_netbox_minors(init_text: str) -> set[str]:
+    """Derive the supported ``major.minor`` NetBox versions from PluginConfig.
+
+    Reads ``min_version`` / ``max_version`` and expands the inclusive range of
+    minors (e.g. 4.4.0 .. 4.6.99 -> {"4.4", "4.5", "4.6"}).
+    """
+    lo = re.search(r"""min_version\s*=\s*["'](\d+)\.(\d+)""", init_text)
+    hi = re.search(r"""max_version\s*=\s*["'](\d+)\.(\d+)""", init_text)
+    if not lo or not hi:
+        return set()
+    major = int(lo.group(1))
+    lo_minor, hi_minor = int(lo.group(2)), int(hi.group(2))
+    return {f"{major}.{minor}" for minor in range(lo_minor, hi_minor + 1)}
+
+
+def badge_netbox_minors(readme_text: str) -> set[str]:
+    """Extract the NetBox minors from the README shields.io badge.
+
+    The badge label is URL-encoded (``4.4%20%7C%204.5`` = ``4.4 | 4.5``). A
+    whole-document version scan would miss a stale badge when the table below it
+    is current, so this parser is intentionally badge-specific.
+    """
+    match = re.search(r"badge/NetBox-(.+?)-[a-z]+\.svg", readme_text)
+    if not match:
+        return set()
+    decoded = urllib.parse.unquote(match.group(1))
+    return {f"4.{minor}" for minor in re.findall(r"4\.(\d+)", decoded)}
+
+
+def netbox_minors_mentioned(text: str) -> set[str]:
+    """Return every ``4.x`` NetBox minor mentioned anywhere in the text."""
+    return {f"4.{minor}" for minor in re.findall(r"4\.(\d+)", text)}
+
+
+def gate_budget_seconds(publish_yml_text: str) -> int | None:
+    """Compute the verify-ci poll budget (``seq 1 N`` x ``sleep M``) in seconds."""
+    seq = re.search(r"seq\s+1\s+(\d+)", publish_yml_text)
+    sleep = re.search(r"sleep\s+(\d+)", publish_yml_text)
+    if not seq or not sleep:
+        return None
+    return int(seq.group(1)) * int(sleep.group(1))
+
+
+def docs_has_serialization_guard(docs_yml_text: str) -> bool:
+    """True iff docs.yml keeps a concurrency group with cancel-in-progress:false."""
+    has_group = "concurrency:" in docs_yml_text
+    keeps_runs = bool(re.search(r"cancel-in-progress:\s*false", docs_yml_text))
+    return has_group and keeps_runs
+
+
+# --------------------------------------------------------------------------- #
+# Checks — return a CheckResult                                                #
+# --------------------------------------------------------------------------- #
+
+
+def check_version_consistency(target: str, pyproject_text: str, init_text: str) -> CheckResult:
+    pyproject_version = extract_pyproject_version(pyproject_text)
+    init_version = extract_init_version(init_text)
+    passed = pyproject_version == init_version == target
+    if passed:
+        detail = f"pyproject.toml, __init__.py and the target all read {target}"
+    else:
+        detail = (
+            f"version mismatch — target={target}, pyproject.toml={pyproject_version}, "
+            f"__init__.py={init_version} (all three must match)"
+        )
+    return CheckResult("version consistency", passed, detail)
+
+
+def check_changelog_has_release(target: str, changelog_text: str) -> CheckResult:
+    versions = changelog_release_versions(changelog_text)
+    passed = target in versions
+    if passed:
+        detail = f"CHANGELOG has a dated '## [{target}]' section"
+    else:
+        detail = (
+            f"CHANGELOG has no dated '## [{target}] - YYYY-MM-DD' section "
+            f"(move the Unreleased entries under it). Dated versions found: {sorted(versions)}"
+        )
+    return CheckResult("changelog release section", passed, detail)
+
+
+def check_netbox_support_matrix(init_text: str, readme_text: str, compatibility_text: str) -> CheckResult:
+    expected = supported_netbox_minors(init_text)
+    problems: list[str] = []
+
+    badge = badge_netbox_minors(readme_text)
+    if badge != expected:
+        problems.append(f"README badge advertises {sorted(badge)} but PluginConfig supports {sorted(expected)}")
+
+    missing_readme = expected - netbox_minors_mentioned(readme_text)
+    if missing_readme:
+        problems.append(f"README never mentions {sorted(missing_readme)}")
+
+    missing_compat = expected - netbox_minors_mentioned(compatibility_text)
+    if missing_compat:
+        problems.append(f"COMPATIBILITY.md never mentions {sorted(missing_compat)}")
+
+    passed = not problems
+    if passed:
+        detail = f"NetBox {sorted(expected)} consistent across PluginConfig, README, and COMPATIBILITY.md"
+    else:
+        detail = "; ".join(problems)
+    return CheckResult("netbox support matrix", passed, detail)
+
+
+def check_publish_gate_budget(publish_yml_text: str, min_seconds: int = MIN_GATE_SECONDS) -> CheckResult:
+    budget = gate_budget_seconds(publish_yml_text)
+    if budget is None:
+        return CheckResult(
+            "publish gate budget",
+            False,
+            "could not find the verify-ci 'seq 1 N / sleep M' poll loop in publish.yml",
+        )
+    passed = budget >= min_seconds
+    if passed:
+        detail = f"verify-ci gate polls for {budget}s (>= {min_seconds}s required)"
+    else:
+        detail = (
+            f"verify-ci gate polls only {budget}s; the integration matrix can take >16min, so the "
+            f"tag-push Publish run will time out before CI goes green — raise it to >= {min_seconds}s "
+            f"(see #141 / #142)"
+        )
+    return CheckResult("publish gate budget", passed, detail)
+
+
+def check_docs_serialization_guard(docs_yml_text: str) -> CheckResult:
+    passed = docs_has_serialization_guard(docs_yml_text)
+    if passed:
+        detail = "docs.yml keeps the gh-pages concurrency group with cancel-in-progress: false"
+    else:
+        detail = (
+            "docs.yml is missing the gh-pages serialization guard (a concurrency group with "
+            "cancel-in-progress: false); the tag-push docs deploy will race the main-push deploy "
+            "(see #110)"
+        )
+    return CheckResult("docs gh-pages serialization guard", passed, detail)
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration + CLI                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def run_all_checks(repo_root: Path | str, target_version: str) -> list[CheckResult]:
+    """Read the repo's release-critical files and run every check."""
+    root = Path(repo_root)
+
+    def read(*parts: str) -> str:
+        return root.joinpath(*parts).read_text(encoding="utf-8")
+
+    pyproject = read("pyproject.toml")
+    init = read("netbox_ssl", "__init__.py")
+    changelog = read("CHANGELOG.md")
+    readme = read("README.md")
+    compatibility = read("COMPATIBILITY.md")
+    publish = read(".github", "workflows", "publish.yml")
+    docs = read(".github", "workflows", "docs.yml")
+
+    return [
+        check_version_consistency(target_version, pyproject, init),
+        check_changelog_has_release(target_version, changelog),
+        check_netbox_support_matrix(init, readme, compatibility),
+        check_publish_gate_budget(publish),
+        check_docs_serialization_guard(docs),
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Pre-cut release rehearsal — assert release-critical invariants before tagging.",
+    )
+    parser.add_argument("target_version", help="The version about to be cut, e.g. 1.3.0")
+    parser.add_argument(
+        "--repo-root",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="Repository root (defaults to the repo containing this script)",
+    )
+    args = parser.parse_args(argv)
+
+    results = run_all_checks(Path(args.repo_root), args.target_version)
+
+    print(f"Release preflight for v{args.target_version}")
+    print("=" * 70)
+    for result in results:
+        marker = "PASS" if result.passed else "FAIL"
+        print(f"[{marker}] {result.name}: {result.detail}")
+    print("=" * 70)
+
+    failures = [r for r in results if not r.passed]
+    if failures:
+        print(f"{len(failures)} of {len(results)} checks FAILED — fix before tagging.")
+        return 1
+    print(f"All {len(results)} checks passed — clear to cut v{args.target_version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_release_preflight.py
+++ b/tests/test_release_preflight.py
@@ -17,12 +17,23 @@ import pytest
 pytestmark = pytest.mark.unit
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+_PREFLIGHT_PATH = _REPO_ROOT / "scripts" / "release_preflight.py"
+
+# These tests need a full repo checkout (the script under scripts/ plus the
+# real release files). The in-container integration run copies only tests/ to
+# /tmp/plugin_tests/, so scripts/ is absent there — skip the whole module
+# rather than crash collection. The host unit lane runs from the repo root and
+# exercises them in full.
+if not _PREFLIGHT_PATH.exists():
+    pytest.skip(
+        "scripts/release_preflight.py not found — needs a full repo checkout",
+        allow_module_level=True,
+    )
 
 
 def _load_preflight():
     """Load scripts/release_preflight.py by path (it lives outside any package)."""
-    path = _REPO_ROOT / "scripts" / "release_preflight.py"
-    spec = importlib.util.spec_from_file_location("release_preflight", path)
+    spec = importlib.util.spec_from_file_location("release_preflight", _PREFLIGHT_PATH)
     module = importlib.util.module_from_spec(spec)
     # Register before exec: Python 3.12's @dataclass resolves cls.__module__ via
     # sys.modules, which raises AttributeError if the module isn't registered.

--- a/tests/test_release_preflight.py
+++ b/tests/test_release_preflight.py
@@ -1,0 +1,305 @@
+"""Unit tests for the pre-cut release-rehearsal checker (scripts/release_preflight.py).
+
+Each check guards a release-critical invariant that has broken a past release:
+version drift, a missing dated CHANGELOG section, a stale NetBox support matrix
+(#110-adjacent README badge), the publish gate budget (#141/#142), and the
+gh-pages serialization guard (#110). The parsers are pure (text in, data out)
+so they test with small fixtures; a handful of smoke tests run the real checks
+against this repo's actual files to catch drift.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_preflight():
+    """Load scripts/release_preflight.py by path (it lives outside any package)."""
+    path = _REPO_ROOT / "scripts" / "release_preflight.py"
+    spec = importlib.util.spec_from_file_location("release_preflight", path)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec: Python 3.12's @dataclass resolves cls.__module__ via
+    # sys.modules, which raises AttributeError if the module isn't registered.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+rp = _load_preflight()
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures — minimal slices of each real file format                           #
+# --------------------------------------------------------------------------- #
+
+PYPROJECT = """\
+[build-system]
+requires = ["setuptools>=61.0"]
+
+[project]
+name = "netbox-ssl"
+version = "1.3.0"
+description = "x"
+"""
+
+INIT = '''\
+"""docstring"""
+from netbox.plugins import PluginConfig
+
+__version__ = "1.3.0"
+
+
+class NetBoxSSLConfig(PluginConfig):
+    version = __version__
+    min_version = "4.4.0"
+    max_version = "4.6.99"
+'''
+
+CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- nothing yet
+
+## [1.3.0] - 2026-06-21
+
+### Added
+
+- the thing
+
+## [1.2.2] - 2026-06-05
+
+### Fixed
+
+- a bug
+"""
+
+README_OK = """\
+<a href="x"><img src="https://img.shields.io/badge/NetBox-4.4%20%7C%204.5%20%7C%204.6-blue.svg" alt="NetBox"></a>
+
+| 4.6.x | 1.2.x | Primary |
+| 4.5.x | 1.2.x | Supported |
+| 4.4.x | 1.2.x | Supported |
+| 4.3.x and older | — | Unsupported |
+"""
+
+# Badge says 4.4 | 4.5 (missing 4.6) but the table below DOES mention 4.6 — a
+# whole-document token scan would pass; only a badge-specific parser catches it.
+README_STALE_BADGE = """\
+<a href="x"><img src="https://img.shields.io/badge/NetBox-4.4%20%7C%204.5-blue.svg" alt="NetBox"></a>
+
+| 4.6.x | 1.2.x | Primary |
+| 4.5.x | 1.2.x | Supported |
+| 4.4.x | 1.2.x | Supported |
+"""
+
+COMPAT_OK = """\
+| Plugin Version | NetBox Version | Status |
+| 1.2.x | 4.6.x | Primary |
+| 1.2.x | 4.5.x | Supported |
+| 1.2.x | 4.4.x | Supported |
+| any | 4.3.x or older | Unsupported |
+"""
+
+COMPAT_MISSING_46 = """\
+| 1.2.x | 4.5.x | Supported |
+| 1.2.x | 4.4.x | Supported |
+"""
+
+PUBLISH_OK = """\
+jobs:
+  verify-ci:
+    steps:
+      - run: |
+          for i in $(seq 1 90); do
+            status=$(gh run list ...)
+            sleep 20
+          done
+"""
+
+PUBLISH_SHORT = """\
+          for i in $(seq 1 30); do
+            sleep 20
+          done
+"""
+
+DOCS_OK = """\
+name: Docs Deploy
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+"""
+
+DOCS_NO_GUARD = """\
+name: Docs Deploy
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+"""
+
+DOCS_CANCEL_TRUE = """\
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: true
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Pure parsers                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_pyproject_version():
+    assert rp.extract_pyproject_version(PYPROJECT) == "1.3.0"
+
+
+def test_extract_init_version():
+    assert rp.extract_init_version(INIT) == "1.3.0"
+
+
+def test_changelog_release_versions_excludes_unreleased():
+    versions = rp.changelog_release_versions(CHANGELOG)
+    assert versions == {"1.3.0", "1.2.2"}
+    assert "Unreleased" not in versions
+
+
+def test_supported_netbox_minors_spans_min_to_max():
+    assert rp.supported_netbox_minors(INIT) == {"4.4", "4.5", "4.6"}
+
+
+def test_badge_netbox_minors_parses_url_encoded_pipe():
+    assert rp.badge_netbox_minors(README_OK) == {"4.4", "4.5", "4.6"}
+    assert rp.badge_netbox_minors(README_STALE_BADGE) == {"4.4", "4.5"}
+
+
+def test_netbox_minors_mentioned():
+    assert {"4.4", "4.5", "4.6"} <= rp.netbox_minors_mentioned(COMPAT_OK)
+    assert "4.6" not in rp.netbox_minors_mentioned(COMPAT_MISSING_46)
+
+
+def test_gate_budget_seconds():
+    assert rp.gate_budget_seconds(PUBLISH_OK) == 1800
+    assert rp.gate_budget_seconds(PUBLISH_SHORT) == 600
+    assert rp.gate_budget_seconds("no loop here") is None
+
+
+def test_docs_has_serialization_guard():
+    assert rp.docs_has_serialization_guard(DOCS_OK) is True
+    assert rp.docs_has_serialization_guard(DOCS_NO_GUARD) is False
+    assert rp.docs_has_serialization_guard(DOCS_CANCEL_TRUE) is False
+
+
+# --------------------------------------------------------------------------- #
+# Checks (return a CheckResult)                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_check_version_consistency_pass():
+    r = rp.check_version_consistency("1.3.0", PYPROJECT, INIT)
+    assert r.passed is True
+
+
+def test_check_version_consistency_detects_target_mismatch():
+    r = rp.check_version_consistency("1.4.0", PYPROJECT, INIT)
+    assert r.passed is False
+    assert "1.4.0" in r.detail
+
+
+def test_check_version_consistency_detects_file_drift():
+    drifted_init = INIT.replace("1.3.0", "1.2.9")
+    r = rp.check_version_consistency("1.3.0", PYPROJECT, drifted_init)
+    assert r.passed is False
+
+
+def test_check_changelog_has_release_pass():
+    assert rp.check_changelog_has_release("1.3.0", CHANGELOG).passed is True
+
+
+def test_check_changelog_has_release_fail_when_missing():
+    r = rp.check_changelog_has_release("1.4.0", CHANGELOG)
+    assert r.passed is False
+    assert "1.4.0" in r.detail
+
+
+def test_check_netbox_support_matrix_pass():
+    r = rp.check_netbox_support_matrix(INIT, README_OK, COMPAT_OK)
+    assert r.passed is True
+
+
+def test_check_netbox_support_matrix_catches_stale_badge():
+    r = rp.check_netbox_support_matrix(INIT, README_STALE_BADGE, COMPAT_OK)
+    assert r.passed is False
+    assert "badge" in r.detail.lower()
+
+
+def test_check_netbox_support_matrix_catches_missing_version():
+    r = rp.check_netbox_support_matrix(INIT, README_OK, COMPAT_MISSING_46)
+    assert r.passed is False
+    assert "4.6" in r.detail
+
+
+def test_check_publish_gate_budget_pass():
+    assert rp.check_publish_gate_budget(PUBLISH_OK).passed is True
+
+
+def test_check_publish_gate_budget_fail_when_too_short():
+    r = rp.check_publish_gate_budget(PUBLISH_SHORT)
+    assert r.passed is False
+    assert "600" in r.detail
+
+
+def test_check_docs_serialization_guard_pass():
+    assert rp.check_docs_serialization_guard(DOCS_OK).passed is True
+
+
+def test_check_docs_serialization_guard_fail():
+    assert rp.check_docs_serialization_guard(DOCS_NO_GUARD).passed is False
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_run_all_checks_returns_one_result_per_check():
+    results = rp.run_all_checks(_REPO_ROOT, "1.2.2")
+    assert len(results) >= 5
+    assert all(isinstance(r, rp.CheckResult) for r in results)
+
+
+# --------------------------------------------------------------------------- #
+# Smoke tests against this repo's REAL files — guard against drift             #
+# --------------------------------------------------------------------------- #
+
+
+def test_real_repo_version_files_agree():
+    pyproject = (_REPO_ROOT / "pyproject.toml").read_text()
+    init = (_REPO_ROOT / "netbox_ssl" / "__init__.py").read_text()
+    assert rp.extract_pyproject_version(pyproject) == rp.extract_init_version(init)
+
+
+def test_real_repo_support_matrix_is_consistent():
+    init = (_REPO_ROOT / "netbox_ssl" / "__init__.py").read_text()
+    readme = (_REPO_ROOT / "README.md").read_text()
+    compat = (_REPO_ROOT / "COMPATIBILITY.md").read_text()
+    r = rp.check_netbox_support_matrix(init, readme, compat)
+    assert r.passed is True, r.detail
+
+
+def test_real_repo_publish_gate_budget_is_sufficient():
+    publish = (_REPO_ROOT / ".github" / "workflows" / "publish.yml").read_text()
+    assert rp.check_publish_gate_budget(publish).passed is True
+
+
+def test_real_repo_docs_has_serialization_guard():
+    docs = (_REPO_ROOT / ".github" / "workflows" / "docs.yml").read_text()
+    assert rp.check_docs_serialization_guard(docs).passed is True


### PR DESCRIPTION
## Why

Measure **C** from the bug-history retro, and the companion to the release-process side of #154/#155. The retro showed our most stubborn release pain isn't code — it's *process*: a publish gate that timed out (#141/#142), a gh-pages docs race (#110), and support matrices that drifted out of sync (caught in pre-flight at v1.2.0). Those recur every release because nothing checks them before the tag goes out.

This adds a **pre-cut rehearsal** the maintainer runs before tagging.

## What

`scripts/release_preflight.py X.Y.Z` — inspects **files only** (no container, no network, no `netbox_ssl` import; stdlib-only, so it also passes the host-lane collect gate and runs in <1s) and asserts:

| Check | Guards |
|---|---|
| **version consistency** | `pyproject.toml` ↔ `netbox_ssl/__init__.py` ↔ target all match |
| **changelog release section** | a dated `## [X.Y.Z] - YYYY-MM-DD` exists (Unreleased moved down) |
| **netbox support matrix** | PluginConfig `min`/`max_version` ↔ README badge + table ↔ COMPATIBILITY.md |
| **publish gate budget** | the `verify-ci` poll loop outlasts the integration matrix (#141/#142) |
| **docs serialization guard** | `docs.yml` keeps its concurrency group + `cancel-in-progress: false` (#110) |

Exit 0 if all pass, 1 if any fail.

## TDD + a real bug caught

Built test-first (`tests/test_release_preflight.py`, 25 tests, host-lane `-m unit`). The architecture splits **pure parsers** (text→data) from thin **file-I/O checks**, so parsers test with small fixtures and a handful of smoke tests run the real checks against this repo.

Writing the smoke tests immediately red-barred on a **real stale matrix**: the README NetBox badge still advertised `4.4 | 4.5` while the plugin supports 4.4–4.6 (the table below it was already correct — only a badge-specific parser catches that). **Fixed in this PR.** Running the script against the repo now passes all 5 checks; running it for an un-bumped `1.3.0` correctly fails version + changelog.

`docs/development/contributing.md` now opens the release process with the preflight step.

## Verification
- `ruff 0.15.18` check + format clean on the new files.
- Host unit lane: `870 passed` (+25), collect gate `1252 tests`.
- `python scripts/release_preflight.py 1.2.2` → all 5 PASS; `1.3.0` → 2 FAIL (exit 1).

## Relationship to the A1–A5 / B set
- **A1/A2/A4** (#154, merged-ready) — CI gates.
- **B** (#155) — Definition-of-Done checklist (author-time).
- **C** (this PR) — release-rehearsal (cut-time).

Contributor-facing tooling/docs only — no `netbox_ssl` runtime change, no migration, no CHANGELOG entry.