### PR TITLE
fix: export MonitoredEndpointPoll so endpoint monitoring can actually run (#163, #161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Monitored endpoints never got polled** ([#163](https://github.com/ctrl-alt-automate/netbox-ssl/issues/163)):
+  the `MonitoredEndpointPoll` script shipped in v1.3.0 but was never re-exported
+  from `netbox_ssl.scripts`, so the documented `SCRIPTS_ROOT` wrapper
+  (`from netbox_ssl.scripts import MonitoredEndpointPoll`) failed with
+  `ImportError` and the script could not be registered in NetBox at all. Every
+  monitored endpoint therefore stayed on **Pending** forever, making
+  website-centric monitoring (#149) unusable. The class is now exported, and a
+  new AST guard (`tests/test_script_exports.py`) fails the build if any bundled
+  `Script` subclass is missing from the package's `__all__` or from
+  `docs/reference/scripts.md`.
+- **Renewal reminders quoted stale certificate data** ([#161](https://github.com/ctrl-alt-automate/netbox-ssl/issues/161)):
+  a consequence of #163 — with the poll script unregistrable, a monitored
+  endpoint stayed linked to the certificate it had at creation time, so
+  reminders reported the pre-renewal certificate. Endpoints now follow the live
+  certificate once the poll is scheduled.
+
+### Documentation
+
+- New how-to guide for [website-centric endpoint monitoring](https://ctrl-alt-automate.github.io/netbox-ssl/latest/how-to/endpoint-monitoring/),
+  covering registration, the mandatory `SCRIPTS_ROOT` step, statuses, events,
+  the private-CIDR allowlist, and troubleshooting. The v1.3.0 feature shipped
+  with no how-to documentation at all.
+- `docs/reference/scripts.md` now documents `MonitoredEndpointPoll` and includes
+  it in the wrapper-module example.
+
 ## [1.3.0] - 2026-06-22
 
 ### Added

--- a/docs/how-to/endpoint-monitoring.md
+++ b/docs/how-to/endpoint-monitoring.md
@@ -1,0 +1,142 @@
+# How-to: Website-centric Endpoint Monitoring
+
+Most of NetBox SSL is certificate-centric: you import a certificate and record
+where it is deployed. Endpoint monitoring inverts that. You register a **URL you
+care about**, and the plugin repeatedly asks that URL which certificate it is
+actually serving — then reconciles the answer with your inventory.
+
+That makes it the fastest way to answer "is what we *think* is deployed the same
+as what is *really* deployed?"
+
+## When to use this
+
+- You want drift detection: the live certificate no longer matches the inventory
+- You want to catch renewals performed outside NetBox (ACME, a load balancer, a
+  hosting provider) without importing anything by hand
+- You want to be alerted when a public endpoint goes unreachable or starts
+  serving an untrusted chain
+
+## Step 1 — Register an endpoint
+
+Navigate to **SSL → Monitored Endpoints → + Add** and fill in:
+
+| Field | Required | Notes |
+|-------|:--------:|-------|
+| **Name** | yes | Human label, e.g. `HR portal` |
+| **URL** | yes | `https://host` or `https://host:port` |
+| **SNI** | no | Override the TLS server name; defaults to the URL host |
+| **Assigned object** | no | Link the endpoint to a Device, VM, or Service |
+| **Tenant** | no | Used for filtering and for scoping poll runs |
+
+A new endpoint starts with status **Pending** — nothing has been polled yet.
+
+## Step 2 — Make the poll script available
+
+!!! important "This step is not optional"
+    NetBox does not auto-discover scripts bundled inside a plugin. Until you
+    register `MonitoredEndpointPoll`, **nothing ever polls your endpoints** and
+    every one of them stays on **Pending** indefinitely.
+
+Add the class to your `SCRIPTS_ROOT` wrapper module (see
+[Custom Scripts](../reference/scripts.md#making-the-scripts-available-to-netbox)):
+
+```python
+# /opt/netbox/netbox/scripts/netbox_ssl_scripts.py
+from netbox_ssl.scripts import MonitoredEndpointPoll
+```
+
+!!! warning "Requires v1.3.1 or newer"
+    In v1.3.0 this import raised `ImportError` because the class was never
+    re-exported from the package
+    ([#163](https://github.com/ctrl-alt-automate/netbox-ssl/issues/163)).
+
+## Step 3 — Schedule the poll
+
+Open **Customization → Scripts → Monitored Endpoint Poll** and schedule it. Daily
+is a sensible default; hourly is reasonable if you rotate certificates often.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `tenant` | Tenant | none | Restrict the run to a single tenant |
+| `dry_run` | Boolean | `false` | Count what would be polled without writing |
+
+Each run performs a TLS handshake per endpoint and then:
+
+1. **Links** the endpoint to the matching `Certificate`, importing it if the
+   plugin has not seen it before
+2. **Records** the certificate in the endpoint's history (`first_seen` /
+   `last_seen`)
+3. **Detects rotation** when the served certificate differs from the previous one
+4. **Updates** `status`, `last_checked`, `last_seen`, and `last_error`
+
+## Step 4 — Read the results
+
+| Status | Meaning |
+|--------|---------|
+| **Pending** | Never polled — the script has not run (see Step 2) |
+| **OK** | Handshake succeeded and the chain verified |
+| **Untrusted** | A certificate was served, but its chain did not verify |
+| **Unreachable** | No usable certificate could be retrieved; see `last_error` |
+
+The endpoint detail page shows the current certificate plus the full history of
+every certificate that endpoint has served, which is what makes rotation visible
+after the fact.
+
+## Step 5 — Alert on changes (optional)
+
+Polling fires plugin events that you can hook up to NetBox **Event Rules** to
+drive a webhook or a script:
+
+| Event | Fired when |
+|-------|------------|
+| `endpoint_cert_rotated` | The served certificate changed since the last poll |
+| `endpoint_untrusted_cert` | The chain failed to verify |
+| `endpoint_unreachable` | The endpoint could not be reached at all |
+
+See [Webhooks](../reference/webhooks.md) for payload templates.
+
+## Configuration
+
+Endpoints resolving to private IP ranges are refused by default — the same
+SSRF protection used by [URL import](url-import.md). To monitor internal
+endpoints, opt in explicitly:
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_ssl": {
+        "url_import_private_cidr_allowlist": ["10.0.0.0/8", "192.168.10.0/24"],
+    },
+}
+```
+
+## Troubleshooting
+
+!!! question "All my endpoints are stuck on Pending"
+    The poll script has never run. Confirm `MonitoredEndpointPoll` appears under
+    **Customization → Scripts**; if it does not, revisit Step 2 and check the
+    NetBox log for an `ImportError` from your wrapper module. On v1.3.0 the
+    import fails by design of the bug — upgrade to v1.3.1+.
+
+!!! question "An internal endpoint reports Unreachable"
+    Private addresses are blocked unless allowlisted. Add the range to
+    `url_import_private_cidr_allowlist` and re-run the script.
+
+!!! question "The endpoint shows Untrusted but the browser is happy"
+    The plugin verifies against the system trust store of the NetBox host, which
+    may not contain your internal root CA. Install the root in that trust store,
+    or accept **Untrusted** as the expected state for that endpoint.
+
+!!! question "A renewal reminder quotes an old certificate"
+    Reminders read the certificate the endpoint is currently linked to. If the
+    poll is not running, that link is stale
+    ([#161](https://github.com/ctrl-alt-automate/netbox-ssl/issues/161)) —
+    schedule the poll and the reminder will follow the live certificate.
+
+## API
+
+```http
+GET  /api/plugins/ssl/monitored-endpoints/
+POST /api/plugins/ssl/monitored-endpoints/
+```
+
+See the [API reference](../reference/api.md) for the full schema.

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -25,6 +25,7 @@ from netbox_ssl.scripts import (
     ExternalSourceSync,
     ScheduledCertificateExport,
     CertificateURLScan,
+    MonitoredEndpointPoll,
 )
 ```
 
@@ -37,6 +38,15 @@ must be readable by the NetBox service user; no restart is required.
     filter field passed a model as a string to `ObjectVar`
     ([#143](https://github.com/ctrl-alt-automate/netbox-ssl/issues/143)). Upgrade
     to **1.2.2+** before registering the scripts.
+
+!!! warning "`MonitoredEndpointPoll` requires v1.3.1 or newer"
+    In v1.3.0 the script module shipped but the class was never re-exported from
+    `netbox_ssl.scripts`, so importing it in the wrapper raised `ImportError` and
+    the whole wrapper failed to load
+    ([#163](https://github.com/ctrl-alt-automate/netbox-ssl/issues/163)). Without
+    it, monitored endpoints stay on **Pending** forever and renewal reminders
+    report stale certificate data
+    ([#161](https://github.com/ctrl-alt-automate/netbox-ssl/issues/161)).
 
 ## Certificate Expiry Notification
 
@@ -90,6 +100,47 @@ You can override the default recipients by entering comma-separated email addres
 > **Prerequisites:** Django's email backend must be configured on the NetBox server. See [Configuration — Email Notifications](./configuration.md#email-notifications).
 
 ---
+
+## Monitored Endpoint Poll
+
+The `MonitoredEndpointPoll` script re-scrapes every **Monitored Endpoint** over a
+TLS handshake and reconciles what it finds with the certificate inventory. This
+is the engine behind website-centric monitoring — without a scheduled run,
+endpoints never leave the **Pending** state.
+
+### Features
+
+- Re-scrapes each endpoint's live certificate over a TLS handshake
+- Links the endpoint to the matching `Certificate`, importing it if it is new
+- Detects certificate rotation and records it in the endpoint's history
+- Marks unreachable endpoints as **Unreachable** and untrusted chains as **Untrusted**
+- Optional tenant filtering and a dry-run mode
+
+### Running the Script
+
+1. Navigate to **Customization > Scripts**
+2. Select **Monitored Endpoint Poll**
+3. Configure options:
+   - **Tenant**: Limit the run to a single tenant (optional)
+   - **Dry run**: Count the endpoints that would be polled without saving anything
+4. Click **Run Script**
+
+### Script Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `tenant` | Tenant | none | Restrict the poll to one tenant |
+| `dry_run` | Boolean | `false` | Log what would happen without writing |
+
+!!! tip "Schedule it"
+    Endpoint data is only as fresh as the last poll. Schedule this script daily
+    (see [Scheduling with NetBox Jobs](#scheduling-with-netbox-jobs)) so renewals
+    are picked up automatically and expiry reminders quote the current
+    certificate.
+
+!!! note "Private addresses are blocked by default"
+    Endpoints resolving to private IP ranges are rejected unless you opt in via
+    `url_import_private_cidr_allowlist` in `PLUGINS_CONFIG`.
 
 ## Scheduling with NetBox Jobs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
       - how-to/acme-auto-renewal.md
       - how-to/compliance-policies.md
       - how-to/external-sources.md
+      - how-to/endpoint-monitoring.md
       - how-to/ari-monitoring.md
       - how-to/aws-acm-sync.md
   - Reference:

--- a/netbox_ssl/scripts/__init__.py
+++ b/netbox_ssl/scripts/__init__.py
@@ -1,9 +1,16 @@
 """
 NetBox SSL custom scripts.
+
+Every ``Script`` subclass bundled with the plugin must be re-exported here.
+NetBox does not auto-discover plugin-bundled scripts: users register them with
+a wrapper module in ``SCRIPTS_ROOT`` that imports from this package (see
+``docs/reference/scripts.md``). A script missing from ``__all__`` is therefore
+unreachable -- see issue #163. ``tests/test_script_exports.py`` guards this.
 """
 
 from .ari_poll import CertificateARIPoll
 from .auto_archive import CertificateAutoArchive
+from .endpoint_monitor import MonitoredEndpointPoll
 from .expiry_notification import CertificateExpiryNotification
 from .expiry_scan import CertificateExpiryScan
 from .external_sync import ExternalSourceSync
@@ -15,7 +22,8 @@ __all__ = [
     "CertificateAutoArchive",
     "CertificateExpiryNotification",
     "CertificateExpiryScan",
-    "ExternalSourceSync",
-    "ScheduledCertificateExport",
     "CertificateURLScan",
+    "ExternalSourceSync",
+    "MonitoredEndpointPoll",
+    "ScheduledCertificateExport",
 ]

--- a/tests/test_script_exports.py
+++ b/tests/test_script_exports.py
@@ -1,0 +1,117 @@
+"""Regression guard: every bundled Script must be exported from the package.
+
+NetBox does not auto-discover plugin-bundled scripts. Users expose them with a
+wrapper module in ``SCRIPTS_ROOT`` that does ``from netbox_ssl.scripts import
+<ClassName>`` (see ``docs/reference/scripts.md``). That documented entry point
+is the *package*, so a ``Script`` subclass that is never re-exported from
+``netbox_ssl/scripts/__init__.py`` cannot be registered at all -- the import
+raises ``ImportError`` and the whole wrapper module fails to load.
+
+That is exactly what happened to ``MonitoredEndpointPoll`` in v1.3.0 (issue
+#163): the module ``scripts/endpoint_monitor.py`` shipped, but the class was
+missing from ``__init__.py``, so website-centric monitoring (#149) could never
+run and endpoints stayed on ``Pending`` forever -- which in turn made renewal
+reminders report stale certificate data (issue #161).
+
+The unit tests missed it because they import the *submodule*
+(``from netbox_ssl.scripts.endpoint_monitor import MonitoredEndpointPoll``)
+rather than the package, so they exercised a different door than the one the
+documentation tells users to open.
+
+This guard is AST-based so it runs in the host unit lane, where NetBox (and
+therefore ``extras.scripts.Script``) is not importable.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from .conftest import get_plugin_source_dir
+
+_SCRIPT_BASE_NAMES = {"Script", "BaseScript"}
+
+
+def _script_classes(source: str, filename: str) -> list[str]:
+    """Return the names of top-level ``Script`` subclasses defined in ``source``."""
+    tree = ast.parse(source, filename=filename)
+    return [
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and any(
+            (base.attr if isinstance(base, ast.Attribute) else getattr(base, "id", None)) in _SCRIPT_BASE_NAMES
+            for base in node.bases
+        )
+    ]
+
+
+def _package_exports(source: str, filename: str) -> tuple[set[str], set[str]]:
+    """Return ``(imported_names, dunder_all_names)`` declared in ``__init__.py``."""
+    tree = ast.parse(source, filename=filename)
+
+    imported: set[str] = set()
+    exported: set[str] = set()
+
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            imported.update(alias.asname or alias.name for alias in node.names)
+        elif (
+            isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets)
+            and isinstance(node.value, ast.List | ast.Tuple)
+        ):
+            exported.update(
+                element.value
+                for element in node.value.elts
+                if isinstance(element, ast.Constant) and isinstance(element.value, str)
+            )
+
+    return imported, exported
+
+
+@pytest.mark.unit
+def test_every_bundled_script_is_exported_from_the_package() -> None:
+    """Each Script subclass must be importable from ``netbox_ssl.scripts`` (issue #163)."""
+    scripts_dir = get_plugin_source_dir() / "scripts"
+    assert scripts_dir.is_dir(), f"scripts dir not found: {scripts_dir}"
+
+    init_file = scripts_dir / "__init__.py"
+    imported, exported = _package_exports(init_file.read_text(), init_file.name)
+
+    missing: list[str] = []
+    for py_file in sorted(scripts_dir.glob("*.py")):
+        if py_file.name == "__init__.py":
+            continue
+        for class_name in _script_classes(py_file.read_text(), py_file.name):
+            if class_name not in imported:
+                missing.append(f"{class_name} ({py_file.name}) is not imported in scripts/__init__.py")
+            if class_name not in exported:
+                missing.append(f"{class_name} ({py_file.name}) is not listed in scripts/__init__.py __all__")
+
+    assert not missing, (
+        "Bundled NetBox Scripts are unreachable through the documented entry point "
+        "`from netbox_ssl.scripts import <ClassName>`, so users cannot register them "
+        "in SCRIPTS_ROOT:\n  " + "\n  ".join(missing)
+    )
+
+
+@pytest.mark.unit
+def test_documented_scripts_match_the_package_exports() -> None:
+    """``docs/reference/scripts.md`` must list exactly the exported scripts (issue #163)."""
+    scripts_dir = get_plugin_source_dir() / "scripts"
+    init_file = scripts_dir / "__init__.py"
+    _, exported = _package_exports(init_file.read_text(), init_file.name)
+
+    docs_file = get_plugin_source_dir().parent / "docs" / "reference" / "scripts.md"
+    if not docs_file.is_file():
+        pytest.skip("docs/ not available (in-container runs copy only tests/)")
+
+    documented = {name for name in exported if name in docs_file.read_text()}
+    undocumented = sorted(exported - documented)
+
+    assert not undocumented, (
+        "These scripts are exported from netbox_ssl.scripts but never mentioned in "
+        "docs/reference/scripts.md, so users will not know to register them:\n  " + "\n  ".join(undocumented)
+    )


### PR DESCRIPTION
## Summary

`MonitoredEndpointPoll` — the engine behind website-centric monitoring shipped in v1.3.0 — could **never be registered in NetBox**. The class lived in `netbox_ssl/scripts/endpoint_monitor.py` but was missing from `netbox_ssl/scripts/__init__.py`, so the documented wrapper import raised `ImportError`:

```python
# /opt/netbox/netbox/scripts/netbox_ssl_scripts.py
from netbox_ssl.scripts import MonitoredEndpointPoll   # ImportError on v1.3.0
```

Because NetBox does not auto-discover plugin-bundled scripts, that import *is* the only entry point. With it broken, nothing ever polled anything.

**This is one root cause behind two issues:**

- **#163** — every Monitored Endpoint stays on **Pending** indefinitely.
- **#161** — renewal reminders quote the *old* certificate. The endpoint stays linked to whatever certificate it had at creation time, because the poll that would re-link it can't run.

## Why the tests didn't catch it

`tests/test_endpoint_poll_script.py` imports the **submodule**:

```python
from netbox_ssl.scripts.endpoint_monitor import MonitoredEndpointPoll   # passes
```

That is a different door than the one the docs tell users to open. The AST guard added for #143 checked `ObjectVar(model=)` arguments but said nothing about export completeness — so this shipped green through both CI lanes.

## Changes

| | |
|---|---|
| **Fix** | Export `MonitoredEndpointPoll` from `netbox_ssl/scripts/__init__.py` |
| **Guard** | New `tests/test_script_exports.py` — AST assertions that every bundled `Script` subclass is imported into the package, present in `__all__`, and mentioned in `docs/reference/scripts.md` |
| **Docs** | `docs/reference/scripts.md`: document the script + add it to the wrapper example |
| **Docs** | New `docs/how-to/endpoint-monitoring.md` — the v1.3.0 feature shipped with **no how-to guide at all**, which is the second reason the reporter got stuck |
| **Docs** | CHANGELOG entry |

The new guard is AST-based so it runs in the host unit lane, where `extras.scripts.Script` is not importable. It fails on the pre-fix tree with the exact reported symptom, and the docs assertion module-skips when `docs/` is absent (in-container runs copy only `tests/`).

## Test plan

- [x] New guard is RED on the pre-fix tree, GREEN after — verified in both directions
- [x] Full unit suite: **872 passed, 70 skipped**, 0 failures
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI integration lane confirms the package import resolves under real NetBox (4.4 / 4.5 / 4.6)
- [ ] Manual: register the wrapper in a live NetBox and confirm the script appears under **Customization → Scripts**

## Notes

Same bug *class* as #143 (bundled scripts unreachable, hidden by tests that bypass the real entry point) — hence the guard rather than only the one-line export. A follow-up is worth considering: making the script tests import via the package so the user-facing path is exercised directly.

Closes #163
Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFR4nbcQsG6uRSi6FhUURq