### PR TITLE
fix: address the plugin by base_url in documented API endpoints (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Documented API URLs returned 404** ([#165](https://github.com/ctrl-alt-automate/netbox-ssl/issues/165)):
+  the documentation addressed the plugin as `/api/plugins/netbox-ssl/`, but
+  NetBox mounts a plugin under its `PluginConfig.base_url` — which is `ssl`, not
+  the distribution name. All 54 affected examples across the API reference,
+  bulk-import and compliance how-tos, and the troubleshooting guide now use
+  `/api/plugins/ssl/`. A new guard (`tests/test_docs_urls.py`) parses `base_url`
+  out of the plugin config and fails the build if the docs and the code disagree.
+
 ## [1.3.0] - 2026-06-22
 
 ### Added

--- a/docs/how-to/bulk-import.md
+++ b/docs/how-to/bulk-import.md
@@ -98,7 +98,7 @@ If you have binary certificate files instead of PEM text:
 - **PKCS#7** (`.p7b`, `.p7c`): bundle containing a certificate and its chain —
   the plugin extracts every certificate from the bundle as a separate record.
 
-Use the `POST /api/plugins/netbox-ssl/certificates/import-file/` endpoint with
+Use the `POST /api/plugins/ssl/certificates/import-file/` endpoint with
 multipart file upload, or paste the file content into the bulk import page (it
 auto-detects the format).
 
@@ -107,7 +107,7 @@ auto-detects the format).
 For scripted ingestion from your CI or automation:
 
 ```bash
-curl -X POST https://netbox.example/api/plugins/netbox-ssl/certificates/bulk-import/ \
+curl -X POST https://netbox.example/api/plugins/ssl/certificates/bulk-import/ \
   -H "Authorization: Token $NETBOX_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/how-to/compliance-policies.md
+++ b/docs/how-to/compliance-policies.md
@@ -62,7 +62,7 @@ You'll see per-policy pass/fail immediately.
 
 ### On-demand, bulk
 
-`POST /api/plugins/netbox-ssl/certificates/compliance-check/` with a list of
+`POST /api/plugins/ssl/certificates/compliance-check/` with a list of
 certificate IDs. Returns per-cert per-policy results.
 
 ### Scheduled
@@ -88,7 +88,7 @@ Two export formats supported:
 - **CSV** — machine-readable, good for feeding into BI tools
 - **JSON** — preserves full structure including per-policy details
 
-`GET /api/plugins/netbox-ssl/certificates/compliance-report/?format=csv` returns
+`GET /api/plugins/ssl/certificates/compliance-report/?format=csv` returns
 the CSV export with the fields allowlisted by the exporter.
 
 ## Troubleshooting

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -86,7 +86,7 @@ pip install --upgrade netbox-ssl
 
 **Solution:** Check certificate ACME status and ensure PEM content is stored:
 ```
-GET /api/plugins/netbox-ssl/certificates/?is_acme=true&has_ari=false
+GET /api/plugins/ssl/certificates/?is_acme=true&has_ari=false
 ```
 
 ### Docker: Plugin not found

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,14 +16,14 @@ All API requests require authentication via NetBox API tokens.
 
 ```bash
 curl -H "Authorization: Token YOUR_API_TOKEN" \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/
+     http://localhost:8000/api/plugins/ssl/certificates/
 ```
 
 ---
 
 ## REST API
 
-Base URL: `/api/plugins/netbox-ssl/`
+Base URL: `/api/plugins/ssl/`
 
 ### Certificates
 
@@ -134,19 +134,19 @@ Base URL: `/api/plugins/netbox-ssl/`
 ```bash
 # List active certificates
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/?status=active"
+     "http://localhost:8000/api/plugins/ssl/certificates/?status=active"
 
 # Certificates expiring in next 30 days
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/?valid_to__lt=$(date -d '+30 days' +%Y-%m-%d)"
+     "http://localhost:8000/api/plugins/ssl/certificates/?valid_to__lt=$(date -d '+30 days' +%Y-%m-%d)"
 
 # Filter by tenant
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/?tenant_id=1"
+     "http://localhost:8000/api/plugins/ssl/certificates/?tenant_id=1"
 
 # Search by common name
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/?common_name__ic=example"
+     "http://localhost:8000/api/plugins/ssl/certificates/?common_name__ic=example"
 ```
 
 ---
@@ -171,7 +171,7 @@ curl -X POST \
        "status": "active",
        "sans": ["api.example.com", "*.api.example.com"]
      }' \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/
+     http://localhost:8000/api/plugins/ssl/certificates/
 ```
 
 ### Create an Assignment
@@ -187,7 +187,7 @@ curl -X POST \
        "is_primary": true,
        "notes": "Production HTTPS endpoint"
      }' \
-     http://localhost:8000/api/plugins/netbox-ssl/assignments/
+     http://localhost:8000/api/plugins/ssl/assignments/
 ```
 
 ### Import a CSR
@@ -202,7 +202,7 @@ curl -X POST \
        "target_ca": "DigiCert",
        "tenant": 1
      }' \
-     http://localhost:8000/api/plugins/netbox-ssl/csrs/import/
+     http://localhost:8000/api/plugins/ssl/csrs/import/
 ```
 
 ---
@@ -213,7 +213,7 @@ Import multiple certificates in a single request for efficient migrations and au
 
 ### Endpoint
 
-`POST /api/plugins/netbox-ssl/certificates/bulk-import/`
+`POST /api/plugins/ssl/certificates/bulk-import/`
 
 ### Features
 
@@ -266,7 +266,7 @@ curl -X POST \
          "private_key_location": "Vault: /secret/prod/web2"
        }
      ]' \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/bulk-import/
