### PR TITLE
feat: wire up the compliance presentation layer and its scheduled script (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Compliance Policies and Compliance Checks in the UI** ([#164](https://github.com/ctrl-alt-automate/netbox-ssl/issues/164)):
+  the compliance data model, filtersets and REST API shipped in v0.7, but no
+  forms, tables, views, URLs or menu entries were ever written — so policies
+  could only be created through the API, and both models' `get_absolute_url()`
+  pointed at routes that did not exist (any link to one raised
+  `NoReverseMatch`). Adds a **Compliance** menu section with full CRUD for
+  policies (including a JSON parameters field that documents each policy type's
+  shape and rejects non-object input) and a filterable, read-only results list
+  for checks. A policy's detail page shows the checks it produced and how many
+  certificates currently fail it. No database migration.
+- **`CertificateComplianceCheck` script** ([#164](https://github.com/ctrl-alt-automate/netbox-ssl/issues/164)):
+  the documentation had referenced this script since v0.7, but it was never
+  written — there was no way to evaluate compliance across the fleet on a
+  schedule, only one certificate at a time via the REST API. It evaluates every
+  enabled policy (or a single one), supports tenant filtering and a dry run,
+  skips archived/replaced certificates by default, and upserts one result per
+  certificate/policy pair so re-runs refresh rather than accumulate.
+
+### Documentation
+
+- `docs/how-to/compliance-policies.md` corrected: policies live under
+  **Plugins → SSL Certificates → Compliance Policies**, not Admin; the
+  parameters field is documented; the scheduled-run step now notes the
+  `SCRIPTS_ROOT` registration requirement; and a new step covers browsing
+  results. Both v1.4 prerequisites are called out with an API fallback for
+  older releases.
+
 ### Fixed
 
 - **Monitored endpoints never got polled** ([#163](https://github.com/ctrl-alt-automate/netbox-ssl/issues/163)):

--- a/docs/how-to/compliance-policies.md
+++ b/docs/how-to/compliance-policies.md
@@ -26,18 +26,36 @@ certificate on demand or on schedule.
 
 ## Step 1 — Create a policy
 
-Navigate to **Admin → NetBox SSL → Compliance Policies → + Add**.
+Navigate to **Plugins → SSL Certificates → Compliance Policies → + Add**.
 
 Example: "No RSA keys below 2048 bits"
 
 - **Name:** `RSA min key size 2048`
 - **Policy type:** `Minimum key size`
-- **Algorithm:** `rsa`
-- **Minimum value:** `2048`
 - **Severity:** `Error` (Error, Warning, or Info)
 - **Enabled:** ✓
+- **Parameters:** `{"min_bits": 2048}`
 
 Save. The policy is now part of your compliance ruleset.
+
+!!! note "Parameters are JSON"
+    Each policy type reads its thresholds from the **Parameters** field. The form
+    lists the shape for every type; the same examples appear in
+    [Built-in policy types](#built-in-policy-types) above.
+
+!!! warning "Requires v1.4 or newer"
+    Earlier releases shipped the compliance data model and REST API but never
+    wired up the UI, so this page did not exist and policies could only be
+    created through the API
+    ([#164](https://github.com/ctrl-alt-automate/netbox-ssl/issues/164)). On
+    v1.3.x and older, use:
+
+    ```bash
+    curl -X POST "$NETBOX/api/plugins/ssl/compliance-policies/" \\
+      -H "Authorization: Token $TOKEN" -H "Content-Type: application/json" \\
+      -d '{"name": "RSA min key size 2048", "policy_type": "min_key_size",
+           "severity": "error", "enabled": true, "parameters": {"min_bits": 2048}}'
+    ```
 
 ## Step 2 — Scope with tags (v0.9+)
 
@@ -67,10 +85,28 @@ certificate IDs. Returns per-cert per-policy results.
 
 ### Scheduled
 
-Schedule the `CertificateComplianceCheck` script (Admin → Scripts) to run daily
-or weekly. Results are stored per run, enabling the trend chart.
+Schedule the `CertificateComplianceCheck` script to run daily or weekly. Results
+are upserted per certificate/policy pair, and the report's trend chart is built
+from the stored snapshots.
 
-## Step 4 — View the compliance report
+The script is bundled with the plugin but, like every plugin script, must first
+be exposed through a `SCRIPTS_ROOT` wrapper before it appears under
+**Customization → Scripts** — see
+[Custom Scripts](../reference/scripts.md#making-the-scripts-available-to-netbox).
+
+!!! warning "Requires v1.4 or newer"
+    This script was referenced by the documentation from v0.7 onward but was
+    never actually shipped
+    ([#164](https://github.com/ctrl-alt-automate/netbox-ssl/issues/164)). On
+    older releases, run checks through the REST API endpoints above.
+
+## Step 4 — Browse the results
+
+Navigate to **Plugins → SSL Certificates → Compliance Checks** for every stored
+result, filterable by certificate, policy, and outcome. A policy's own detail
+page lists the checks it produced and how many certificates currently fail it.
+
+## Step 5 — View the compliance report
 
 Navigate to **Plugins → SSL Certificates → Compliance Report**.
 
@@ -81,7 +117,7 @@ The report shows:
 - **90-day trend chart** (is compliance improving or drifting?)
 - **Top failing certificates** (ranked by number of failed policies)
 
-## Step 5 — Export results
+## Step 6 — Export results
 
 Two export formats supported:
 

--- a/docs/how-to/compliance-policies.md
+++ b/docs/how-to/compliance-policies.md
@@ -32,7 +32,7 @@ Example: "No RSA keys below 2048 bits"
 
 - **Name:** `RSA min key size 2048`
 - **Policy type:** `Minimum key size`
-- **Severity:** `Error` (Error, Warning, or Info)
+- **Severity:** `Critical` (Critical, Warning, or Info)
 - **Enabled:** ✓
 - **Parameters:** `{"min_bits": 2048}`
 
@@ -54,7 +54,7 @@ Save. The policy is now part of your compliance ruleset.
     curl -X POST "$NETBOX/api/plugins/ssl/compliance-policies/" \\
       -H "Authorization: Token $TOKEN" -H "Content-Type: application/json" \\
       -d '{"name": "RSA min key size 2048", "policy_type": "min_key_size",
-           "severity": "error", "enabled": true, "parameters": {"min_bits": 2048}}'
+           "severity": "critical", "enabled": true, "parameters": {"min_bits": 2048}}'
     ```
 
 ## Step 2 — Scope with tags (v0.9+)

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -26,6 +26,7 @@ from netbox_ssl.scripts import (
     ScheduledCertificateExport,
     CertificateURLScan,
     MonitoredEndpointPoll,
+    CertificateComplianceCheck,
 )
 ```
 
@@ -141,6 +142,48 @@ endpoints never leave the **Pending** state.
 !!! note "Private addresses are blocked by default"
     Endpoints resolving to private IP ranges are rejected unless you opt in via
     `url_import_private_cidr_allowlist` in `PLUGINS_CONFIG`.
+
+## Certificate Compliance Check
+
+The `CertificateComplianceCheck` script evaluates every enabled compliance
+policy against the certificate inventory and stores the results, which then feed
+the **Compliance Policies** and **Compliance Checks** lists and the Compliance
+Report.
+
+### Features
+
+- Evaluates all enabled policies, or a single policy
+- Optional tenant filtering
+- Skips archived and replaced certificates unless asked otherwise
+- Upserts one result per certificate/policy pair, so re-runs refresh rather than
+  accumulate
+- Logs every failing check as a warning
+
+### Running the Script
+
+1. Navigate to **Customization > Scripts**
+2. Select **Certificate Compliance Check**
+3. Configure options:
+   - **Tenant**: limit the run to one tenant (optional)
+   - **Policy**: evaluate a single policy instead of all enabled ones (optional)
+   - **Include inactive**: also check archived and replaced certificates
+   - **Dry run**: report what would be evaluated without writing results
+4. Click **Run Script**
+
+### Script Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `tenant` | Tenant | none | Restrict the run to one tenant |
+| `policy` | CompliancePolicy | none | Evaluate only this policy |
+| `include_inactive` | Boolean | `false` | Include archived/replaced certificates |
+| `dry_run` | Boolean | `false` | Report without writing |
+
+!!! note "Requires v1.4 or newer"
+    The documentation referenced this script from v0.7 onward, but it was never
+    actually shipped ([#164](https://github.com/ctrl-alt-automate/netbox-ssl/issues/164)).
+    Before v1.4, compliance could only be evaluated per certificate through the
+    REST API.
 
 ## Scheduling with NetBox Jobs
 

--- a/netbox_ssl/filtersets/compliance.py
+++ b/netbox_ssl/filtersets/compliance.py
@@ -5,8 +5,10 @@ FilterSets for compliance reporting models.
 import django_filters
 from django.db import models
 from netbox.filtersets import NetBoxModelFilterSet
+from tenancy.models import Tenant
 
 from ..models import (
+    Certificate,
     ComplianceCheck,
     CompliancePolicy,
     CompliancePolicyTypeChoices,
@@ -26,7 +28,13 @@ class CompliancePolicyFilterSet(NetBoxModelFilterSet):
         choices=ComplianceSeverityChoices,
     )
     enabled = django_filters.BooleanFilter()
-    tenant_id = django_filters.NumberFilter()
+    # ModelMultipleChoiceFilter, not NumberFilter: the filter form offers a
+    # multi-select, and a NumberFilter silently keeps only the last value --
+    # wrong results rather than an error. Matches every other filterset here.
+    tenant_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Tenant.objects.all(),
+        label="Tenant",
+    )
     tenant = django_filters.CharFilter(
         field_name="tenant__name",
         lookup_expr="icontains",
@@ -54,12 +62,19 @@ class CompliancePolicyFilterSet(NetBoxModelFilterSet):
 class ComplianceCheckFilterSet(NetBoxModelFilterSet):
     """FilterSet for ComplianceCheck model."""
 
-    certificate_id = django_filters.NumberFilter()
+    certificate_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Certificate.objects.all(),
+        label="Certificate",
+    )
     certificate = django_filters.CharFilter(
         field_name="certificate__common_name",
         lookup_expr="icontains",
     )
-    policy_id = django_filters.NumberFilter()
+    policy_id = django_filters.ModelMultipleChoiceFilter(
+        field_name="policy",
+        queryset=CompliancePolicy.objects.all(),
+        label="Policy",
+    )
     policy = django_filters.CharFilter(
         field_name="policy__name",
         lookup_expr="icontains",

--- a/netbox_ssl/forms/__init__.py
+++ b/netbox_ssl/forms/__init__.py
@@ -14,6 +14,11 @@ from .certificates import (
     CertificateForm,
     CertificateImportForm,
 )
+from .compliance import (
+    ComplianceCheckFilterForm,
+    CompliancePolicyFilterForm,
+    CompliancePolicyForm,
+)
 from .csr import (
     CertificateSigningRequestBulkEditForm,
     CertificateSigningRequestFilterForm,
@@ -54,4 +59,7 @@ __all__ = [
     "MonitoredEndpointFilterForm",
     "MonitoredEndpointImportForm",
     "UrlImportForm",
+    "CompliancePolicyForm",
+    "CompliancePolicyFilterForm",
+    "ComplianceCheckFilterForm",
 ]

--- a/netbox_ssl/forms/compliance.py
+++ b/netbox_ssl/forms/compliance.py
@@ -1,0 +1,133 @@
+"""
+Forms for CompliancePolicy and ComplianceCheck models.
+"""
+
+from django import forms
+from django.utils.translation import gettext_lazy as _
+from netbox.forms import NetBoxModelFilterSetForm, NetBoxModelForm
+from tenancy.models import Tenant
+from utilities.forms.fields import DynamicModelChoiceField, DynamicModelMultipleChoiceField, TagFilterField
+from utilities.forms.rendering import FieldSet
+
+from ..models import (
+    Certificate,
+    ComplianceCheck,
+    CompliancePolicy,
+    CompliancePolicyTypeChoices,
+    ComplianceResultChoices,
+    ComplianceSeverityChoices,
+)
+
+# Shown under the parameters field so operators do not have to consult the docs
+# to learn the JSON shape each policy type expects.
+_PARAMETER_EXAMPLES = """Examples by policy type:
+min_key_size: {"min_bits": 2048}
+algorithm_allowed: {"algorithms": ["rsa", "ecdsa"]}
+algorithm_forbidden: {"algorithms": ["rsa"]}
+max_validity_days: {"max_days": 397}
+expiry_warning: {"warning_days": 30}
+issuer_allowed: {"issuers": ["DigiCert", "Let's Encrypt"]}
+issuer_forbidden: {"issuers": ["Unknown CA"]}"""
+
+
+class CompliancePolicyForm(NetBoxModelForm):
+    """Form for creating and editing compliance policies."""
+
+    tenant = DynamicModelChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label=_("Tenant"),
+        help_text=_("Limit the policy to one tenant. Leave empty to apply globally."),
+    )
+    parameters = forms.JSONField(
+        required=False,
+        label=_("Parameters"),
+        help_text=_PARAMETER_EXAMPLES,
+        widget=forms.Textarea(attrs={"rows": 6, "class": "font-monospace"}),
+    )
+
+    fieldsets = (
+        FieldSet("name", "description", "policy_type", "severity", "enabled", name=_("Policy")),
+        FieldSet("parameters", name=_("Parameters")),
+        FieldSet("tenant", "tag_filter", name=_("Scope")),
+        FieldSet("tags", name=_("Tags")),
+    )
+
+    class Meta:
+        model = CompliancePolicy
+        fields = (
+            "name",
+            "description",
+            "policy_type",
+            "severity",
+            "enabled",
+            "parameters",
+            "tenant",
+            "tag_filter",
+            "tags",
+        )
+
+    def clean_parameters(self):
+        """Default to an empty object and reject anything that is not a mapping.
+
+        ``parameters`` is consumed as ``policy.parameters.get(key)`` by
+        ComplianceChecker, so a list or scalar would raise at check time rather
+        than at entry time.
+        """
+        parameters = self.cleaned_data.get("parameters")
+        if parameters in (None, ""):
+            return {}
+        if not isinstance(parameters, dict):
+            raise forms.ValidationError(_('Parameters must be a JSON object, e.g. {"min_bits": 2048}.'))
+        return parameters
+
+
+class CompliancePolicyFilterForm(NetBoxModelFilterSetForm):
+    """Filter form for the compliance policy list."""
+
+    model = CompliancePolicy
+
+    policy_type = forms.MultipleChoiceField(
+        choices=CompliancePolicyTypeChoices,
+        required=False,
+        label=_("Policy type"),
+    )
+    severity = forms.MultipleChoiceField(
+        choices=ComplianceSeverityChoices,
+        required=False,
+        label=_("Severity"),
+    )
+    enabled = forms.NullBooleanField(
+        required=False,
+        label=_("Enabled"),
+        widget=forms.Select(choices=[("", "---------"), (True, _("Yes")), (False, _("No"))]),
+    )
+    tenant_id = DynamicModelMultipleChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label=_("Tenant"),
+    )
+    tag = TagFilterField(model)
+
+
+class ComplianceCheckFilterForm(NetBoxModelFilterSetForm):
+    """Filter form for the compliance check results list."""
+
+    model = ComplianceCheck
+
+    certificate_id = DynamicModelMultipleChoiceField(
+        queryset=Certificate.objects.all(),
+        required=False,
+        label=_("Certificate"),
+    )
+    policy_id = DynamicModelMultipleChoiceField(
+        queryset=CompliancePolicy.objects.all(),
+        required=False,
+        label=_("Policy"),
+    )
+    result = forms.MultipleChoiceField(
+        choices=ComplianceResultChoices,
+        required=False,
+        label=_("Result"),
+    )
+    tag = TagFilterField(model)

--- a/netbox_ssl/navigation.py
+++ b/netbox_ssl/navigation.py
@@ -121,6 +121,29 @@ menu = PluginMenu(
             ),
         ),
         (
+            "Compliance",
+            (
+                PluginMenuItem(
+                    link="plugins:netbox_ssl:compliancepolicy_list",
+                    link_text="Compliance Policies",
+                    permissions=["netbox_ssl.view_compliancepolicy"],
+                    buttons=(
+                        PluginMenuButton(
+                            link="plugins:netbox_ssl:compliancepolicy_add",
+                            title="Add",
+                            icon_class="mdi mdi-plus-thick",
+                            permissions=["netbox_ssl.add_compliancepolicy"],
+                        ),
+                    ),
+                ),
+                PluginMenuItem(
+                    link="plugins:netbox_ssl:compliancecheck_list",
+                    link_text="Compliance Checks",
+                    permissions=["netbox_ssl.view_compliancecheck"],
+                ),
+            ),
+        ),
+        (
             "Insights",
             (
                 PluginMenuItem(

--- a/netbox_ssl/scripts/__init__.py
+++ b/netbox_ssl/scripts/__init__.py
@@ -10,6 +10,7 @@ unreachable -- see issue #163. ``tests/test_script_exports.py`` guards this.
 
 from .ari_poll import CertificateARIPoll
 from .auto_archive import CertificateAutoArchive
+from .compliance_check import CertificateComplianceCheck
 from .endpoint_monitor import MonitoredEndpointPoll
 from .expiry_notification import CertificateExpiryNotification
 from .expiry_scan import CertificateExpiryScan
@@ -20,6 +21,7 @@ from .url_scan import CertificateURLScan
 __all__ = [
     "CertificateARIPoll",
     "CertificateAutoArchive",
+    "CertificateComplianceCheck",
     "CertificateExpiryNotification",
     "CertificateExpiryScan",
     "CertificateURLScan",

--- a/netbox_ssl/scripts/compliance_check.py
+++ b/netbox_ssl/scripts/compliance_check.py
@@ -1,0 +1,111 @@
+"""
+Scheduled compliance evaluation across the certificate inventory.
+
+The documentation has described a ``CertificateComplianceCheck`` script since
+v0.7, but no such script was ever written (issue #164): compliance could only be
+evaluated one certificate at a time through the REST API. This provides the
+scheduled, fleet-wide evaluation the docs promised.
+
+Results are upserted per (certificate, policy) pair by
+``ComplianceChecker.save_check_results``, so re-running the script refreshes the
+existing rows rather than accumulating duplicates.
+"""
+
+from extras.scripts import BooleanVar, ObjectVar, Script
+from tenancy.models import Tenant
+
+from netbox_ssl.models import Certificate, CertificateStatusChoices, CompliancePolicy
+from netbox_ssl.utils.compliance_checker import ComplianceChecker
+
+
+class CertificateComplianceCheck(Script):
+    """
+    Evaluate every enabled compliance policy against the certificate inventory.
+
+    Features:
+    - Optional tenant filtering
+    - Optional restriction to a single policy
+    - Skips archived/replaced certificates by default
+    - Dry-run mode that reports counts without writing results
+    """
+
+    class Meta:
+        name = "Certificate Compliance Check"
+        description = "Evaluate compliance policies against all certificates"
+        commit_default = True
+        job_timeout = 1800
+
+    tenant = ObjectVar(
+        model=Tenant,
+        description="Limit the run to one tenant (optional).",
+        required=False,
+    )
+    policy = ObjectVar(
+        model=CompliancePolicy,
+        description="Evaluate only this policy (optional; default is every enabled policy).",
+        required=False,
+    )
+    include_inactive = BooleanVar(
+        description="Also check archived and replaced certificates.",
+        default=False,
+    )
+    dry_run = BooleanVar(
+        description="Report what would be evaluated without saving results.",
+        default=False,
+    )
+
+    def run(self, data: dict, commit: bool) -> str:
+        """Evaluate policies across the selected certificates and return a summary."""
+        tenant = data.get("tenant")
+        policy = data.get("policy")
+        include_inactive = bool(data.get("include_inactive", False))
+        dry_run = bool(data.get("dry_run", False))
+
+        certificates = Certificate.objects.all()
+        if tenant:
+            certificates = certificates.filter(tenant=tenant)
+        if not include_inactive:
+            certificates = certificates.exclude(
+                status__in=[
+                    CertificateStatusChoices.STATUS_ARCHIVED,
+                    CertificateStatusChoices.STATUS_REPLACED,
+                ]
+            )
+
+        if policy:
+            policies = CompliancePolicy.objects.filter(pk=policy.pk, enabled=True)
+            if not policies.exists():
+                self.log_warning(f"Policy '{policy}' is disabled — nothing to evaluate.")
+                return "No enabled policy selected."
+        else:
+            policies = None  # ComplianceChecker resolves the enabled, in-scope set
+
+        total = certificates.count()
+        if dry_run:
+            scope = f"policy '{policy}'" if policy else "all enabled policies"
+            self.log_info(f"Dry-run: would evaluate {scope} against {total} certificate(s).")
+            return f"Dry-run: {total} certificate(s) would be evaluated."
+
+        checked = 0
+        passed = 0
+        failed = 0
+
+        for certificate in certificates.select_related("tenant").iterator():
+            results = ComplianceChecker.run_all_checks(certificate, policies)
+            if not results:
+                continue
+            saved = ComplianceChecker.save_check_results(certificate, results)
+            checked += 1
+            for check in saved:
+                if check.is_passing:
+                    passed += 1
+                else:
+                    failed += 1
+                    self.log_warning(f"{certificate.common_name} failed '{check.policy.name}': {check.message}")
+
+        if failed:
+            self.log_warning(f"{failed} failing check(s) across {checked} certificate(s).")
+        else:
+            self.log_success(f"All {passed} check(s) passed across {checked} certificate(s).")
+
+        return f"Evaluated {checked} certificate(s): {passed} passed, {failed} failed."

--- a/netbox_ssl/tables/__init__.py
+++ b/netbox_ssl/tables/__init__.py
@@ -1,6 +1,7 @@
 from .assignments import CertificateAssignmentTable
 from .certificate_authorities import CertificateAuthorityTable
 from .certificates import CertificateTable
+from .compliance import ComplianceCheckTable, CompliancePolicyTable
 from .csr import CertificateSigningRequestTable
 from .external_sources import ExternalSourceTable
 from .monitored_endpoints import MonitoredEndpointTable
@@ -12,4 +13,6 @@ __all__ = [
     "CertificateSigningRequestTable",
     "ExternalSourceTable",
     "MonitoredEndpointTable",
+    "CompliancePolicyTable",
+    "ComplianceCheckTable",
 ]

--- a/netbox_ssl/tables/compliance.py
+++ b/netbox_ssl/tables/compliance.py
@@ -1,0 +1,98 @@
+"""
+Table definitions for CompliancePolicy and ComplianceCheck models.
+"""
+
+import django_tables2 as tables
+from netbox.tables import NetBoxTable, columns
+
+from ..models import ComplianceCheck, CompliancePolicy
+
+
+class CompliancePolicyTable(NetBoxTable):
+    """Table for displaying compliance policies."""
+
+    name = tables.Column(
+        linkify=True,
+    )
+    policy_type = columns.ChoiceFieldColumn(
+        verbose_name="Type",
+    )
+    severity = columns.ChoiceFieldColumn()
+    enabled = columns.BooleanColumn()
+    tenant = tables.Column(
+        linkify=True,
+    )
+    check_count = tables.Column(
+        verbose_name="Checks",
+        accessor="check_count",
+        orderable=False,
+    )
+    tags = columns.TagColumn(
+        url_name="plugins:netbox_ssl:compliancepolicy_list",
+    )
+
+    class Meta(NetBoxTable.Meta):
+        model = CompliancePolicy
+        fields = (
+            "pk",
+            "id",
+            "name",
+            "description",
+            "policy_type",
+            "severity",
+            "enabled",
+            "tenant",
+            "check_count",
+            "tags",
+        )
+        default_columns = (
+            "name",
+            "policy_type",
+            "severity",
+            "enabled",
+            "tenant",
+            "check_count",
+        )
+
+
+class ComplianceCheckTable(NetBoxTable):
+    """Table for displaying compliance check results."""
+
+    certificate = tables.Column(
+        linkify=True,
+    )
+    policy = tables.Column(
+        linkify=True,
+    )
+    result = columns.ChoiceFieldColumn()
+    severity = tables.Column(
+        accessor="policy__severity",
+        verbose_name="Severity",
+        orderable=True,
+    )
+    checked_at = columns.DateTimeColumn(
+        verbose_name="Checked At",
+    )
+
+    class Meta(NetBoxTable.Meta):
+        model = ComplianceCheck
+        fields = (
+            "pk",
+            "id",
+            "certificate",
+            "policy",
+            "result",
+            "severity",
+            "message",
+            "checked_value",
+            "expected_value",
+            "checked_at",
+        )
+        default_columns = (
+            "certificate",
+            "policy",
+            "result",
+            "severity",
+            "message",
+            "checked_at",
+        )

--- a/netbox_ssl/tables/compliance.py
+++ b/netbox_ssl/tables/compliance.py
@@ -25,7 +25,9 @@ class CompliancePolicyTable(NetBoxTable):
     check_count = tables.Column(
         verbose_name="Checks",
         accessor="check_count",
-        orderable=False,
+        # A real annotation (Count("checks")) added by CompliancePolicyListView,
+        # so the database can order on it -- no reason to disable sorting.
+        order_by="check_count",
     )
     tags = columns.TagColumn(
         url_name="plugins:netbox_ssl:compliancepolicy_list",

--- a/netbox_ssl/templates/netbox_ssl/compliancecheck.html
+++ b/netbox_ssl/templates/netbox_ssl/compliancecheck.html
@@ -1,0 +1,69 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load plugins %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item">
+    <a href="{% url 'plugins:netbox_ssl:compliancecheck_list' %}">{% trans "Compliance Checks" %}</a>
+  </li>
+{% endblock breadcrumbs %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Check" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Certificate" %}</th>
+            <td><a href="{{ object.certificate.get_absolute_url }}">{{ object.certificate }}</a></td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Policy" %}</th>
+            <td><a href="{{ object.policy.get_absolute_url }}">{{ object.policy }}</a></td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Result" %}</th>
+            <td>{% badge object.get_result_display %}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Severity" %}</th>
+            <td>{% badge object.policy.get_severity_display %}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Checked at" %}</th>
+            <td>{{ object.checked_at }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+    {% plugin_left_page object %}
+  </div>
+
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Detail" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Message" %}</th>
+            <td>{{ object.message|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Checked value" %}</th>
+            <td>{{ object.checked_value|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Expected value" %}</th>
+            <td>{{ object.expected_value|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+    {% plugin_right_page object %}
+  </div>
+</div>
+{% endblock content %}

--- a/netbox_ssl/templates/netbox_ssl/compliancepolicy.html
+++ b/netbox_ssl/templates/netbox_ssl/compliancepolicy.html
@@ -1,0 +1,115 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load plugins %}
+{% load render_table from django_tables2 %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item">
+    <a href="{% url 'plugins:netbox_ssl:compliancepolicy_list' %}">{% trans "Compliance Policies" %}</a>
+  </li>
+{% endblock breadcrumbs %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Policy" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Name" %}</th>
+            <td>{{ object.name }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Description" %}</th>
+            <td>{{ object.description|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Type" %}</th>
+            <td>{{ object.get_policy_type_display }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Severity" %}</th>
+            <td>{% badge object.get_severity_display %}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Enabled" %}</th>
+            <td>{% checkmark object.enabled %}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Scope" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Tenant" %}</th>
+            <td>
+              {% if object.tenant %}
+                <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+              {% else %}
+                <span class="text-muted">{% trans "All tenants" %}</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Required tags" %}</th>
+            <td>
+              {% for tag in object.tag_filter.all %}
+                {% badge tag.name %}
+              {% empty %}
+                <span class="text-muted">{% trans "All certificates" %}</span>
+              {% endfor %}
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+    {% plugin_left_page object %}
+  </div>
+
+  <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">{% trans "Parameters" %}</h5>
+      <div class="card-body">
+        {% if object.parameters %}
+          <pre class="mb-0"><code>{{ object.parameters|json }}</code></pre>
+        {% else %}
+          <span class="text-muted">{% trans "No parameters set" %}</span>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="card">
+      <h5 class="card-header">{% trans "Results" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Failing certificates" %}</th>
+            <td>{{ failing_count }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    {% include 'inc/panels/tags.html' %}
+    {% plugin_right_page object %}
+  </div>
+</div>
+
+<div class="row mb-3">
+  <div class="col col-md-12">
+    <div class="card">
+      <h5 class="card-header">{% trans "Compliance Checks" %}</h5>
+      <div class="card-body htmx-container table-responsive">
+        {% render_table check_table 'inc/table.html' %}
+      </div>
+    </div>
+    {% plugin_full_width_page object %}
+  </div>
+</div>
+{% endblock content %}

--- a/netbox_ssl/templates/netbox_ssl/compliancepolicy.html
+++ b/netbox_ssl/templates/netbox_ssl/compliancepolicy.html
@@ -1,7 +1,6 @@
 {% extends 'generic/object.html' %}
 {% load helpers %}
 {% load plugins %}
-{% load render_table from django_tables2 %}
 {% load i18n %}
 
 {% block breadcrumbs %}
@@ -106,7 +105,7 @@
     <div class="card">
       <h5 class="card-header">{% trans "Compliance Checks" %}</h5>
       <div class="card-body htmx-container table-responsive">
-        {% render_table check_table 'inc/table.html' %}
+        {% htmx_table 'plugins:netbox_ssl:compliancecheck_list' policy_id=object.pk %}
       </div>
     </div>
     {% plugin_full_width_page object %}

--- a/netbox_ssl/urls.py
+++ b/netbox_ssl/urls.py
@@ -236,6 +236,65 @@ urlpatterns = [
         name="externalsource_changelog",
         kwargs={"model": models.ExternalSource},
     ),
+    # CompliancePolicy URLs
+    path(
+        "compliance-policies/",
+        views.CompliancePolicyListView.as_view(),
+        name="compliancepolicy_list",
+    ),
+    path(
+        "compliance-policies/add/",
+        views.CompliancePolicyEditView.as_view(),
+        name="compliancepolicy_add",
+    ),
+    path(
+        "compliance-policies/delete/",
+        views.CompliancePolicyBulkDeleteView.as_view(),
+        name="compliancepolicy_bulk_delete",
+    ),
+    path(
+        "compliance-policies/<int:pk>/",
+        views.CompliancePolicyView.as_view(),
+        name="compliancepolicy",
+    ),
+    path(
+        "compliance-policies/<int:pk>/edit/",
+        views.CompliancePolicyEditView.as_view(),
+        name="compliancepolicy_edit",
+    ),
+    path(
+        "compliance-policies/<int:pk>/delete/",
+        views.CompliancePolicyDeleteView.as_view(),
+        name="compliancepolicy_delete",
+    ),
+    path(
+        "compliance-policies/<int:pk>/changelog/",
+        ObjectChangeLogView.as_view(),
+        name="compliancepolicy_changelog",
+        kwargs={"model": models.CompliancePolicy},
+    ),
+    # ComplianceCheck URLs
+    path(
+        "compliance-checks/",
+        views.ComplianceCheckListView.as_view(),
+        name="compliancecheck_list",
+    ),
+    path(
+        "compliance-checks/delete/",
+        views.ComplianceCheckBulkDeleteView.as_view(),
+        name="compliancecheck_bulk_delete",
+    ),
+    path(
+        "compliance-checks/<int:pk>/",
+        views.ComplianceCheckView.as_view(),
+        name="compliancecheck",
+    ),
+    path(
+        "compliance-checks/<int:pk>/changelog/",
+        ObjectChangeLogView.as_view(),
+        name="compliancecheck_changelog",
+        kwargs={"model": models.ComplianceCheck},
+    ),
     # MonitoredEndpoint URLs
     path(
         "monitored-endpoints/",

--- a/netbox_ssl/utils/compliance_reporter.py
+++ b/netbox_ssl/utils/compliance_reporter.py
@@ -57,6 +57,11 @@ class ComplianceReporter:
         # Breakdown by severity
         severity_breakdown = list(
             checks_qs.filter(result="fail")
+            # Shadows ComplianceCheck.severity (a @property), which is safe only
+            # because .values() follows: no model instances are hydrated, so
+            # Django never setattr()s onto the property. Do NOT reuse this shape
+            # in a query that returns model instances -- that raises
+            # "property has no setter" and 500s the endpoint (see #167).
             .annotate(severity=F("policy__severity"))
             .values("severity")
             .annotate(count=Count("id"))

--- a/netbox_ssl/views/__init__.py
+++ b/netbox_ssl/views/__init__.py
@@ -25,6 +25,16 @@ from .certificates import (
     CertificateRenewView,
     CertificateView,
 )
+from .compliance import (
+    ComplianceCheckBulkDeleteView,
+    ComplianceCheckListView,
+    ComplianceCheckView,
+    CompliancePolicyBulkDeleteView,
+    CompliancePolicyDeleteView,
+    CompliancePolicyEditView,
+    CompliancePolicyListView,
+    CompliancePolicyView,
+)
 from .csr import (
     CertificateSigningRequestBulkDeleteView,
     CertificateSigningRequestBulkEditView,
@@ -102,4 +112,13 @@ __all__ = [
     "MonitoredEndpointDeleteView",
     "MonitoredEndpointBulkDeleteView",
     "MonitoredEndpointImportView",
+    # Compliance views
+    "CompliancePolicyListView",
+    "CompliancePolicyView",
+    "CompliancePolicyEditView",
+    "CompliancePolicyDeleteView",
+    "CompliancePolicyBulkDeleteView",
+    "ComplianceCheckListView",
+    "ComplianceCheckView",
+    "ComplianceCheckBulkDeleteView",
 ]

--- a/netbox_ssl/views/compliance.py
+++ b/netbox_ssl/views/compliance.py
@@ -1,0 +1,92 @@
+"""
+Views for CompliancePolicy and ComplianceCheck models.
+
+The compliance data model, filtersets and REST API shipped in v0.7 but the
+presentation layer was never wired up, so policies were reachable only through
+the API even though both models declare ``get_absolute_url()`` and the docs
+described an Admin UI (issue #164).
+
+ComplianceCheck rows are *results*, produced by the checker rather than typed in
+by an operator, so they get list and detail views but no create/edit form.
+"""
+
+from django.db.models import Count
+from netbox.views import generic
+
+from ..filtersets import ComplianceCheckFilterSet, CompliancePolicyFilterSet
+from ..forms import ComplianceCheckFilterForm, CompliancePolicyFilterForm, CompliancePolicyForm
+from ..models import ComplianceCheck, CompliancePolicy
+from ..tables import ComplianceCheckTable, CompliancePolicyTable
+
+
+class CompliancePolicyListView(generic.ObjectListView):
+    """List all compliance policies."""
+
+    queryset = CompliancePolicy.objects.select_related("tenant").annotate(check_count=Count("checks"))
+    filterset = CompliancePolicyFilterSet
+    filterset_form = CompliancePolicyFilterForm
+    table = CompliancePolicyTable
+
+
+class CompliancePolicyView(generic.ObjectView):
+    """Display a single compliance policy and its most recent results."""
+
+    queryset = CompliancePolicy.objects.select_related("tenant").prefetch_related("tags", "tag_filter")
+
+    def get_extra_context(self, request, instance):
+        checks = (
+            ComplianceCheck.objects.restrict(request.user, "view")
+            .filter(policy=instance)
+            .select_related("certificate", "policy")
+        )
+        return {
+            "check_table": ComplianceCheckTable(checks),
+            "failing_count": checks.filter(result="fail").count(),
+        }
+
+
+class CompliancePolicyEditView(generic.ObjectEditView):
+    """Create or edit a compliance policy."""
+
+    queryset = CompliancePolicy.objects.all()
+    form = CompliancePolicyForm
+
+
+class CompliancePolicyDeleteView(generic.ObjectDeleteView):
+    """Delete a compliance policy."""
+
+    queryset = CompliancePolicy.objects.all()
+
+
+class CompliancePolicyBulkDeleteView(generic.BulkDeleteView):
+    """Delete multiple compliance policies."""
+
+    queryset = CompliancePolicy.objects.all()
+    filterset = CompliancePolicyFilterSet
+    table = CompliancePolicyTable
+
+
+class ComplianceCheckListView(generic.ObjectListView):
+    """List compliance check results."""
+
+    queryset = ComplianceCheck.objects.select_related("certificate", "policy")
+    filterset = ComplianceCheckFilterSet
+    filterset_form = ComplianceCheckFilterForm
+    table = ComplianceCheckTable
+    # Results are produced by the checker, so no add/import actions -- but a
+    # stale result set should still be clearable in bulk.
+    actions = {"export": {"view"}, "bulk_delete": {"delete"}}
+
+
+class ComplianceCheckView(generic.ObjectView):
+    """Display a single compliance check result."""
+
+    queryset = ComplianceCheck.objects.select_related("certificate", "policy")
+
+
+class ComplianceCheckBulkDeleteView(generic.BulkDeleteView):
+    """Delete multiple compliance check results."""
+
+    queryset = ComplianceCheck.objects.all()
+    filterset = ComplianceCheckFilterSet
+    table = ComplianceCheckTable

--- a/netbox_ssl/views/compliance.py
+++ b/netbox_ssl/views/compliance.py
@@ -15,7 +15,7 @@ from netbox.views import generic
 
 from ..filtersets import ComplianceCheckFilterSet, CompliancePolicyFilterSet
 from ..forms import ComplianceCheckFilterForm, CompliancePolicyFilterForm, CompliancePolicyForm
-from ..models import ComplianceCheck, CompliancePolicy
+from ..models import ComplianceCheck, CompliancePolicy, ComplianceResultChoices
 from ..tables import ComplianceCheckTable, CompliancePolicyTable
 
 
@@ -34,15 +34,18 @@ class CompliancePolicyView(generic.ObjectView):
     queryset = CompliancePolicy.objects.select_related("tenant").prefetch_related("tags", "tag_filter")
 
     def get_extra_context(self, request, instance):
-        checks = (
+        """Count the certificates currently failing this policy.
+
+        The results table itself is rendered by ``{% htmx_table %}`` against the
+        compliance check list view, so it is lazily loaded, paginated and
+        permission-filtered by that view rather than assembled here.
+        """
+        failing = (
             ComplianceCheck.objects.restrict(request.user, "view")
-            .filter(policy=instance)
-            .select_related("certificate", "policy")
+            .filter(policy=instance, result=ComplianceResultChoices.RESULT_FAIL)
+            .count()
         )
-        return {
-            "check_table": ComplianceCheckTable(checks),
-            "failing_count": checks.filter(result="fail").count(),
-        }
+        return {"failing_count": failing}
 
 
 class CompliancePolicyEditView(generic.ObjectEditView):

--- a/tests/test_compliance_ui.py
+++ b/tests/test_compliance_ui.py
@@ -112,7 +112,7 @@ class TestCompliancePolicyForm:
             data={
                 "name": "RSA min key size 2048",
                 "policy_type": "min_key_size",
-                "severity": "error",
+                "severity": "critical",
                 "enabled": True,
                 "parameters": '{"min_bits": 2048}',
             }
@@ -143,10 +143,58 @@ class TestCompliancePolicyForm:
             data={
                 "name": "Bad params",
                 "policy_type": "min_key_size",
-                "severity": "error",
+                "severity": "critical",
                 "enabled": True,
                 "parameters": "[2048]",
             }
         )
         assert not form.is_valid()
         assert "parameters" in form.errors
+
+
+@pytest.mark.unit
+class TestDocumentedChoicesExist:
+    """The how-to must only name choice values the ChoiceSets actually define.
+
+    The guide told readers to set a severity of ``Error``; the choices are
+    Critical, Warning and Info, so the documented value was unusable and the
+    API example it showed would have been rejected. Same class of drift as the
+    documented API URLs in #165 -- prose that nothing verifies against the code.
+    """
+
+    def _choice_values(self, class_name: str) -> set[str]:
+        import ast
+
+        tree = ast.parse(_read("models/compliance.py"))
+        for cls in tree.body:
+            if isinstance(cls, ast.ClassDef) and cls.name == class_name:
+                return {
+                    node.value
+                    for stmt in cls.body
+                    if isinstance(stmt, ast.Assign)
+                    for node in ast.walk(stmt)
+                    if isinstance(node, ast.Constant) and isinstance(node.value, str)
+                }
+        raise AssertionError(f"{class_name} not found in models/compliance.py")
+
+    def _how_to(self) -> str:
+        docs = get_plugin_source_dir().parent / "docs" / "how-to" / "compliance-policies.md"
+        if not docs.is_file():
+            pytest.skip("docs/ not available (in-container runs copy only tests/)")
+        return docs.read_text()
+
+    def test_documented_severity_values_exist(self):
+        import re
+
+        valid = self._choice_values("ComplianceSeverityChoices")
+        used = set(re.findall(r'"severity":\s*"([a-z_]+)"', self._how_to()))
+        unknown = sorted(used - valid)
+        assert not unknown, f"how-to names severity values that do not exist: {unknown} (valid: {sorted(valid)})"
+
+    def test_documented_policy_types_exist(self):
+        import re
+
+        valid = self._choice_values("CompliancePolicyTypeChoices")
+        used = set(re.findall(r'"policy_type":\s*"([a-z_]+)"', self._how_to()))
+        unknown = sorted(used - valid)
+        assert not unknown, f"how-to names policy types that do not exist: {unknown}"

--- a/tests/test_compliance_ui.py
+++ b/tests/test_compliance_ui.py
@@ -1,0 +1,152 @@
+"""Tests for the CompliancePolicy / ComplianceCheck presentation layer (#164).
+
+The compliance models, filtersets and REST API shipped in v0.7, but no forms,
+tables, views, URLs or menu entries were ever written. Both models nevertheless
+declare ``get_absolute_url()`` pointing at ``plugins:netbox_ssl:compliancepolicy``
+and ``...:compliancecheck``, so any template that linked to one raised
+``NoReverseMatch``.
+
+The URL/menu assertions are source-level so they run in the host unit lane,
+where NetBox is not importable; the form and checker tests need the ORM and are
+marked ``django_db``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import get_plugin_source_dir
+
+
+def _read(relative: str) -> str:
+    return (get_plugin_source_dir() / relative).read_text()
+
+
+@pytest.mark.unit
+class TestComplianceUrlsExist:
+    """The URLs the models' get_absolute_url() already pointed at must resolve."""
+
+    def test_policy_urls_are_registered(self):
+        urls = _read("urls.py")
+        for name in (
+            "compliancepolicy_list",
+            "compliancepolicy_add",
+            "compliancepolicy_bulk_delete",
+            "compliancepolicy_edit",
+            "compliancepolicy_delete",
+            "compliancepolicy_changelog",
+        ):
+            assert f'name="{name}"' in urls, f"missing URL: {name}"
+        assert 'name="compliancepolicy",' in urls, "missing detail URL: compliancepolicy"
+
+    def test_check_urls_are_registered(self):
+        urls = _read("urls.py")
+        for name in ("compliancecheck_list", "compliancecheck_bulk_delete", "compliancecheck_changelog"):
+            assert f'name="{name}"' in urls, f"missing URL: {name}"
+        assert 'name="compliancecheck",' in urls, "missing detail URL: compliancecheck"
+
+    def test_get_absolute_url_targets_have_routes(self):
+        """Every reverse() target named in the models must exist in urls.py."""
+        import re
+
+        models_source = _read("models/compliance.py")
+        urls = _read("urls.py")
+        targets = re.findall(r'reverse\(\s*"plugins:netbox_ssl:([a-z_]+)"', models_source)
+        assert targets, "no reverse() targets found in models/compliance.py"
+        for target in targets:
+            assert f'name="{target}"' in urls, f"models reverse to '{target}' but no such URL is registered"
+
+
+@pytest.mark.unit
+class TestComplianceNavigation:
+    """Policies must be reachable from the menu, which is what #164 reported."""
+
+    def test_menu_exposes_policies_and_checks(self):
+        nav = _read("navigation.py")
+        assert "compliancepolicy_list" in nav
+        assert "compliancecheck_list" in nav
+
+    def test_menu_add_button_is_permission_gated(self):
+        nav = _read("navigation.py")
+        assert "netbox_ssl.add_compliancepolicy" in nav
+        assert "netbox_ssl.view_compliancepolicy" in nav
+
+
+@pytest.mark.unit
+class TestComplianceViewsWiring:
+    """The view classes must be exported so urls.py can reference them."""
+
+    def test_views_are_exported(self):
+        exports = _read("views/__init__.py")
+        for name in (
+            "CompliancePolicyListView",
+            "CompliancePolicyView",
+            "CompliancePolicyEditView",
+            "CompliancePolicyDeleteView",
+            "CompliancePolicyBulkDeleteView",
+            "ComplianceCheckListView",
+            "ComplianceCheckView",
+            "ComplianceCheckBulkDeleteView",
+        ):
+            assert name in exports, f"view not exported: {name}"
+
+    def test_check_views_offer_no_create_or_edit(self):
+        """Check results are produced by the checker, never typed in by hand."""
+        source = _read("views/compliance.py")
+        assert "class ComplianceCheckEditView" not in source
+        assert "ComplianceCheckForm" not in source
+
+    def test_detail_view_restricts_the_related_checks(self):
+        source = _read("views/compliance.py")
+        assert 'restrict(request.user, "view")' in source
+
+
+@pytest.mark.django_db
+class TestCompliancePolicyForm:
+    """Parameters are consumed as a mapping, so the form must enforce that."""
+
+    def test_valid_parameters_are_accepted(self):
+        from netbox_ssl.forms import CompliancePolicyForm
+
+        form = CompliancePolicyForm(
+            data={
+                "name": "RSA min key size 2048",
+                "policy_type": "min_key_size",
+                "severity": "error",
+                "enabled": True,
+                "parameters": '{"min_bits": 2048}',
+            }
+        )
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["parameters"] == {"min_bits": 2048}
+
+    def test_empty_parameters_default_to_an_empty_dict(self):
+        from netbox_ssl.forms import CompliancePolicyForm
+
+        form = CompliancePolicyForm(
+            data={
+                "name": "Chain required",
+                "policy_type": "chain_required",
+                "severity": "warning",
+                "enabled": True,
+                "parameters": "",
+            }
+        )
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data["parameters"] == {}
+
+    def test_non_object_parameters_are_rejected(self):
+        """A JSON list would blow up later in policy.parameters.get()."""
+        from netbox_ssl.forms import CompliancePolicyForm
+
+        form = CompliancePolicyForm(
+            data={
+                "name": "Bad params",
+                "policy_type": "min_key_size",
+                "severity": "error",
+                "enabled": True,
+                "parameters": "[2048]",
+            }
+        )
+        assert not form.is_valid()
+        assert "parameters" in form.errors


### PR DESCRIPTION
## Summary

Compliance shipped **half-finished** in v0.7. The data model, filtersets and REST API are complete; the presentation layer was never written. There are no forms, tables, views, URLs, menu entries or templates for `CompliancePolicy` or `ComplianceCheck`.

Two things make this worse than a missing feature:

1. Both models already declare `get_absolute_url()` pointing at `plugins:netbox_ssl:compliancepolicy` / `...:compliancecheck` — **routes that do not exist**, so any template linking to one raises `NoReverseMatch`.
2. The documentation described an Admin UI *and* a `CertificateComplianceCheck` script. Neither existed. The reporter followed the how-to, found no menu entry, then searched the repo and found the script name appears in exactly one place: the docs.

## Changes

### UI

| File | What |
|---|---|
| `forms/compliance.py` | `CompliancePolicyForm` with a JSON parameters field that documents each policy type's shape inline; filter forms for both models |
| `tables/compliance.py` | Policy table with a check count; result table carrying the policy's severity |
| `views/compliance.py` | Full CRUD for policies; list/detail + bulk delete for checks |
| `urls.py`, `navigation.py` | A permission-gated **Compliance** menu section |
| templates | Detail pages for both models |

Two deliberate calls:

- **Checks get no create or edit form.** They are results produced by the checker, not operator input. Bulk delete stays, so a stale result set can be cleared.
- **`parameters` rejects anything that is not a JSON object.** `ComplianceChecker` reads it as `policy.parameters.get(key)`, so a list or scalar would not fail at entry — it would fail much later, during a scheduled check, as an opaque error.

### Script

`scripts/compliance_check.py` provides `CertificateComplianceCheck`: evaluates every enabled policy (or a single one), filters by tenant, skips archived/replaced certificates unless asked, supports a dry run, and logs each failing check. Results are upserted per certificate/policy pair, so re-runs refresh rather than accumulate.

### Docs

`compliance-policies.md` corrected throughout — the menu path was **Admin → NetBox SSL**, which is not where the plugin lives; the parameters field was undocumented; the scheduled-run step did not mention that plugin scripts need a `SCRIPTS_ROOT` wrapper. Both v1.4 prerequisites are flagged with a working API fallback for older releases.

## Test plan

- [x] `tests/test_compliance_ui.py` — asserts every `reverse()` target named in `models/compliance.py` has a registered route (the `NoReverseMatch` class of bug), that the menu exposes both lists behind the right permissions, that check views expose no create/edit path, and that `parameters` accepts objects, defaults empty input to `{}`, and rejects a JSON list
- [x] Full unit suite: **882 passed, 70 skipped**, 0 failures
- [x] `ruff check` + `ruff format --check` clean
- [x] The #163 export guard passes — it required the new script to be both exported and documented, and caught the missing docs entry on the first run
- [ ] Integration lanes (4.4 / 4.5 / 4.6) exercise the form and checker tests, which need the ORM
- [ ] Manual: create a policy in the UI, run the script, confirm results appear in the Compliance Checks list and on the policy detail page

## Notes

No database migration — this is presentation only.

The script's `ObjectVar(model=CompliancePolicy)` passes the model **class**, per the #143 guard.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFR4nbcQsG6uRSi6FhUURq