### PR TITLE
release: v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-09-10
+
 ### Added
 
 - **Certificate type: server, client or mTLS** ([#168](https://github.com/ctrl-alt-automate/netbox-ssl/issues/168)):

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,7 +6,7 @@ This document tracks compatibility between NetBox SSL plugin versions and NetBox
 
 | Plugin Version | NetBox Version | Python Version | Status |
 |:--------------:|:--------------:|:--------------:|:------:|
-| 1.4.x          | 4.7.x          | 3.10 - 3.12   | Supported |
+| 1.4.x          | 4.7.x          | 3.12 - 3.14   | Supported |
 | 1.4.x          | 4.6.x          | 3.10 - 3.12   | Primary |
 | 1.4.x          | 4.5.x          | 3.10 - 3.12   | Supported |
 | 1.4.x          | 4.4.x          | 3.10 - 3.12   | Supported |
@@ -39,6 +39,11 @@ This document tracks compatibility between NetBox SSL plugin versions and NetBox
 - **Primary**: Actively developed and tested in CI
 - **Supported**: Tested in CI, receives bug fixes
 - **End of Life**: No longer tested or maintained
+
+The Python column is the range actually exercised: the unit suite runs 3.10,
+3.11 and 3.12, and each integration lane runs whatever interpreter that NetBox
+release ships (3.12 through 4.6, 3.14 on 4.7). The plugin's own floor is Python
+3.10 (`requires-python`); in practice the NetBox release you run decides.
 
 A newly released NetBox minor enters as **Supported** — covered by the full CI
 integration matrix — and is promoted to **Primary** once it has carried a plugin

--- a/netbox_ssl/__init__.py
+++ b/netbox_ssl/__init__.py
@@ -7,7 +7,7 @@ Provides a "Single Source of Truth" for certificate inventory and lifecycle mana
 
 from netbox.plugins import PluginConfig
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 
 class NetBoxSSLConfig(PluginConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-ssl"
-version = "1.3.0"
+version = "1.4.0"
 description = "NetBox plugin for TLS/SSL certificate management - Project Janus"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## v1.4.0

Bumps the version, dates the CHANGELOG section, and corrects the Python column in `COMPATIBILITY.md`.

`scripts/release_preflight.py 1.4.0` → **5/5 PASS**.

## Contents

### Added
- **Certificate type** — `server` / `client` / `mtls`, detected from the X.509 Extended Key Usage extension on import and overridable (#168)
- **NetBox 4.7 support** — `max_version` → `4.7.99`, 4.7 CI lane, full breaking-change audit in `COMPATIBILITY.md`
- **Compliance Policies and Checks in the UI** (#164) — the data model and API shipped in v0.7 with no presentation layer at all
- **`CertificateComplianceCheck` script** (#164) — referenced by the documentation since v0.7 but never actually written
- **Sort and search assignments by their assigned object** (#167)

### Fixed
- **Monitored endpoints never got polled** (#163) — the poll script was unreachable through its documented entry point, so website monitoring was dead on arrival in v1.3.0
- **Renewal reminders quoted stale certificate data** (#161) — a consequence of #163
- **54 documented API URLs returned 404** (#165) — the docs addressed the plugin by distribution name instead of `base_url`
- **Three custom permissions could never be granted** (#166) — NetBox requires `<action>_<model>`; `bulk_operations`, `run_urlimport` and `manage_compliance` were structurally ungrantable to every non-superuser since v0.9 (migration 0026)
- **Compliance check list returned HTTP 500** — twice: unreversible row actions on all versions, then the legacy `actions` dict on 4.7 only
- **`docker compose up -d` aborted on NetBox 4.7** — healthcheck budget was below the cold-start migration time

### Migrations
`0026` (permission rename, metadata-only) and `0027` (certificate_type, additive). No breaking changes.

## Verification

Verified **ALL PASS** against a live NetBox on every supported version — 36 assertions each, 144 total:

| NetBox | Python | Result |
|---|---|---|
| 4.4.10 | 3.12 | ✅ 36/36 |
| 4.5.2 | 3.12 | ✅ 36/36 |
| 4.6.0 | 3.12 | ✅ 36/36 |
| 4.7.0 | 3.14 | ✅ 36/36 |

Covering EKU detection through the full import path, compliance policies, the script including idempotency, fourteen pages rendering, and detail-page/filter/menu content.

## Note on the Python column

`COMPATIBILITY.md` claimed "3.10 - 3.12" for every row. NetBox 4.7 ships **Python 3.14**, which the 4.7 integration lane actually exercises — so the table was telling 4.7 users they were unsupported on the interpreter their own NetBox runs. The 4.7 row now reads 3.12 - 3.14, with a note explaining that the NetBox release decides the interpreter and the plugin's own floor is 3.10.

Caught by the pre-cut adversarial audit, which has now found a stale support claim before three consecutive releases.

## Test plan

- [x] `release_preflight.py 1.4.0` — 5/5
- [x] Full unit suite: 899 passed, 70 skipped
- [x] `ruff check` + `ruff format --check` clean
- [x] Live verification on 4.4 / 4.5 / 4.6 / 4.7
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFR4nbcQsG6uRSi6FhUURq