+     http://localhost:8000/api/plugins/ssl/certificates/bulk-import/
 ```
 
 ### Success Response (201 Created)
@@ -333,7 +333,7 @@ for cert_file in cert_files:
 
 # Bulk import (batch of 100 max)
 response = requests.post(
-    "http://localhost:8000/api/plugins/netbox-ssl/certificates/bulk-import/",
+    "http://localhost:8000/api/plugins/ssl/certificates/bulk-import/",
     headers={"Authorization": "Token YOUR_TOKEN"},
     json=certificates[:100]
 )
@@ -353,7 +353,7 @@ Import certificate metadata from CSV or JSON content via the API. Unlike `bulk-i
 
 ### Endpoint
 
-`POST /api/plugins/netbox-ssl/certificates/bulk-data-import/`
+`POST /api/plugins/ssl/certificates/bulk-data-import/`
 
 ### Request Format
 
@@ -390,7 +390,7 @@ curl -X POST \
        "content": "[{\"common_name\":\"example.com\",\"serial_number\":\"01:23:45:67:89\",\"issuer\":\"CN=DigiCert CA\",\"valid_from\":\"2024-01-01\",\"valid_to\":\"2025-01-01\",\"fingerprint_sha256\":\"AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99\",\"algorithm\":\"rsa\",\"key_size\":2048}]",
        "on_duplicate": "skip"
      }' \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/bulk-data-import/
+     http://localhost:8000/api/plugins/ssl/certificates/bulk-data-import/
 ```
 
 ### Example Request (CSV)
@@ -403,7 +403,7 @@ curl -X POST \
        "format": "csv",
        "content": "common_name,serial_number,issuer,valid_from,valid_to,fingerprint_sha256,algorithm,key_size\nexample.com,01:23:45:67:89,CN=DigiCert CA,2024-01-01,2025-01-01,AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99,rsa,2048"
      }' \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/bulk-data-import/
+     http://localhost:8000/api/plugins/ssl/certificates/bulk-data-import/
 ```
 
 ### Success Response (201 Created)
