### PR TITLE
feat: support NetBox 4.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - netbox_version: "v4.7.0"
+            netbox_major: "v4.7"
           - netbox_version: "v4.6.0"
             netbox_major: "v4.6"
           - netbox_version: "v4.5-4.0.0"
@@ -169,8 +171,8 @@ jobs:
           mkdir -p env development/configuration
 
           # Create NetBox environment file (version-specific settings)
-          if [[ "${{ matrix.netbox_major }}" == "v4.5" || "${{ matrix.netbox_major }}" == "v4.6" ]]; then
-            # v4.5/v4.6: Skip automatic superuser creation (v2 token incompatibility)
+          if [[ "${{ matrix.netbox_major }}" != "v4.4" ]]; then
+            # v4.5+: Skip automatic superuser creation (v2 token incompatibility)
             printf '%s\n' \
               'CORS_ORIGIN_ALLOW_ALL=True' \
               'DB_HOST=postgres' \
@@ -239,7 +241,7 @@ jobs:
           echo "REDIS_PASSWORD=netbox" > env/redis-cache.env
 
           # Create plugins configuration with version-specific settings
-          if [[ "${{ matrix.netbox_major }}" == "v4.5" || "${{ matrix.netbox_major }}" == "v4.6" ]]; then
+          if [[ "${{ matrix.netbox_major }}" != "v4.4" ]]; then
             printf '%s\n' \
               'PLUGINS = ["netbox_ssl"]' \
               'PLUGINS_CONFIG = {' \
@@ -283,8 +285,8 @@ jobs:
           timeout 1800 bash -c 'until docker compose exec -T netbox curl -sf http://localhost:8080/login/ > /dev/null 2>&1; do echo "Waiting for NetBox..."; sleep 15; done'
           echo "NetBox is ready!"
 
-      - name: Create superuser for v4.5/v4.6
-        if: matrix.netbox_major == 'v4.5' || matrix.netbox_major == 'v4.6'
+      - name: Create superuser (v2 token scheme, v4.5+)
+        if: matrix.netbox_major != 'v4.4'
         run: |
           docker compose exec -T netbox /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py shell -c "
           from django.contrib.auth import get_user_model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **NetBox 4.7 support**: `max_version` raised to `4.7.99` and a NetBox 4.7 lane
+  added to the CI integration matrix, which now covers 4.4, 4.5, 4.6 and 4.7.
+  NetBox 4.7 (released 2026-09-02) carries a large set of breaking changes —
+  `ipam.Service.protocol`/`.ports` replaced by `port_mappings`, the `EMAIL_*`
+  settings superseded by `MAILERS`, django-tables2 v3.0 dropping
+  `RelatedLinkColumn` and renaming the `querystring` tag, `registry['models']`
+  removed, django-mptt replaced by `ltree` — **none of which the plugin
+  depends on**; see the audit table in `COMPATIBILITY.md`. NetBox 4.7 enters as
+  **Supported**; 4.6 remains **Primary** until 4.7 has carried a release.
+
+### Changed
+
+- The CI integration matrix no longer enumerates the NetBox versions that use
+  the v2 API token scheme (`== v4.5 || == v4.6`) but excludes the one that does
+  not (`!= v4.4`), so a newly added version is covered by default instead of
+  silently falling into the legacy-token branch.
+- `scripts/release_preflight.py` now validates the NetBox badge in
+  `docs/index.md` as well as the one in `README.md`. v1.3.0 shipped with a stale
+  badge there that only the manual release rehearsal caught, because the
+  preflight checked README alone.
+
 ## [1.3.0] - 2026-06-22
 
 ### Added

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,6 +6,10 @@ This document tracks compatibility between NetBox SSL plugin versions and NetBox
 
 | Plugin Version | NetBox Version | Python Version | Status |
 |:--------------:|:--------------:|:--------------:|:------:|
+| 1.4.x          | 4.7.x          | 3.10 - 3.12   | Supported |
+| 1.4.x          | 4.6.x          | 3.10 - 3.12   | Primary |
+| 1.4.x          | 4.5.x          | 3.10 - 3.12   | Supported |
+| 1.4.x          | 4.4.x          | 3.10 - 3.12   | Supported |
 | 1.3.x          | 4.6.x          | 3.10 - 3.12   | Primary |
 | 1.3.x          | 4.5.x          | 3.10 - 3.12   | Supported |
 | 1.3.x          | 4.4.x          | 3.10 - 3.12   | Supported |
