### PR TITLE
release: v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-22
+
 ### Added
 
 - **Assign one certificate to many objects** ([#148](https://github.com/ctrl-alt-automate/netbox-ssl/issues/148)):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unreachable / rotated / untrusted endpoints. Endpoints can be added manually,
   bulk-imported from CSV, or auto-created from the URL import flow. A certificate's
   detail page now lists every website presenting it. One additive migration.
+- **`compliance-trends` REST endpoint** ([#154](https://github.com/ctrl-alt-automate/netbox-ssl/pull/154)):
+  compliance trend snapshots (the 90-day compliance history) are now exposed
+  read-only at `GET /api/plugins/ssl/compliance-trends/`. This also registers the
+  serializer NetBox needs to change-log `ComplianceTrendSnapshot` on save —
+  previously a missing serializer raised `SerializerNotFound`, a hard 500 on
+  NetBox 4.4.
 
 ### Fixed
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,7 +6,10 @@ This document tracks compatibility between NetBox SSL plugin versions and NetBox
 
 | Plugin Version | NetBox Version | Python Version | Status |
 |:--------------:|:--------------:|:--------------:|:------:|
-| 1.2.x          | 4.6.x          | 3.10 - 3.12   | Primary |
+| 1.3.x          | 4.6.x          | 3.10 - 3.12   | Primary |
+| 1.3.x          | 4.5.x          | 3.10 - 3.12   | Supported |
+| 1.3.x          | 4.4.x          | 3.10 - 3.12   | Supported |
+| 1.2.x          | 4.6.x          | 3.10 - 3.12   | Supported |
 | 1.2.x          | 4.5.x          | 3.10 - 3.12   | Supported |
 | 1.2.x          | 4.4.x          | 3.10 - 3.12   | Supported |
 | 1.1.x          | 4.6.x          | 3.10 - 3.12   | Supported |

--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ Add the widget to your NetBox dashboard to see:
 
 | NetBox Version | Plugin Version | Status |
 |:--------------:|:--------------:|:------:|
-| 4.6.x          | 1.1.x - 1.2.x  | ✅ Primary |
-| 4.5.x          | 1.1.x - 1.2.x  | ✅ Supported |
-| 4.4.x          | 1.1.x - 1.2.x  | ✅ Supported |
+| 4.6.x          | 1.1.x - 1.3.x  | ✅ Primary |
+| 4.5.x          | 1.1.x - 1.3.x  | ✅ Supported |
+| 4.4.x          | 1.1.x - 1.3.x  | ✅ Supported |
 | 4.3.x and older| —              | ❌ Unsupported |
 
 ## 📚 Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/netbox-ssl)](https://pypi.org/project/netbox-ssl/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![NetBox](https://img.shields.io/badge/NetBox-4.4%20%7C%204.5-blue.svg)](https://github.com/netbox-community/netbox)
+[![NetBox](https://img.shields.io/badge/NetBox-4.4%20%7C%204.5%20%7C%204.6-blue.svg)](https://github.com/netbox-community/netbox)
 [![Status](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](#)
 
 ---

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "1.2.2"
+__version__ = "1.3.0"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "1.2.2"
+version = "1.3.0"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## v1.3.0 release prep

Cuts **v1.3.0** from `dev`. Reversible prep only — the irreversible `dev → main → tag → PyPI publish` is held for an explicit go.

`scripts/release_preflight.py 1.3.0` → **all 5 checks PASS** (version consistency, dated CHANGELOG, support matrix, publish-gate budget, docs serialization guard). Readiness verified by the adversarial release-readiness rehearsal: **GO, 0 confirmed blockers**.

### Changes in this PR
- **Version bump** 1.2.2 → 1.3.0 (`pyproject.toml`, `netbox_ssl/__init__.py` — the two sources of truth)
- **CHANGELOG** `## [Unreleased]` → `## [1.3.0] - 2026-06-22` (keeps the #148/#149 Added + #147 Fixed entries; fresh empty Unreleased retained)
- **COMPATIBILITY.md** — added `1.3.x` rows (NetBox 4.4–4.6), demoted `1.2.x / 4.6` from Primary → Supported
- **README** support table — plugin column `1.1.x - 1.2.x` → `1.1.x - 1.3.x`
- **docs/index.md** — fixed a second stale NetBox badge (`4.4 | 4.5` → `4.4 | 4.5 | 4.6`), surfaced by the rehearsal (the preflight only checked README's badge)

### Release content
| Issue | Type | Summary |
|---|---|---|
| #147 | fix | expiry emails now sent from `SERVER_EMAIL` (was `DEFAULT_FROM_EMAIL`) |
| #148 | feat | assign one certificate to many Devices/VMs/Services (`assign-targets` API) |
| #149 | feat | website-centric monitoring — MonitoredEndpoint + poll script (migration 0025, additive) |
| #153–#156 | chore/ci/docs | roadmap defer, release-readiness CI gates, Definition of Done, release preflight |

v1.3 milestone (#10): release issues attached, **0 open**.

### Verified
- Preflight 5/5 · host unit lane green · collect gate 1252 tests · migration 0025 additive + sole leaf + carries `custom_field_data`/`tags`.

### Open decision for the maintainer (non-blocking)
- New public REST route `/api/plugins/ssl/compliance-trends/` (from #154) is **not** in the CHANGELOG — it's an internal correctness artifact (so `ComplianceTrendSnapshot` change-logging resolves a serializer on 4.4). Add a one-line note or accept the omission — say the word and I'll add it.

### Remaining cut steps (paused for your go)
`release/v1.3.0 → dev` (this PR, CI gate) → `dev → main` (`--admin`, shows BEHIND) → annotated tag `v1.3.0` (triggers PyPI publish + docs deploy) → close milestone #10.