@@ -448,7 +448,7 @@ from pathlib import Path
 csv_content = Path("certificates.csv").read_text()
 
 response = requests.post(
-    "http://localhost:8000/api/plugins/netbox-ssl/certificates/bulk-data-import/",
+    "http://localhost:8000/api/plugins/ssl/certificates/bulk-data-import/",
     headers={"Authorization": "Token YOUR_TOKEN"},
     json={
         "format": "csv",
@@ -472,7 +472,7 @@ Validate certificate chains to ensure they are complete and properly signed.
 
 ### Single Certificate Validation
 
-`POST /api/plugins/netbox-ssl/certificates/{id}/validate-chain/`
+`POST /api/plugins/ssl/certificates/{id}/validate-chain/`
 
 Validates the chain for a specific certificate and updates its chain status fields.
 
@@ -481,7 +481,7 @@ Validates the chain for a specific certificate and updates its chain status fiel
 ```bash
 curl -X POST \
      -H "Authorization: Token $TOKEN" \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/1/validate-chain/
+     http://localhost:8000/api/plugins/ssl/certificates/1/validate-chain/
 ```
 
 ### Response
@@ -522,7 +522,7 @@ curl -X POST \
 
 ### Bulk Chain Validation
 
-`POST /api/plugins/netbox-ssl/certificates/bulk-validate-chain/`
+`POST /api/plugins/ssl/certificates/bulk-validate-chain/`
 
 Validates chains for multiple certificates in a single request.
 
@@ -541,7 +541,7 @@ Export certificates in multiple formats for integration, reporting, and backup p
 
 ### Bulk Export Endpoint
 
-`GET/POST /api/plugins/netbox-ssl/certificates/export/`
+`GET/POST /api/plugins/ssl/certificates/export/`
 
 #### Parameters
 
@@ -578,7 +578,7 @@ PLUGINS_CONFIG = {
 ```bash
 # Export all active certificates as CSV
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/export/?format=csv&status=active"
+     "http://localhost:8000/api/plugins/ssl/certificates/export/?format=csv&status=active"
 ```
 
 Response (file download):
@@ -595,7 +595,7 @@ curl -X POST \
      -H "Authorization: Token $TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"format": "json", "ids": [1, 2, 3], "include_pem": true}' \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/export/
+     http://localhost:8000/api/plugins/ssl/certificates/export/
 ```
 
 Response:
@@ -625,7 +625,7 @@ Response:
 ```bash
 # Export certificates as PEM bundle with chain
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/export/?format=pem&include_chain=true"
+     "http://localhost:8000/api/plugins/ssl/certificates/export/?format=pem&include_chain=true"
 ```
 
 Response:
@@ -649,19 +649,19 @@ MIIE...
 ```bash
 # Export only specific fields
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/export/?format=json&fields=id&fields=common_name&fields=valid_to&fields=days_remaining"
+     "http://localhost:8000/api/plugins/ssl/certificates/export/?format=json&fields=id&fields=common_name&fields=valid_to&fields=days_remaining"
 ```
 
 ### Single Certificate Export
 
-`GET /api/plugins/netbox-ssl/certificates/{id}/export/`
+`GET /api/plugins/ssl/certificates/{id}/export/`
 
 Export a single certificate with the certificate's common name as the filename.
 
 ```bash
 # Export single certificate as PEM
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/1/export/?format=pem"
+     "http://localhost:8000/api/plugins/ssl/certificates/1/export/?format=pem"
 
 # Response headers include:
 # Content-Disposition: attachment; filename="example.com.pem"
@@ -674,7 +674,7 @@ import requests
 
 # Export expiring certificates
 response = requests.get(
-    "http://localhost:8000/api/plugins/netbox-ssl/certificates/export/",
+    "http://localhost:8000/api/plugins/ssl/certificates/export/",
     headers={"Authorization": "Token YOUR_TOKEN"},
     params={
         "format": "json",
@@ -691,7 +691,7 @@ if response.status_code == 200:
 
 # Save PEM bundle to file
 response = requests.get(
-    "http://localhost:8000/api/plugins/netbox-ssl/certificates/export/",
+    "http://localhost:8000/api/plugins/ssl/certificates/export/",
     headers={"Authorization": "Token YOUR_TOKEN"},
     params={"format": "pem", "tenant_id": 1}
 )
@@ -708,7 +708,7 @@ Run compliance checks on certificates against defined policies to ensure they me
 
 ### Single Certificate Compliance Check
 
-`POST /api/plugins/netbox-ssl/certificates/{id}/compliance-check/`
+`POST /api/plugins/ssl/certificates/{id}/compliance-check/`
 
 Run all enabled compliance policies against a single certificate.
 
@@ -720,7 +720,7 @@ Automatically detect if certificates were issued via ACME protocol (Let's Encryp
 
 ### Single Certificate Detection
 
-`POST /api/plugins/netbox-ssl/certificates/{id}/detect-acme/`
+`POST /api/plugins/ssl/certificates/{id}/detect-acme/`
 
 Analyzes a single certificate's issuer and updates `is_acme` and `acme_provider` fields based on known ACME CA patterns.
 
@@ -729,7 +729,7 @@ Analyzes a single certificate's issuer and updates `is_acme` and `acme_provider`
 ```bash
 curl -X POST \
      -H "Authorization: Token $TOKEN" \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/1/detect-acme/
+     http://localhost:8000/api/plugins/ssl/certificates/1/detect-acme/
 ```
 
 #### Success Response (ACME Detected)
@@ -760,7 +760,7 @@ curl -X POST \
 
 ### Bulk ACME Detection
 
-`POST /api/plugins/netbox-ssl/certificates/bulk-detect-acme/`
+`POST /api/plugins/ssl/certificates/bulk-detect-acme/`
 
 Process multiple certificates for ACME detection in a single request.
 
@@ -779,7 +779,7 @@ curl -X POST \
      -H "Authorization: Token $TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"ids": [1, 2, 3, 4, 5]}' \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/bulk-validate-chain/
+     http://localhost:8000/api/plugins/ssl/certificates/bulk-validate-chain/
 ```
 
 ### Response
@@ -825,7 +825,7 @@ curl -X POST \
      -H "Authorization: Token $TOKEN" \
      -H "Content-Type: application/json" \
      -d '{}' \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/1/compliance-check/
+     http://localhost:8000/api/plugins/ssl/certificates/1/compliance-check/
 ```
 
 #### With Specific Policies
@@ -835,7 +835,7 @@ curl -X POST \
      -H "Authorization: Token $TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"policy_ids": [1, 2, 3]}' \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/1/compliance-check/
+     http://localhost:8000/api/plugins/ssl/certificates/1/compliance-check/
 ```
 
 #### Success Response
@@ -876,7 +876,7 @@ curl -X POST \
      -H "Authorization: Token $TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"ids": [1, 2, 3, 4, 5]}' \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/bulk-detect-acme/
+     http://localhost:8000/api/plugins/ssl/certificates/bulk-detect-acme/
 ```
 
 #### Success Response
@@ -925,7 +925,7 @@ curl -X POST \
 
 ### Bulk Compliance Check
 
-`POST /api/plugins/netbox-ssl/certificates/bulk-compliance-check/`
+`POST /api/plugins/ssl/certificates/bulk-compliance-check/`
 
 Run compliance checks on multiple certificates.
 
@@ -939,7 +939,7 @@ curl -X POST \
        "certificate_ids": [1, 2, 3, 4, 5],
        "policy_ids": [1, 2]
      }' \
-     http://localhost:8000/api/plugins/netbox-ssl/certificates/bulk-compliance-check/
+     http://localhost:8000/api/plugins/ssl/certificates/bulk-compliance-check/
 ```
 
 #### Success Response
@@ -975,7 +975,7 @@ curl -X POST \
 
 ### Creating Compliance Policies
 
-`POST /api/plugins/netbox-ssl/compliance-policies/`
+`POST /api/plugins/ssl/compliance-policies/`
 
 #### Policy Examples
 
@@ -992,7 +992,7 @@ curl -X POST \
        "enabled": true,
        "parameters": {"min_bits": 2048}
      }' \
-     http://localhost:8000/api/plugins/netbox-ssl/compliance-policies/
+     http://localhost:8000/api/plugins/ssl/compliance-policies/
 
 # Expiry warning policy
 curl -X POST \
@@ -1006,7 +1006,7 @@ curl -X POST \
        "enabled": true,
        "parameters": {"warning_days": 30}
      }' \
-     http://localhost:8000/api/plugins/netbox-ssl/compliance-policies/
+     http://localhost:8000/api/plugins/ssl/compliance-policies/
 
 # Forbidden algorithm policy
 curl -X POST \
@@ -1020,7 +1020,7 @@ curl -X POST \
        "enabled": true,
        "parameters": {"algorithms": ["dsa"]}
      }' \
-     http://localhost:8000/api/plugins/netbox-ssl/compliance-policies/
+     http://localhost:8000/api/plugins/ssl/compliance-policies/
 
 # Wildcard forbidden policy
 curl -X POST \
@@ -1034,7 +1034,7 @@ curl -X POST \
        "enabled": true,
        "parameters": {}
      }' \
-     http://localhost:8000/api/plugins/netbox-ssl/compliance-policies/
+     http://localhost:8000/api/plugins/ssl/compliance-policies/
 ```
 
 ### Compliance Filters
@@ -1042,15 +1042,15 @@ curl -X POST \
 ```bash
 # List all compliance checks that failed
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/compliance-checks/?result=fail"
+     "http://localhost:8000/api/plugins/ssl/compliance-checks/?result=fail"
 
 # List critical severity policy violations
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/compliance-checks/?severity=critical&result=fail"
+     "http://localhost:8000/api/plugins/ssl/compliance-checks/?severity=critical&result=fail"
 
 # List all enabled policies
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/compliance-policies/?enabled=true"
+     "http://localhost:8000/api/plugins/ssl/compliance-policies/?enabled=true"
 ```
 
 ### Supported ACME Providers
@@ -1074,15 +1074,15 @@ Filter certificates by ACME status:
 ```bash
 # List all ACME certificates
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/?is_acme=true"
+     "http://localhost:8000/api/plugins/ssl/certificates/?is_acme=true"
 
 # Filter by ACME provider
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/?acme_provider=letsencrypt"
+     "http://localhost:8000/api/plugins/ssl/certificates/?acme_provider=letsencrypt"
 
 # Certificates due for renewal
 curl -H "Authorization: Token $TOKEN" \
-     "http://localhost:8000/api/plugins/netbox-ssl/certificates/?is_acme=true&acme_auto_renewal=true"
+     "http://localhost:8000/api/plugins/ssl/certificates/?is_acme=true&acme_auto_renewal=true"
 ```
 
 ---

--- a/tests/test_docs_urls.py
+++ b/tests/test_docs_urls.py
@@ -1,0 +1,109 @@
+"""Regression guard: documented plugin URLs must match the real ``base_url``.
+
+NetBox mounts a plugin under its ``PluginConfig.base_url``, not under its
+package or distribution name. This plugin sets ``base_url = "ssl"``, so its
+routes live at ``/plugins/ssl/`` and ``/api/plugins/ssl/`` -- **not** at
+``/plugins/netbox-ssl/``.
+
+The published documentation nevertheless used the distribution name in 54
+places, so effectively every copy-pasteable API example in the docs returned
+404 (issue #165). Nothing caught it because the docs are prose: no test, no
+link checker, and no CI step ever compared them against the plugin config.
+
+These guards parse ``base_url`` straight out of ``netbox_ssl/__init__.py`` with
+AST (the host unit lane cannot import the plugin, which needs NetBox) and assert
+the docs agree. If ``base_url`` is ever changed, these tests fail and point at
+every document that needs updating.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from .conftest import get_plugin_source_dir
+
+# Slugs that legitimately belong to something other than this plugin's routes.
+# "plugins/development" is part of the upstream NetBox documentation URL
+# https://docs.netbox.dev/en/stable/plugins/development/.
+_EXTERNAL_SLUGS = {"development"}
+
+# docs/superpowers/ holds historical specs and plans; it is excluded from the
+# MkDocs build (`exclude_docs` in mkdocs.yml), so it is not user-facing.
+_UNPUBLISHED_DIRS = {"superpowers"}
+
+_API_ROUTE = re.compile(r"api/plugins/([A-Za-z0-9_-]+)")
+
+
+def _plugin_base_url() -> str:
+    """Return ``PluginConfig.base_url`` parsed out of ``netbox_ssl/__init__.py``."""
+    source = (get_plugin_source_dir() / "__init__.py").read_text()
+    tree = ast.parse(source, filename="__init__.py")
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "base_url" for target in node.targets)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            return node.value.value
+    raise AssertionError("base_url not found in netbox_ssl/__init__.py")
+
+
+def _published_docs() -> list[Path]:
+    """Return every user-facing Markdown file, or an empty list if docs/ is absent."""
+    repo_root = get_plugin_source_dir().parent
+    docs_dir = repo_root / "docs"
+    if not docs_dir.is_dir():
+        return []
+
+    files = [p for p in docs_dir.rglob("*.md") if not _UNPUBLISHED_DIRS.intersection(p.parts)]
+    readme = repo_root / "README.md"
+    if readme.is_file():
+        files.append(readme)
+    return sorted(files)
+
+
+@pytest.mark.unit
+def test_documented_api_routes_use_the_plugin_base_url() -> None:
+    """Every ``api/plugins/<slug>`` in the docs must use the real base_url (issue #165)."""
+    docs = _published_docs()
+    if not docs:
+        pytest.skip("docs/ not available (in-container runs copy only tests/)")
+
+    base_url = _plugin_base_url()
+    wrong: list[str] = []
+
+    for path in docs:
+        for line_no, line in enumerate(path.read_text().splitlines(), start=1):
+            for slug in _API_ROUTE.findall(line):
+                if slug != base_url and slug not in _EXTERNAL_SLUGS:
+                    wrong.append(f"{path}:{line_no} uses api/plugins/{slug}")
+
+    assert not wrong, (
+        f"The plugin is mounted at api/plugins/{base_url}/ (PluginConfig.base_url = "
+        f"{base_url!r}), so these documented endpoints 404 for every reader:\n  " + "\n  ".join(wrong)
+    )
+
+
+@pytest.mark.unit
+def test_docs_never_use_the_distribution_name_as_a_url_slug() -> None:
+    """The PyPI name ``netbox-ssl`` is not a URL slug -- catch the #165 mistake by name."""
+    docs = _published_docs()
+    if not docs:
+        pytest.skip("docs/ not available (in-container runs copy only tests/)")
+
+    offenders = [
+        f"{path}:{line_no}"
+        for path in docs
+        for line_no, line in enumerate(path.read_text().splitlines(), start=1)
+        if "plugins/netbox-ssl" in line
+    ]
+
+    assert not offenders, (
+        "`netbox-ssl` is the distribution name, not the URL slug -- the plugin is "
+        "mounted at /plugins/ssl/ and /api/plugins/ssl/ (issue #165):\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Summary

NetBox mounts a plugin under its `PluginConfig.base_url` — **not** under its distribution name. This plugin sets:

```python
base_url = "ssl"     # netbox_ssl/__init__.py
```

so its API lives at `/api/plugins/ssl/`. The documentation said `/api/plugins/netbox-ssl/` in **54 places**, which means effectively every copy-pasteable API example on the docs site returned 404 for the reader.

Counted before the fix: 54 wrong vs 2 correct.

## Why nothing caught it

The docs are prose. There is no test, no link checker, and no CI step that compares documented routes against the plugin config — so a wrong base path is invisible to the entire pipeline while being the very first thing a new user hits.

## Changes

| | |
|---|---|
| **Fix** | 54 occurrences rewritten to `/api/plugins/ssl/` across `reference/api.md` (49), `how-to/bulk-import.md` (2), `how-to/compliance-policies.md` (2), `operations/troubleshooting.md` (1) |
| **Guard** | New `tests/test_docs_urls.py` — parses `base_url` out of `netbox_ssl/__init__.py` via AST and asserts every documented `api/plugins/<slug>` matches it; plus a by-name guard against the distribution-name mistake |
| **Docs** | CHANGELOG entry |

`docs/superpowers/` is deliberately untouched — historical specs, excluded from the MkDocs build via `exclude_docs`.

The guard allowlists `plugins/development`, which is part of the upstream `docs.netbox.dev` URL, and module-skips when `docs/` is absent (in-container runs copy only `tests/`).

## Test plan

- [x] Guard verified RED against the pre-fix tree (reported `api.md:19`, `:26`, `:137`, …) and GREEN after — checked in both directions
- [x] Full unit suite: **872 passed, 70 skipped**, 0 failures
- [x] `ruff check` + `ruff format --check` clean
- [x] 0 wrong occurrences remain in published docs; 56 correct
- [ ] Docs build renders cleanly on the PR's Docs CI run

## Note

Because `base_url` is now parsed rather than hardcoded in the test, changing it later fails these guards and lists every document that needs updating.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFR4nbcQsG6uRSi6FhUURq