@@ -35,6 +39,24 @@ This document tracks compatibility between NetBox SSL plugin versions and NetBox
 - **Primary**: Actively developed and tested in CI
 - **Supported**: Tested in CI, receives bug fixes
 - **End of Life**: No longer tested or maintained
+
+A newly released NetBox minor enters as **Supported** — covered by the full CI
+integration matrix — and is promoted to **Primary** once it has carried a plugin
+release. NetBox 4.7 was released 2026-09-02 and is Supported as of plugin 1.4.
+
+### NetBox 4.7 notes
+
+NetBox 4.7 carries a large set of breaking changes, none of which the plugin
+depends on:
+
+| 4.7 change | Impact on netbox-ssl |
+|------------|----------------------|
+| `ipam.Service.protocol` / `.ports` replaced by `port_mappings` | None — the plugin references `Service` only as an assignment target and never reads its port fields |
+| `EMAIL_*` settings superseded by `MAILERS`; `get_connection()` with an explicit backend raises `RuntimeError` | None — expiry mail uses `EmailMultiAlternatives(...).send()` with no explicit backend |
+| django-tables2 v3.0 drops `RelatedLinkColumn` and renames the `querystring` tag | None — neither is used |
+| `registry['models']` and `registry['denormalized_fields']` removed | None — the plugin's `registry` is its own adapter dict |
+| django-mptt replaced by `ltree`; `NestedGroupModel` deprecated | None — no hierarchical models |
+| PostgreSQL 15+ and Redis 6+ now required | Infrastructure only; the bundled compose stack already runs PostgreSQL 18 and Valkey 9 |
 
 Each plugin release is tested against all supported NetBox versions via GitHub Actions CI.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://pypi.org/project/netbox-ssl/"><img src="https://img.shields.io/pypi/pyversions/netbox-ssl" alt="Python"></a>
   <a href="https://github.com/ctrl-alt-automate/netbox-ssl/actions/workflows/ci.yml"><img src="https://github.com/ctrl-alt-automate/netbox-ssl/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
-  <a href="https://github.com/netbox-community/netbox"><img src="https://img.shields.io/badge/NetBox-4.4%20%7C%204.5%20%7C%204.6-blue.svg" alt="NetBox"></a>
+  <a href="https://github.com/netbox-community/netbox"><img src="https://img.shields.io/badge/NetBox-4.4%20%7C%204.5%20%7C%204.6%20%7C%204.7-blue.svg" alt="NetBox"></a>
   <img src="https://img.shields.io/badge/Status-Stable-brightgreen.svg" alt="Stable">
 </p>
 
@@ -36,7 +36,7 @@ Managing SSL certificates across your infrastructure shouldn't be a scavenger hu
 
 | Dependency | Version |
 |------------|---------|
-| NetBox     | 4.4.0 - 4.6.x |
+| NetBox     | 4.4.0 - 4.7.x |
 | Python     | 3.10+ |
 
 The plugin uses the Python [`cryptography`](https://cryptography.io/) library for X.509 certificate parsing (installed automatically as a dependency).
@@ -252,9 +252,10 @@ Add the widget to your NetBox dashboard to see:
 
 | NetBox Version | Plugin Version | Status |
 |:--------------:|:--------------:|:------:|
-| 4.6.x          | 1.1.x - 1.3.x  | ✅ Primary |
-| 4.5.x          | 1.1.x - 1.3.x  | ✅ Supported |
-| 4.4.x          | 1.1.x - 1.3.x  | ✅ Supported |
+| 4.7.x          | 1.4.x          | ✅ Supported |
+| 4.6.x          | 1.1.x - 1.4.x  | ✅ Primary |
+| 4.5.x          | 1.1.x - 1.4.x  | ✅ Supported |
+| 4.4.x          | 1.1.x - 1.4.x  | ✅ Supported |
 | 4.3.x and older| —              | ❌ Unsupported |
 
 ## 📚 Documentation

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -133,7 +133,7 @@ The automated checks on PR are:
 - Ruff (lint + format)
 - Unit tests on Python 3.10, 3.11, 3.12
 - Package check (wheel inclusion)
-- Integration tests on NetBox 4.4, 4.5, and 4.6
+- Integration tests on NetBox 4.4, 4.5, 4.6, and 4.7
 - MkDocs strict build (on docs-touching PRs)
 - Gemini code review (automatic, informational)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/netbox-ssl)](https://pypi.org/project/netbox-ssl/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![NetBox](https://img.shields.io/badge/NetBox-4.4%20%7C%204.5%20%7C%204.6-blue.svg)](https://github.com/netbox-community/netbox)
+[![NetBox](https://img.shields.io/badge/NetBox-4.4%20%7C%204.5%20%7C%204.6%20%7C%204.7-blue.svg)](https://github.com/netbox-community/netbox)
 [![Status](https://img.shields.io/badge/Status-Stable-brightgreen.svg)](#)
 
 ---

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -21,7 +21,7 @@ class NetBoxSSLConfig(PluginConfig):
     author_email = "info@example.com"
     base_url = "ssl"
     min_version = "4.4.0"
-    max_version = "4.6.99"
+    max_version = "4.7.99"
     required_settings = []
     default_settings = {
         "expiry_warning_days": 30,

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -10,8 +10,8 @@ second:
   - **CHANGELOG** missing a dated ``## [X.Y.Z] - YYYY-MM-DD`` section for the
     release you are about to cut
   - **NetBox support matrix** stale across the PluginConfig ``min_version`` /
-    ``max_version``, the README badge + table, and ``COMPATIBILITY.md``
-    (a stale README badge shipped in v1.2.x)
+    ``max_version``, the README and docs/index.md badges, and
+    ``COMPATIBILITY.md`` (stale badges shipped in v1.2.x and v1.3.0)
   - **publish gate budget** — the ``verify-ci`` poll loop in ``publish.yml`` must
     outlast the integration matrix, or the tag-push Publish run times out before
     CI goes green (#141 / #142)
@@ -88,14 +88,14 @@ def supported_netbox_minors(init_text: str) -> set[str]:
     return {f"{major}.{minor}" for minor in range(lo_minor, hi_minor + 1)}
 
 
-def badge_netbox_minors(readme_text: str) -> set[str]:
-    """Extract the NetBox minors from the README shields.io badge.
+def badge_netbox_minors(text: str) -> set[str]:
+    """Extract the NetBox minors from a shields.io NetBox badge.
 
     The badge label is URL-encoded (``4.4%20%7C%204.5`` = ``4.4 | 4.5``). A
     whole-document version scan would miss a stale badge when the table below it
     is current, so this parser is intentionally badge-specific.
     """
-    match = re.search(r"badge/NetBox-(.+?)-[a-z]+\.svg", readme_text)
+    match = re.search(r"badge/NetBox-(.+?)-[a-z]+\.svg", text)
     if not match:
         return set()
     decoded = urllib.parse.unquote(match.group(1))
@@ -155,13 +155,26 @@ def check_changelog_has_release(target: str, changelog_text: str) -> CheckResult
     return CheckResult("changelog release section", passed, detail)
 
 
-def check_netbox_support_matrix(init_text: str, readme_text: str, compatibility_text: str) -> CheckResult:
+def check_netbox_support_matrix(
+    init_text: str,
+    readme_text: str,
+    compatibility_text: str,
+    docs_index_text: str = "",
+) -> CheckResult:
     expected = supported_netbox_minors(init_text)
     problems: list[str] = []
 
-    badge = badge_netbox_minors(readme_text)
-    if badge != expected:
-        problems.append(f"README badge advertises {sorted(badge)} but PluginConfig supports {sorted(expected)}")
+    # Every page carrying a NetBox badge must advertise the same range. v1.3.0
+    # shipped with a stale badge in docs/index.md because only README was
+    # checked here -- it was caught by hand during the release rehearsal.
+    badged = [("README.md", readme_text)]
+    if docs_index_text:
+        badged.append(("docs/index.md", docs_index_text))
+
+    for label, text in badged:
+        badge = badge_netbox_minors(text)
+        if badge != expected:
+            problems.append(f"{label} badge advertises {sorted(badge)} but PluginConfig supports {sorted(expected)}")
 
     missing_readme = expected - netbox_minors_mentioned(readme_text)
     if missing_readme:
@@ -173,7 +186,8 @@ def check_netbox_support_matrix(init_text: str, readme_text: str, compatibility_
 
     passed = not problems
     if passed:
-        detail = f"NetBox {sorted(expected)} consistent across PluginConfig, README, and COMPATIBILITY.md"
+        sources = "PluginConfig, README" + (", docs/index.md" if docs_index_text else "") + ", and COMPATIBILITY.md"
+        detail = f"NetBox {sorted(expected)} consistent across {sources}"
     else:
         detail = "; ".join(problems)
     return CheckResult("netbox support matrix", passed, detail)
@@ -229,13 +243,14 @@ def run_all_checks(repo_root: Path | str, target_version: str) -> list[CheckResu
     changelog = read("CHANGELOG.md")
     readme = read("README.md")
     compatibility = read("COMPATIBILITY.md")
+    docs_index = read("docs", "index.md")
     publish = read(".github", "workflows", "publish.yml")
     docs = read(".github", "workflows", "docs.yml")
 
     return [
         check_version_consistency(target_version, pyproject, init),
         check_changelog_has_release(target_version, changelog),
-        check_netbox_support_matrix(init, readme, compatibility),
+        check_netbox_support_matrix(init, readme, compatibility, docs_index),
         check_publish_gate_budget(publish),
         check_docs_serialization_guard(docs),
     ]


### PR DESCRIPTION
## Summary

NetBox **4.7.0** shipped on 2026-09-02. The plugin refuses to load on it — `PluginConfig` caps `max_version` at `4.6.99` — and CI never exercised it. This raises the ceiling to `4.7.99` and adds a 4.7 lane to the integration matrix.

## The audit

4.7 is a big release, so rather than bumping the number and hoping, every breaking change was checked against this codebase. **None of them apply:**

| 4.7 breaking change | Impact here |
|---|---|
| `ipam.Service.protocol` / `.ports` → `port_mappings`; ORM access now raises | **None** — `Service` is referenced only as an assignment target; the plugin never reads its port fields |
| `EMAIL_*` superseded by `MAILERS`; `get_connection()` with an explicit backend raises `RuntimeError` | **None** — expiry mail uses `EmailMultiAlternatives(...).send()` with no explicit backend |
| django-tables2 v3.0 drops `RelatedLinkColumn`, renames `querystring` → `querystring_replace` | **None** — neither is used |
| NetBox's `querystring` template tag removed | **None** — not used in any template |
| `registry['models']` / `registry['denormalized_fields']` removed | **None** — the plugin's `registry` is its own adapter dict |
| django-mptt → `ltree`; `NestedGroupModel` deprecated | **None** — no hierarchical models |
| `DEFAULT_ACTION_PERMISSIONS`, `LEGACY_ACTIONS`, `OptionalLimitOffsetPagination` removed | **None** — not referenced |
| PostgreSQL 15+ and Redis 6+ required | Infrastructure only — the bundled compose stack already runs PostgreSQL 18 and Valkey 9 |

The table is reproduced in `COMPATIBILITY.md` so the reasoning survives the PR.

## Changes

- `max_version` `4.6.99` → `4.7.99`
- **CI**: new `v4.7.0` integration lane (matrix is now 4.4 / 4.5 / 4.6 / 4.7)
- **CI**: the version conditionals enumerated the versions using the v2 token scheme (`== 'v4.5' || == 'v4.6'`) in 3 places. Every new NetBox release silently fell into the *legacy* token branch and would have failed for the wrong reason. Inverted to `!= 'v4.4'` — the one version that actually uses the old scheme — so future versions are covered by default.
- `COMPATIBILITY.md`: 4.7 rows + the audit table + a stated promotion rule (a new minor enters as **Supported** and becomes **Primary** once it has carried a release)
- Badges and support tables updated in `README.md`, `docs/index.md`, `docs/development/contributing.md`
- `scripts/release_preflight.py` now checks the `docs/index.md` badge as well as README's

## Preflight follow-up

v1.3.0 shipped with a stale NetBox badge in `docs/index.md`; the preflight only inspected `README.md`, so the manual release rehearsal caught it by hand. That gap is now closed — verified by re-introducing the exact v1.3.0 mistake:

```
[FAIL] netbox support matrix: docs/index.md badge advertises ['4.4', '4.5', '4.6']
       but PluginConfig supports ['4.4', '4.5', '4.6', '4.7']
```

and confirming it passes once corrected.

## Test plan

- [x] Full unit suite: **870 passed, 70 skipped**, 0 failures
- [x] `ruff check` + `ruff format --check` clean
- [x] `ci.yml` parses; matrix resolves to `['v4.7', 'v4.6', 'v4.5', 'v4.4']`
- [x] `release_preflight.py` support-matrix check passes across PluginConfig, README, docs/index.md and COMPATIBILITY.md — and fails as designed on a stale badge
- [ ] **The 4.7 integration lane is the real test.** The static audit says the plugin is clean; CI is what confirms it. If the lane surfaces breakage, it gets fixed in this PR before merge.

## Deliberately not done

The `spectacular --fail-on-warn` and `makemigrations --check` gates stay pinned to **v4.6**. Both were pinned there because older cores emit their own upstream warnings, and moving a strict gate onto a core that is one week old invites failures that are not ours. Once the 4.7 lane has a track record, moving the gates is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFR4nbcQsG6uRSi6FhUURq